### PR TITLE
[CMN] 랜딩 추천 매물 카드 및 푸터 UI/UX 개편

### DIFF
--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -9,21 +9,21 @@ export function Footer() {
 
   const footerLinks = {
     explore: [
-      { name: "Living Spaces", path: "/rooms" },
-      { name: "Community", path: "/community" },
-      { name: "VOC", path: "/voc" },
-      { name: "IoT Guide", path: "/rooms" },
+      { name: "Living", path: "/rooms" },
+      { name: "Stay", path: "/rooms" },
+      { name: "Facility", path: "/facility" },
     ],
     community: [
-      { name: "Residents", path: "/profile" },
-      { name: "Community", path: "/community" },
-      { name: "Archive", path: "/rooms" },
-      { name: "Philosophy", path: "/" },
+      { name: "Board", path: "/community" },
+      { name: "Event", path: "/events" },
+      { name: "Notice", path: "/notices" },
+      { name: "VOC", path: "/voc" },
     ],
     support: [
-      { name: "Concierge", path: "/voc" },
-      { name: "Safe & Secure", path: "/community" },
-      { name: "Terms & Privacy", path: "/community" },
+      { name: "Profile", path: "/profile" },
+      { name: "Device", path: "/devices" },
+      { name: "Contract", path: "/contract" },
+      { name: "Reservation", path: "/reservation" },
     ],
   };
 
@@ -33,7 +33,7 @@ export function Footer() {
         <div className="mb-16 grid grid-cols-1 gap-16 lg:grid-cols-12">
           <div className="lg:col-span-8">
             <Link href="/" className="group mb-8 inline-block">
-              <span className="block text-[15vw] font-black leading-[0.8] tracking-tighter uppercase md:text-[8vw]">
+              <span className="block text-[11vw] font-black leading-[0.8] tracking-tighter uppercase md:text-[5vw]">
                 COKKIRI<span className="text-secondary">.</span>
               </span>
               <span className="mt-4 block whitespace-nowrap text-[min(10vw,15px)] font-black uppercase opacity-50 transition-opacity duration-500 group-hover:opacity-100 md:mt-6 md:text-xs md:tracking-[0.4em]">
@@ -76,8 +76,8 @@ export function Footer() {
 
         <div className="mb-16 grid grid-cols-2 gap-10 border-t border-primary/20 pt-12 md:grid-cols-3 lg:grid-cols-4">
           <div>
-            <h5 className="mb-6 text-[16px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
-              Navigation / 01
+            <h5 className="mb-6 text-[13px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
+              EXPLORE / 01
             </h5>
             <ul className="space-y-4">
               {footerLinks.explore.map((link) => (
@@ -93,8 +93,8 @@ export function Footer() {
             </ul>
           </div>
           <div>
-            <h5 className="mb-6 text-[16px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
-              Community / 02
+            <h5 className="mb-6 text-[13px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
+              COMMUNITY / 02
             </h5>
             <ul className="space-y-4">
               {footerLinks.community.map((link) => (
@@ -110,8 +110,8 @@ export function Footer() {
             </ul>
           </div>
           <div>
-            <h5 className="mb-6 text-[16px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
-              Legal / 03
+            <h5 className="mb-6 text-[13px] font-black tracking-[0.3em] text-balance text-primary/50 uppercase">
+              SUPPORT / 03
             </h5>
             <ul className="space-y-4">
               {footerLinks.support.map((link) => (

--- a/frontend/src/components/shared/LandingFeaturedListing.tsx
+++ b/frontend/src/components/shared/LandingFeaturedListing.tsx
@@ -32,8 +32,9 @@ export function LandingFeaturedListing({ listing, size }: { listing: Listing; si
 
   return (
     <motion.div ref={ref} style={{ y }} className="group">
-      <Link href={`/rooms/${listing.id}`}>
-        <div className="relative mb-8 overflow-hidden">
+      <Link href={`/rooms/${listing.id}`} className="block focus:outline-none">
+        {/* Image Display */}
+        <div className="relative mb-6 overflow-hidden">
           <motion.div
             whileHover={{ scale: 1.05 }}
             transition={{ duration: 0.8, ease: [0.22, 1, 0.36, 1] }}
@@ -48,13 +49,19 @@ export function LandingFeaturedListing({ listing, size }: { listing: Listing; si
           </motion.div>
         </div>
 
-        <div className="space-y-4">
-          <div className="flex items-baseline justify-between">
-            <h3 className="text-2xl font-black tracking-tighter">{listing.title}</h3>
-            <span className="text-sm font-black whitespace-nowrap opacity-10">/ {listing.id.padStart(2, "0")}</span>
+        {/* Text Container Below Image */}
+        <div className="flex flex-col gap-3 font-sans pb-4">
+          <div className="flex items-baseline justify-between mb-1">
+            <h3 className="text-2xl md:text-3xl font-black tracking-tighter text-primary uppercase transition-colors group-hover:text-accent">
+              {listing.title}
+            </h3>
+            <span className="text-sm md:text-base font-bold tracking-widest text-secondary">
+              / {listing.id.padStart(2, "0")}
+            </span>
           </div>
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center justify-between text-xs font-black tracking-widest text-secondary uppercase">
+          
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center justify-between text-[11px] md:text-xs font-bold tracking-[0.15em] text-primary uppercase">
               <span>
                 {listing.roomType === "Private Suite"
                   ? "개인 전용 공간"
@@ -62,11 +69,17 @@ export function LandingFeaturedListing({ listing, size }: { listing: Listing; si
                     ? "전체 독립형"
                     : "공유 아틀리에"}
               </span>
-              <span className="opacity-40">보증금 상담 가능</span>
+              <span>보증금 상담 가능</span>
             </div>
-            <div className="flex items-center justify-between text-xs font-black tracking-widest text-foreground/40 uppercase">
-              <span>IoT 스마트 보안 포함</span>
-              <span className="text-foreground opacity-100">월 {listing.price.toLocaleString()}원</span>
+            <div className="flex items-end justify-between text-primary uppercase mt-2">
+              <span className="text-[11px] md:text-xs font-bold tracking-[0.15em] mb-1">IoT 스마트 보안 포함</span>
+              <div className="flex items-baseline gap-1">
+                <span className="text-[13px] font-semibold opacity-50 tracking-normal">월</span>
+                <span className="text-2xl md:text-3xl font-extrabold tracking-tighter [font-family:var(--font-manrope),_var(--font-pretendard),_sans-serif]">
+                  {listing.price.toLocaleString()}
+                </span>
+                <span className="text-[13px] font-semibold opacity-50 tracking-normal">원</span>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/src/components/shared/ListingCard.tsx
+++ b/frontend/src/components/shared/ListingCard.tsx
@@ -12,10 +12,7 @@ interface ListingCardProps {
 
 export function ListingCard({ listing }: ListingCardProps) {
   return (
-    <Link
-      href={`/rooms/${listing.id}`}
-      className="group block [font-family:var(--font-manrope),_var(--font-pretendard),_sans-serif]"
-    >
+    <Link href={`/rooms/${listing.id}`} className="group block">
       <motion.div
         initial={{ opacity: 0, y: 20 }}
         whileInView={{ opacity: 1, y: 0 }}
@@ -53,7 +50,7 @@ export function ListingCard({ listing }: ListingCardProps) {
 
         <div className="mt-8 space-y-3 px-2">
           <div className="flex items-baseline justify-between">
-            <h3 className="[font-family:inherit] text-2xl font-black tracking-tighter text-primary transition-colors duration-500 group-hover:text-secondary">
+            <h3 className="text-2xl font-black tracking-tighter text-primary transition-colors duration-500 group-hover:text-secondary">
               {listing.title}
             </h3>
             <span className="text-base font-black whitespace-nowrap text-primary opacity-10">


### PR DESCRIPTION

## 🔑 주요 변경 사항 (What)
- LandingFeaturedListing: 프로젝트 UI가이드라인(Moss&Aloe) 컬러 기반 텍스트 계층화 적용
- LandingFeaturedListing: 가격 단위 분리 및 숫자에 전용 폰트(Manrope) 도입으로 가독성 크게 개선
- Footer: 메인 로고 텍스트 크기 축소 조정
- Footer: 플랫폼 도메인(Living, Board, VOC, Contract 등)에 맞춰 네비게이션 링크 영문화 개편
