### PR TITLE
🔧 [CMN] 프론트 postinstall Git 훅 연결 및 Docker npm ci 시 스크립트 생략

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+# postinstall은 로컬 Git 훅용; 이미지에는 상위 .githooks·git 없음
+RUN npm ci --ignore-scripts
 
 # ── Stage 2: 빌드 ──
 FROM node:20-alpine AS builder

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start --port 3111",
     "lint": "next lint",
-    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\""
+    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
+    "postinstall": "cd .. && bash .githooks/setup.sh"
   },
   "dependencies": {
     "clsx": "^2.1.1",


### PR DESCRIPTION
Made-with: Cursor

## 💡 배경 및 목적 (Why)
**Git Hook 자동 변환:** 위와 같이 텍스트 타입으로 커밋하면, `prepare-commit-msg` Hook이 자동으로 이모지로 변환합니다.

## 🔑 주요 변경 사항 (What)
- 프론트 postinstall Git 훅 연결 및 Docker npm ci 시 스크립트 생략
