### PR TITLE
feat(RSV-4.1): Reservation 엔티티/리포지토리 구현 및 테스트

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'com.h2database:h2'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/coliving/global/entity/ReservationStatus.java
+++ b/backend/src/main/java/com/coliving/global/entity/ReservationStatus.java
@@ -1,0 +1,21 @@
+package com.coliving.global.entity;
+
+/**
+ * 예약 상태 Enum
+ * - reservation 테이블의 status 컬럼에 매핑된다.
+ * - EnumType.STRING 으로 저장되므로, 값 이름이 곧 DB 저장 값이다.
+ */
+public enum ReservationStatus {
+
+    /** 예약 대기 (입주자가 예약 신청 직후 기본 상태) */
+    PENDING,
+
+    /** 예약 승인 (관리자가 승인 처리) */
+    APPROVED,
+
+    /** 예약 취소 (입주자 또는 관리자가 취소) */
+    CANCELLED,
+
+    /** 이용 완료 (예약 시간 종료 후 완료 처리) */
+    COMPLETED
+}

--- a/backend/src/main/java/com/coliving/infra/persistence/entity/Reservation.java
+++ b/backend/src/main/java/com/coliving/infra/persistence/entity/Reservation.java
@@ -1,0 +1,132 @@
+package com.coliving.infra.persistence.entity;
+
+import com.coliving.global.entity.BaseEntity;
+import com.coliving.global.entity.ReservationStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 시설 예약 엔티티
+ * - 공용 시설(COMMON)에 대한 입주자(RESIDENT)의 예약 정보를 관리한다.
+ * - schema.sql의 reservation 테이블에 매핑된다.
+ *
+ * ┌──────────────────────────────────────────────────────────────────┐
+ * │ [TODO - 머지 시 수정 필요]                                        │
+ * │                                                                  │
+ * │ 현재 user_id, space_id, approved_by 필드가 Long 타입으로          │
+ * │ 선언되어 있습니다. User/Space 엔티티가 완성되면 아래와 같이          │
+ * │ @ManyToOne 관계로 변경해야 합니다:                                 │
+ * │                                                                  │
+ * │ [변경 전]                                                         │
+ * │   @Column(name = "user_id", nullable = false)                    │
+ * │   private Long userId;                                           │
+ * │                                                                  │
+ * │ [변경 후]                                                         │
+ * │   @ManyToOne(fetch = FetchType.LAZY)                             │
+ * │   @JoinColumn(name = "user_id", nullable = false)                │
+ * │   private User user;                                             │
+ * │                                                                  │
+ * │ space_id → Space, approved_by → User 도 동일하게 변경             │
+ * │                                                                  │
+ * │ 관련 담당: User(팀원1 USR-1.1), Space(팀원2 SPC-2.1)              │
+ * └──────────────────────────────────────────────────────────────────┘
+ */
+@Entity
+@Table(name = "reservation")
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+
+    // TODO: User 엔티티 완성 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // TODO: Space 엔티티 완성 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
+    @Column(name = "space_id", nullable = false)
+    private Long spaceId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 15)
+    private ReservationStatus status;
+
+    @Column(name = "reservation_date", nullable = false)
+    private LocalDate reservationDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    // TODO: User 엔티티 완성 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
+    @Column(name = "approved_by")
+    private Long approvedBy;
+
+    @Builder
+    public Reservation(Long userId, Long spaceId, LocalDate reservationDate,
+                       LocalTime startTime, LocalTime endTime) {
+        this.userId = userId;
+        this.spaceId = spaceId;
+        this.reservationDate = reservationDate;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.status = ReservationStatus.PENDING;
+    }
+
+    // ── 상태 전환 비즈니스 메서드 ──
+
+    /**
+     * 예약 승인 처리
+     * @param adminId 승인한 관리자 ID
+     * @throws IllegalStateException PENDING 상태가 아닌 경우
+     */
+    public void approve(Long adminId) {
+        validateStatus(ReservationStatus.PENDING, "승인");
+        this.status = ReservationStatus.APPROVED;
+        this.approvedBy = adminId;
+    }
+
+    /**
+     * 예약 취소 처리
+     * - PENDING 또는 APPROVED 상태에서만 취소 가능
+     * @throws IllegalStateException 취소 불가 상태인 경우
+     */
+    public void cancel() {
+        if (this.status == ReservationStatus.COMPLETED || this.status == ReservationStatus.CANCELLED) {
+            throw new IllegalStateException(
+                    "현재 상태(" + this.status + ")에서는 취소할 수 없습니다.");
+        }
+        this.status = ReservationStatus.CANCELLED;
+    }
+
+    /**
+     * 예약 이용 완료 처리
+     * @throws IllegalStateException APPROVED 상태가 아닌 경우
+     */
+    public void complete() {
+        validateStatus(ReservationStatus.APPROVED, "완료");
+        this.status = ReservationStatus.COMPLETED;
+    }
+
+    // 상태 검증 헬퍼 메서드
+    private void validateStatus(ReservationStatus expected, String action) {
+        if (this.status != expected) {
+            throw new IllegalStateException(
+                    "현재 상태(" + this.status + ")에서는 " + action + " 처리를 할 수 없습니다. "
+                    + expected + " 상태여야 합니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/coliving/infra/persistence/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/coliving/infra/persistence/repository/ReservationRepository.java
@@ -1,0 +1,84 @@
+package com.coliving.infra.persistence.repository;
+
+import com.coliving.global.entity.ReservationStatus;
+import com.coliving.infra.persistence.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 시설 예약 Repository
+ *
+ * ┌──────────────────────────────────────────────────────────────────┐
+ * │ [TODO - 머지 시 수정 필요]                                        │
+ * │                                                                  │
+ * │ User/Space 엔티티 완성 후 @ManyToOne 전환 시,                     │
+ * │ 쿼리 메서드의 파라미터 타입과 반환 타입을 검토하세요.                  │
+ * │ 예: findByUserId → findByUser(User user) 등                      │
+ * │                                                                  │
+ * │ 관련 담당: User(팀원1 USR-1.1), Space(팀원2 SPC-2.1)              │
+ * └──────────────────────────────────────────────────────────────────┘
+ */
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    // 특정 사용자의 예약 목록 조회 (상태 필터링)
+    List<Reservation> findByUserIdAndStatusIn(Long userId, List<ReservationStatus> statuses);
+
+    // 특정 사용자의 전체 예약 목록 조회 (최신순)
+    List<Reservation> findByUserIdOrderByReservationDateDescStartTimeDesc(Long userId);
+
+    // 특정 시설의 특정 날짜 예약 목록 조회 (승인된 예약만)
+    List<Reservation> findBySpaceIdAndReservationDateAndStatus(
+            Long spaceId, LocalDate reservationDate, ReservationStatus status);
+
+    // 특정 시설의 특정 날짜 전체 예약 목록 조회
+    List<Reservation> findBySpaceIdAndReservationDate(Long spaceId, LocalDate reservationDate);
+
+    /**
+     * 예약 시간대 중복 체크 (비즈니스 규칙 #10)
+     * - 동일 시설, 동일 날짜에 APPROVED 상태인 예약 중 시간이 겹치는 건이 있는지 확인
+     * - 새 예약의 시작 < 기존 종료 AND 새 예약의 종료 > 기존 시작 이면 중복
+     */
+    @Query("SELECT COUNT(r) > 0 FROM Reservation r " +
+           "WHERE r.spaceId = :spaceId " +
+           "AND r.reservationDate = :date " +
+           "AND r.status = 'APPROVED' " +
+           "AND r.startTime < :endTime " +
+           "AND r.endTime > :startTime")
+    boolean existsOverlappingReservation(
+            @Param("spaceId") Long spaceId,
+            @Param("date") LocalDate date,
+            @Param("startTime") LocalTime startTime,
+            @Param("endTime") LocalTime endTime);
+
+    /**
+     * 특정 사용자가 특정 시설에 현재 시각 기준 유효한 APPROVED 예약이 있는지 확인
+     * - 공용 기기 제어 권한 검증에 사용 (비즈니스 규칙 #9)
+     */
+    @Query("SELECT COUNT(r) > 0 FROM Reservation r " +
+           "WHERE r.userId = :userId " +
+           "AND r.spaceId = :spaceId " +
+           "AND r.reservationDate = :date " +
+           "AND r.status = 'APPROVED' " +
+           "AND r.startTime <= :currentTime " +
+           "AND r.endTime > :currentTime")
+    boolean hasActiveReservation(
+            @Param("userId") Long userId,
+            @Param("spaceId") Long spaceId,
+            @Param("date") LocalDate date,
+            @Param("currentTime") LocalTime currentTime);
+
+    // 특정 시설의 특정 기간 예약 목록 조회 (타임테이블 UI용, RSV-4.3)
+    @Query("SELECT r FROM Reservation r " +
+           "WHERE r.spaceId = :spaceId " +
+           "AND r.reservationDate BETWEEN :startDate AND :endDate " +
+           "ORDER BY r.reservationDate, r.startTime")
+    List<Reservation> findBySpaceIdAndDateRange(
+            @Param("spaceId") Long spaceId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate);
+}

--- a/backend/src/test/java/com/coliving/infra/persistence/entity/ReservationTest.java
+++ b/backend/src/test/java/com/coliving/infra/persistence/entity/ReservationTest.java
@@ -1,0 +1,181 @@
+package com.coliving.infra.persistence.entity;
+
+import com.coliving.global.entity.ReservationStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Reservation 엔티티 단위 테스트
+ * - DB 없이 순수 Java 로직만 검증한다.
+ * - 상태 전환 비즈니스 메서드의 정상/예외 케이스를 테스트한다.
+ */
+class ReservationTest {
+
+    private Reservation createPendingReservation() {
+        return Reservation.builder()
+                .userId(1L)
+                .spaceId(10L)
+                .reservationDate(LocalDate.of(2026, 4, 5))
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(12, 0))
+                .build();
+    }
+
+    // ── 생성 테스트 ──
+
+    @Test
+    @DisplayName("Builder로 예약 생성 시 상태는 PENDING이어야 한다")
+    void createReservation_shouldHavePendingStatus() {
+        Reservation reservation = createPendingReservation();
+
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PENDING);
+        assertThat(reservation.getUserId()).isEqualTo(1L);
+        assertThat(reservation.getSpaceId()).isEqualTo(10L);
+        assertThat(reservation.getApprovedBy()).isNull();
+    }
+
+    // ── approve() 테스트 ──
+
+    @Nested
+    @DisplayName("approve() - 예약 승인")
+    class Approve {
+
+        @Test
+        @DisplayName("PENDING 상태에서 승인하면 APPROVED 상태가 되고, approvedBy에 관리자 ID가 설정된다")
+        void approve_fromPending_shouldBeApproved() {
+            Reservation reservation = createPendingReservation();
+
+            reservation.approve(100L);
+
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.APPROVED);
+            assertThat(reservation.getApprovedBy()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("APPROVED 상태에서 승인하면 IllegalStateException이 발생한다")
+        void approve_fromApproved_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.approve(100L);
+
+            assertThatThrownBy(() -> reservation.approve(200L))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("승인");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서 승인하면 IllegalStateException이 발생한다")
+        void approve_fromCancelled_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.cancel();
+
+            assertThatThrownBy(() -> reservation.approve(100L))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 승인하면 IllegalStateException이 발생한다")
+        void approve_fromCompleted_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.approve(100L);
+            reservation.complete();
+
+            assertThatThrownBy(() -> reservation.approve(200L))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    // ── cancel() 테스트 ──
+
+    @Nested
+    @DisplayName("cancel() - 예약 취소")
+    class Cancel {
+
+        @Test
+        @DisplayName("PENDING 상태에서 취소하면 CANCELLED 상태가 된다")
+        void cancel_fromPending_shouldBeCancelled() {
+            Reservation reservation = createPendingReservation();
+
+            reservation.cancel();
+
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("APPROVED 상태에서 취소하면 CANCELLED 상태가 된다")
+        void cancel_fromApproved_shouldBeCancelled() {
+            Reservation reservation = createPendingReservation();
+            reservation.approve(100L);
+
+            reservation.cancel();
+
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 취소하면 IllegalStateException이 발생한다")
+        void cancel_fromCompleted_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.approve(100L);
+            reservation.complete();
+
+            assertThatThrownBy(() -> reservation.cancel())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("취소");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서 다시 취소하면 IllegalStateException이 발생한다")
+        void cancel_fromCancelled_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.cancel();
+
+            assertThatThrownBy(() -> reservation.cancel())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("취소");
+        }
+    }
+
+    // ── complete() 테스트 ──
+
+    @Nested
+    @DisplayName("complete() - 이용 완료")
+    class Complete {
+
+        @Test
+        @DisplayName("APPROVED 상태에서 완료하면 COMPLETED 상태가 된다")
+        void complete_fromApproved_shouldBeCompleted() {
+            Reservation reservation = createPendingReservation();
+            reservation.approve(100L);
+
+            reservation.complete();
+
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.COMPLETED);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 완료하면 IllegalStateException이 발생한다")
+        void complete_fromPending_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+
+            assertThatThrownBy(() -> reservation.complete())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("완료");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서 완료하면 IllegalStateException이 발생한다")
+        void complete_fromCancelled_shouldThrow() {
+            Reservation reservation = createPendingReservation();
+            reservation.cancel();
+
+            assertThatThrownBy(() -> reservation.complete())
+                    .isInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/backend/src/test/java/com/coliving/infra/persistence/repository/ReservationRepositoryTest.java
+++ b/backend/src/test/java/com/coliving/infra/persistence/repository/ReservationRepositoryTest.java
@@ -1,0 +1,231 @@
+package com.coliving.infra.persistence.repository;
+
+import com.coliving.global.entity.ReservationStatus;
+import com.coliving.infra.persistence.entity.Reservation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * ReservationRepository 통합 테스트
+ * - H2 인메모리 DB를 사용하여 JPA 쿼리 메서드를 검증한다.
+ * - @DataJpaTest는 JPA 관련 빈만 로드하므로 가볍게 실행된다.
+ */
+@DataJpaTest
+@Import(TestJpaConfig.class)   // OffsetDateTime용 DateTimeProvider 포함 JPA Auditing 활성화
+@ActiveProfiles("default")     // test/resources/application.yml 사용
+class ReservationRepositoryTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    private static final LocalDate DATE = LocalDate.of(2026, 4, 5);
+
+    @BeforeEach
+    void setUp() {
+        reservationRepository.deleteAll();
+    }
+
+    private Reservation saveReservation(Long userId, Long spaceId,
+                                        LocalTime start, LocalTime end) {
+        Reservation reservation = Reservation.builder()
+                .userId(userId)
+                .spaceId(spaceId)
+                .reservationDate(DATE)
+                .startTime(start)
+                .endTime(end)
+                .build();
+        return reservationRepository.save(reservation);
+    }
+
+    // ── 기본 CRUD ──
+
+    @Test
+    @DisplayName("예약을 저장하면 ID가 자동 생성된다")
+    void save_shouldGenerateId() {
+        Reservation reservation = saveReservation(1L, 10L,
+                LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        assertThat(reservation.getId()).isNotNull();
+        assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PENDING);
+    }
+
+    // ── 사용자별 조회 ──
+
+    @Nested
+    @DisplayName("사용자별 예약 조회")
+    class FindByUser {
+
+        @Test
+        @DisplayName("특정 사용자의 상태별 예약 목록을 조회할 수 있다")
+        void findByUserIdAndStatusIn() {
+            Reservation pending = saveReservation(1L, 10L,
+                    LocalTime.of(10, 0), LocalTime.of(12, 0));
+            Reservation approved = saveReservation(1L, 11L,
+                    LocalTime.of(14, 0), LocalTime.of(16, 0));
+            approved.approve(100L);
+            reservationRepository.save(approved);
+
+            // 다른 사용자 예약
+            saveReservation(2L, 10L, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+            List<Reservation> results = reservationRepository.findByUserIdAndStatusIn(
+                    1L, List.of(ReservationStatus.PENDING, ReservationStatus.APPROVED));
+
+            assertThat(results).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("특정 사용자의 전체 예약을 최신순으로 조회할 수 있다")
+        void findByUserIdOrderByReservationDateDescStartTimeDesc() {
+            saveReservation(1L, 10L, LocalTime.of(10, 0), LocalTime.of(12, 0));
+            saveReservation(1L, 11L, LocalTime.of(14, 0), LocalTime.of(16, 0));
+
+            List<Reservation> results =
+                    reservationRepository.findByUserIdOrderByReservationDateDescStartTimeDesc(1L);
+
+            assertThat(results).hasSize(2);
+            // 같은 날짜이므로 startTime 기준 내림차순 → 14:00 먼저
+            assertThat(results.get(0).getStartTime()).isEqualTo(LocalTime.of(14, 0));
+        }
+    }
+
+    // ── 시설별 조회 ──
+
+    @Test
+    @DisplayName("특정 시설의 특정 날짜 승인된 예약만 조회할 수 있다")
+    void findBySpaceIdAndReservationDateAndStatus() {
+        Reservation approved = saveReservation(1L, 10L,
+                LocalTime.of(10, 0), LocalTime.of(12, 0));
+        approved.approve(100L);
+        reservationRepository.save(approved);
+
+        saveReservation(2L, 10L, LocalTime.of(14, 0), LocalTime.of(16, 0)); // PENDING
+
+        List<Reservation> results = reservationRepository
+                .findBySpaceIdAndReservationDateAndStatus(10L, DATE, ReservationStatus.APPROVED);
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getStatus()).isEqualTo(ReservationStatus.APPROVED);
+    }
+
+    // ── 중복 예약 체크 ──
+
+    @Nested
+    @DisplayName("existsOverlappingReservation() - 시간대 중복 체크")
+    class OverlapCheck {
+
+        @Test
+        @DisplayName("시간이 겹치는 APPROVED 예약이 있으면 true를 반환한다")
+        void overlapping_shouldReturnTrue() {
+            // 기존 예약: 10:00 ~ 12:00 (APPROVED)
+            Reservation existing = saveReservation(1L, 10L,
+                    LocalTime.of(10, 0), LocalTime.of(12, 0));
+            existing.approve(100L);
+            reservationRepository.save(existing);
+
+            // 새 예약 시도: 11:00 ~ 13:00 (겹침)
+            boolean overlaps = reservationRepository.existsOverlappingReservation(
+                    10L, DATE, LocalTime.of(11, 0), LocalTime.of(13, 0));
+
+            assertThat(overlaps).isTrue();
+        }
+
+        @Test
+        @DisplayName("시간이 겹치지 않으면 false를 반환한다")
+        void noOverlap_shouldReturnFalse() {
+            Reservation existing = saveReservation(1L, 10L,
+                    LocalTime.of(10, 0), LocalTime.of(12, 0));
+            existing.approve(100L);
+            reservationRepository.save(existing);
+
+            // 새 예약 시도: 12:00 ~ 14:00 (안 겹침 - 경계)
+            boolean overlaps = reservationRepository.existsOverlappingReservation(
+                    10L, DATE, LocalTime.of(12, 0), LocalTime.of(14, 0));
+
+            assertThat(overlaps).isFalse();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태 예약은 중복 체크 대상이 아니다")
+        void pendingReservation_shouldNotOverlap() {
+            // PENDING 상태 예약: 10:00 ~ 12:00
+            saveReservation(1L, 10L, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+            // 같은 시간대 중복 체크 → APPROVED만 체크하므로 false
+            boolean overlaps = reservationRepository.existsOverlappingReservation(
+                    10L, DATE, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+            assertThat(overlaps).isFalse();
+        }
+    }
+
+    // ── 활성 예약 확인 ──
+
+    @Nested
+    @DisplayName("hasActiveReservation() - 현재 활성 예약 확인")
+    class ActiveReservation {
+
+        @Test
+        @DisplayName("현재 시각이 예약 시간 범위 안에 있으면 true를 반환한다")
+        void withinTimeRange_shouldReturnTrue() {
+            Reservation reservation = saveReservation(1L, 10L,
+                    LocalTime.of(10, 0), LocalTime.of(12, 0));
+            reservation.approve(100L);
+            reservationRepository.save(reservation);
+
+            boolean active = reservationRepository.hasActiveReservation(
+                    1L, 10L, DATE, LocalTime.of(11, 0));
+
+            assertThat(active).isTrue();
+        }
+
+        @Test
+        @DisplayName("현재 시각이 예약 시간 범위 밖이면 false를 반환한다")
+        void outsideTimeRange_shouldReturnFalse() {
+            Reservation reservation = saveReservation(1L, 10L,
+                    LocalTime.of(10, 0), LocalTime.of(12, 0));
+            reservation.approve(100L);
+            reservationRepository.save(reservation);
+
+            boolean active = reservationRepository.hasActiveReservation(
+                    1L, 10L, DATE, LocalTime.of(13, 0));
+
+            assertThat(active).isFalse();
+        }
+    }
+
+    // ── 기간별 조회 ──
+
+    @Test
+    @DisplayName("특정 시설의 기간별 예약 목록을 날짜/시간 순으로 조회할 수 있다")
+    void findBySpaceIdAndDateRange() {
+        saveReservation(1L, 10L, LocalTime.of(10, 0), LocalTime.of(12, 0));
+
+        // 범위 밖 날짜 예약
+        Reservation outOfRange = Reservation.builder()
+                .userId(1L).spaceId(10L)
+                .reservationDate(LocalDate.of(2026, 5, 1))
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(12, 0))
+                .build();
+        reservationRepository.save(outOfRange);
+
+        List<Reservation> results = reservationRepository.findBySpaceIdAndDateRange(
+                10L, DATE, DATE.plusDays(7));
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getReservationDate()).isEqualTo(DATE);
+    }
+}

--- a/backend/src/test/java/com/coliving/infra/persistence/repository/TestJpaConfig.java
+++ b/backend/src/test/java/com/coliving/infra/persistence/repository/TestJpaConfig.java
@@ -1,0 +1,24 @@
+package com.coliving.infra.persistence.repository;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+/**
+ * 테스트용 JPA Auditing 설정
+ * - BaseEntity의 createdAt/updatedAt이 OffsetDateTime이므로
+ *   DateTimeProvider를 등록하여 Auditing 시 올바른 타입을 제공한다.
+ */
+@Configuration
+@EnableJpaAuditing(dateTimeProviderRef = "offsetDateTimeProvider")
+public class TestJpaConfig {
+
+    @Bean
+    public DateTimeProvider offsetDateTimeProvider() {
+        return () -> Optional.of(OffsetDateTime.now());
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+
+  jackson:
+    time-zone: Asia/Seoul
+
+jwt:
+  secret: test-secret-key-minimum-32-characters-long!!
+  access-expiration: 1800000
+  refresh-expiration: 604800000
+
+mock-iot:
+  base-url: http://localhost:8000
+
+logging:
+  level:
+    com.coliving: DEBUG
+    org.hibernate.SQL: DEBUG

--- a/docs/RSV-4.1.md
+++ b/docs/RSV-4.1.md
@@ -1,0 +1,134 @@
+# [RSV-4.1] 예약/시설(Reservation) DB 및 엔티티 구현
+
+> **담당**: 이영준
+> **기간**: 2026-04-01 ~ 2026-04-03  
+> **상태**: ✅ 완료
+
+---
+
+## 생성 파일 목록
+
+| # | 파일 | 경로 | 역할 |
+|---|---|---|---|
+| 1 | `ReservationStatus.java` | `global/entity/` | 예약 상태 Enum |
+| 2 | `Reservation.java` | `infra/persistence/entity/` | 예약 JPA 엔티티 |
+| 3 | `ReservationRepository.java` | `infra/persistence/repository/` | Spring Data JPA Repository |
+| 4 | `ReservationTest.java` | `test/.../entity/` | 엔티티 단위 테스트 |
+| 5 | `ReservationRepositoryTest.java` | `test/.../repository/` | Repository 통합 테스트 |
+| 6 | `TestJpaConfig.java` | `test/.../repository/` | 테스트용 JPA Auditing 설정 |
+| 7 | `application.yml` | `test/resources/` | H2 인메모리 DB 테스트 설정 |
+
+---
+
+## 설계 결정 사항
+
+### 1. FK 매핑 방식: `Long` 타입 사용
+
+User/Space 엔티티가 아직 구현되지 않았으므로, `@ManyToOne` 대신 `@Column`으로 Long 타입 FK를 선언했습니다.
+
+```java
+// ── 현재 (Long FK) ──
+@Column(name = "user_id", nullable = false)
+private Long userId;
+
+// ── 추후 변경 (User 엔티티 완성 후) ──
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "user_id", nullable = false)
+private User user;
+```
+
+### 2. Soft Delete 지원
+
+`BaseEntity` 상속 + `@SQLRestriction("deleted_at IS NULL")` 적용으로 논리 삭제를 자동 필터링합니다.
+
+### 3. 상태 전환 비즈니스 메서드
+
+엔티티 내부에 상태 전환 로직을 캡슐화하여, 잘못된 상태 전환을 방지합니다.
+
+| 메서드 | 허용 상태 | 결과 상태 |
+|---|---|---|
+| `approve(adminId)` | PENDING → | APPROVED |
+| `cancel()` | PENDING / APPROVED → | CANCELLED |
+| `complete()` | APPROVED → | COMPLETED |
+
+---
+
+## Repository 주요 쿼리
+
+| 메서드 | 용도 | 관련 규칙 |
+|---|---|---|
+| `existsOverlappingReservation()` | 동일 시설/날짜의 시간대 중복 예약 방지 | ERD 비즈니스 규칙 #10 |
+| `hasActiveReservation()` | 공용 기기 제어 권한 확인 (현재 시각 기준) | ERD 비즈니스 규칙 #9 |
+| `findBySpaceIdAndDateRange()` | 주단위 타임테이블 조회 | RSV-4.3 UI 연동용 |
+| `findByUserIdAndStatusIn()` | 사용자별 예약 목록 필터 조회 | RSV-4.2 예약 시설 조회 |
+
+---
+
+## 테스트 결과
+
+> **실행일시**: 2026-04-02  
+> **결과**: ✅ **22개 전체 통과 (failures: 0, errors: 0)**
+
+### 테스트 실행 방법
+
+```bash
+# Reservation 관련 테스트만 실행
+./gradlew test --tests "com.coliving.infra.persistence.*"
+
+# 전체 테스트 실행
+./gradlew test
+
+# HTML 리포트 확인
+open build/reports/tests/test/index.html
+```
+
+### 테스트 인프라
+
+| 항목 | 설정 |
+|---|---|
+| DB | H2 인메모리 (PostgreSQL 호환 모드) |
+| DDL | `create-drop` (테스트 시 자동 생성/삭제) |
+| Auditing | `TestJpaConfig` - `OffsetDateTime`용 `DateTimeProvider` 등록 |
+| 의존성 추가 | `testRuntimeOnly 'com.h2database:h2'` (`build.gradle`) |
+
+### 1. 엔티티 단위 테스트 (`ReservationTest`) — 12건
+
+DB 없이 순수 Java 로직만 검증합니다.
+
+| 테스트 그룹 | 건수 | 검증 항목 |
+|---|---|---|
+| Builder 생성 | 1 | 생성 시 PENDING 상태, userId/spaceId 매핑, approvedBy null |
+| `approve()` 성공 | 1 | PENDING → APPROVED, approvedBy 설정 |
+| `approve()` 예외 | 3 | APPROVED/CANCELLED/COMPLETED 에서 승인 시 `IllegalStateException` |
+| `cancel()` 성공 | 2 | PENDING → CANCELLED, APPROVED → CANCELLED |
+| `cancel()` 예외 | 2 | COMPLETED/CANCELLED 에서 취소 시 `IllegalStateException` |
+| `complete()` 성공 | 1 | APPROVED → COMPLETED |
+| `complete()` 예외 | 2 | PENDING/CANCELLED 에서 완료 시 `IllegalStateException` |
+
+### 2. Repository 통합 테스트 (`ReservationRepositoryTest`) — 10건
+
+H2 인메모리 DB + `@DataJpaTest`로 JPA 쿼리를 검증합니다.
+
+| 테스트 그룹 | 건수 | 검증 항목 |
+|---|---|---|
+| 기본 CRUD | 1 | `save()` 시 ID 자동 생성, 초기 상태 PENDING |
+| 사용자별 조회 | 2 | `findByUserIdAndStatusIn()` 상태 필터, `findByUserId...Desc()` 정렬 |
+| 시설별 조회 | 1 | `findBySpaceIdAndReservationDateAndStatus()` APPROVED 필터 |
+| 중복 예약 체크 | 3 | 시간 겹침 → `true`, 경계값 → `false`, PENDING 무시 → `false` |
+| 활성 예약 확인 | 2 | 시간 범위 내 → `true`, 범위 외 → `false` |
+| 기간별 조회 | 1 | `findBySpaceIdAndDateRange()` 날짜 범위 필터 + 정렬 |
+
+---
+
+## ⚠️ 머지 시 수정 필요 항목
+
+User(팀원1) / Space(팀원2) 엔티티가 완성되면 아래 3개 필드를 `@ManyToOne`으로 변경해야 합니다.
+
+| 파일 | 현재 필드 | 변경 후 |
+|---|---|---|
+| `Reservation.java` | `Long userId` | `@ManyToOne User user` |
+| `Reservation.java` | `Long spaceId` | `@ManyToOne Space space` |
+| `Reservation.java` | `Long approvedBy` | `@ManyToOne User approvedByUser` |
+| `ReservationRepository.java` | 쿼리 메서드 파라미터 | 엔티티 참조 방식으로 검토 |
+
+> 각 필드에 `// TODO` 주석이 달려 있으니 검색하면 바로 찾을 수 있습니다.


### PR DESCRIPTION
- ReservationStatus enum 생성 (PENDING, APPROVED, CANCELLED, COMPLETED)
- Reservation 엔티티 (상태 전환 비즈니스 메서드 포함)
- ReservationRepository (중복 예약 체크, 활성 예약 확인 등 쿼리)
- 단위 테스트 12건 + Repository 통합 테스트 10건 (전체 통과)
- H2 인메모리 DB 테스트 인프라 구성
- RSV-4.1 문서에 테스트 결과 기록 추가

close #75 
close #76 