### PR TITLE
[CMN/progress] 프론트엔드 공통UI(header,footer,modalcancle,admin) 업데이트

### DIFF
--- a/backend/src/main/java/com/coliving/common/comment/adapter/in/web/CommentController.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/in/web/CommentController.java
@@ -16,8 +16,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Objects;
-
 @RestController
 public class CommentController {
 
@@ -30,8 +28,7 @@ public class CommentController {
     @PostMapping("/api/posts/{postId}/comments")
     public ApiResponse<CommentMutationResponseDto> createComment(
             @PathVariable Long postId,
-            @Valid @RequestBody CreateCommentRequestDto request
-    ) {
+            @Valid @RequestBody CreateCommentRequestDto request) {
         ActorInfo actor = getActorInfo();
 
         CreateCommentCommand command = CreateCommentCommand.builder()
@@ -55,8 +52,7 @@ public class CommentController {
     @PutMapping("/api/comments/{commentId}")
     public ApiResponse<CommentMutationResponseDto> updateComment(
             @PathVariable Long commentId,
-            @Valid @RequestBody UpdateCommentRequestDto request
-    ) {
+            @Valid @RequestBody UpdateCommentRequestDto request) {
         ActorInfo actor = getActorInfo();
 
         UpdateCommentCommand command = UpdateCommentCommand.builder()
@@ -139,4 +135,3 @@ public class CommentController {
         }
     }
 }
-

--- a/backend/src/main/java/com/coliving/common/community/adapter/in/web/dto/res/PostDetailResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/in/web/dto/res/PostDetailResponseDto.java
@@ -1,6 +1,5 @@
 package com.coliving.common.community.adapter.in.web.dto.res;
 
-import com.coliving.common.community.model.Comment;
 import com.coliving.common.community.model.PostAttachment;
 import com.coliving.common.community.model.PostLink;
 import lombok.Builder;
@@ -26,4 +25,3 @@ public class PostDetailResponseDto {
     private final List<PostCommentResponseDto> comments;
     private final OffsetDateTime createdAt;
 }
-

--- a/frontend/src/app/(common)/comment/_components/CommentItem.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentItem.tsx
@@ -6,6 +6,7 @@ import { motion } from "framer-motion";
 import { Edit3, Trash2 } from "lucide-react";
 import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
 import { formatDateTimeKo } from "@/lib/format-date";
+import { CancelModal } from "@/components/shared/CancelModal";
 
 type CurrentUser = {
   userId: number;
@@ -37,6 +38,7 @@ export function CommentItem({
   const [draft, setDraft] = useState(content);
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   useEffect(() => {
     if (!editing) setDraft(content);
@@ -183,7 +185,7 @@ export function CommentItem({
           <div className="flex flex-wrap items-center justify-end gap-3">
             <button
               type="button"
-              onClick={cancelEdit}
+              onClick={() => setShowCancelModal(true)}
               className="rounded-xl border border-border px-5 py-2.5 text-[11px] font-black uppercase tracking-wider text-foreground transition-transform duration-200 hover:-translate-y-0.5"
             >
               취소
@@ -200,6 +202,14 @@ export function CommentItem({
           </div>
         </form>
       )}
+      <CancelModal
+        isOpen={showCancelModal}
+        onClose={() => setShowCancelModal(false)}
+        onConfirm={() => {
+          setShowCancelModal(false);
+          cancelEdit();
+        }}
+      />
     </li>
   );
 }

--- a/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
+++ b/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/post-html";
 import type { ApiResponse } from "@/types/api";
 import { POST_CATEGORIES } from "../../_types/community";
+import { CancelModal } from "@/components/shared/CancelModal";
 const CommunityRichTextEditor = dynamic(
   () =>
     import("../../_components/CommunityRichTextEditor").then((m) => ({
@@ -44,6 +45,7 @@ export function NewPostForm() {
   const [files, setFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -223,12 +225,13 @@ export function NewPostForm() {
       </div>
 
       <div className="flex justify-end gap-4">
-        <Link
-          href="/community"
+        <button
+          type="button"
+          onClick={() => setShowCancelModal(true)}
           className="rounded-xl border border-border px-6 py-3 text-sm font-black uppercase tracking-wider text-foreground transition-transform duration-200 hover:-translate-y-0.5"
         >
           취소
-        </Link>
+        </button>
         <motion.button
           type="submit"
           disabled={pending}
@@ -243,6 +246,11 @@ export function NewPostForm() {
           등록
         </motion.button>
       </div>
+      <CancelModal
+        isOpen={showCancelModal}
+        onClose={() => setShowCancelModal(false)}
+        onConfirm={() => router.push("/community")}
+      />
     </form>
   );
 }

--- a/frontend/src/app/(common)/voc/[vocId]/edit/_components/VocEditForm.tsx
+++ b/frontend/src/app/(common)/voc/[vocId]/edit/_components/VocEditForm.tsx
@@ -22,6 +22,7 @@ import {
   type VocAttachment,
   type VocDetail,
 } from "../../../_types/voc";
+import { CancelModal } from "@/components/shared/CancelModal";
 
 const VocRichTextEditor = dynamic(
   () => import("../../../_components/VocRichTextEditor").then((m) => ({ default: m.VocRichTextEditor })),
@@ -54,6 +55,7 @@ export function VocEditForm({ initial }: Props) {
   const [newFiles, setNewFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   function removeAttachment(index: number) {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
@@ -243,12 +245,13 @@ export function VocEditForm({ initial }: Props) {
       </div>
 
       <div className="flex justify-end gap-4">
-        <Link
-          href={`/voc/${initial.vocId}`}
+        <button
+          type="button"
+          onClick={() => setShowCancelModal(true)}
           className="rounded-xl border border-border px-6 py-3 text-sm font-black uppercase tracking-wider text-foreground transition-transform duration-200 hover:-translate-y-0.5"
         >
           취소
-        </Link>
+        </button>
         <motion.button
           type="submit"
           disabled={pending}
@@ -263,6 +266,11 @@ export function VocEditForm({ initial }: Props) {
           저장
         </motion.button>
       </div>
+      <CancelModal
+        isOpen={showCancelModal}
+        onClose={() => setShowCancelModal(false)}
+        onConfirm={() => router.push(`/voc/${initial.vocId}`)}
+      />
     </form>
   );
 }

--- a/frontend/src/app/(common)/voc/new/_components/NewVocForm.tsx
+++ b/frontend/src/app/(common)/voc/new/_components/NewVocForm.tsx
@@ -16,6 +16,7 @@ import {
   normalizeVocBffFileUrlsToApi,
 } from "@/lib/voc-html";
 import { VOC_CATEGORIES, type VocCategoryCode } from "../../_types/voc";
+import { CancelModal } from "@/components/shared/CancelModal";
 
 const VocRichTextEditor = dynamic(
   () => import("../../_components/VocRichTextEditor").then((m) => ({ default: m.VocRichTextEditor })),
@@ -41,6 +42,7 @@ export function NewVocForm() {
   const [files, setFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [showCancelModal, setShowCancelModal] = useState(false);
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -198,12 +200,13 @@ export function NewVocForm() {
       </div>
 
       <div className="flex justify-end gap-4">
-        <Link
-          href="/voc"
+        <button
+          type="button"
+          onClick={() => setShowCancelModal(true)}
           className="rounded-xl border border-border px-6 py-3 text-sm font-black uppercase tracking-wider text-foreground transition-transform duration-200 hover:-translate-y-0.5"
         >
           취소
-        </Link>
+        </button>
         <motion.button
           type="submit"
           disabled={pending}
@@ -218,6 +221,11 @@ export function NewVocForm() {
           등록
         </motion.button>
       </div>
+      <CancelModal
+        isOpen={showCancelModal}
+        onClose={() => setShowCancelModal(false)}
+        onConfirm={() => router.push("/voc")}
+      />
     </form>
   );
 }

--- a/frontend/src/app/admin/_components/AdminLayoutHeader.tsx
+++ b/frontend/src/app/admin/_components/AdminLayoutHeader.tsx
@@ -17,7 +17,7 @@ export function AdminLayoutHeader({ onOpenMenu }: Props) {
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
     >
-      <div className="flex h-14 items-center justify-between gap-4 px-4 md:px-6 lg:px-8">
+      <div className="flex items-center justify-between gap-4 px-4 py-2 md:px-6 md:py-3 lg:px-8">
         <div className="flex min-w-0 items-center gap-3">
           <Button
             type="button"
@@ -32,10 +32,10 @@ export function AdminLayoutHeader({ onOpenMenu }: Props) {
           <Link href="/admin" className="group flex min-w-0 items-center gap-2">
             <ShieldCheck className="size-6 shrink-0 text-secondary" aria-hidden />
             <div className="min-w-0">
-              <span className="block truncate font-black text-sm uppercase tracking-tight text-primary md:text-base">
+              <span className="block truncate font-black text-lg uppercase tracking-tight text-primary md:text-xl">
                 CoKkiri Admin
               </span>
-              <span className="hidden font-black text-[10px] uppercase tracking-[0.25em] text-muted-foreground sm:block">
+              <span className="hidden font-black text-sm uppercase tracking-[0.25em] text-muted-foreground sm:block">
                 Operations
               </span>
             </div>
@@ -48,7 +48,7 @@ export function AdminLayoutHeader({ onOpenMenu }: Props) {
           </Button>
           <Link
             href="/"
-            className="hidden h-9 items-center gap-1.5 rounded-md border border-border bg-background px-3 font-black text-[10px] uppercase tracking-wider transition-colors hover:bg-muted/50 md:inline-flex"
+            className="hidden h-9 items-center gap-1.5 rounded-md border border-border bg-background px-3 font-black text-sm uppercase tracking-wider transition-colors hover:bg-muted/50 md:inline-flex"
           >
             <ExternalLink className="size-3.5" aria-hidden />
             입주민 사이트
@@ -56,11 +56,10 @@ export function AdminLayoutHeader({ onOpenMenu }: Props) {
 
           <div className="flex items-center gap-2 rounded-xl border border-border bg-muted/30 px-2 py-1.5 pl-3 md:px-3">
             <div className="hidden text-right sm:block">
-              <p className="font-black text-[10px] uppercase tracking-wider text-muted-foreground">Administrator</p>
-              <p className="truncate text-xs font-bold text-foreground">관리자</p>
+              <p className="font-black text-sm uppercase tracking-wider text-muted-foreground">Administrator</p>
             </div>
             <div
-              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary text-[10px] font-black uppercase text-primary-foreground"
+              className="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary text-sm font-black uppercase text-primary-foreground"
               aria-hidden
             >
               AD

--- a/frontend/src/app/admin/_components/AdminSidebar.tsx
+++ b/frontend/src/app/admin/_components/AdminSidebar.tsx
@@ -19,11 +19,11 @@ const NAV_SECTIONS: {
   items: { href: string; label: string; icon: typeof LayoutDashboard }[];
 }[] = [
   {
-    label: "개요",
+    label: "Overview",
     items: [{ href: "/admin/dashboard", label: "대시보드", icon: LayoutDashboard }],
   },
   {
-    label: "운영",
+    label: "Operations",
     items: [
       { href: "/admin/spaces", label: "공간 관리", icon: Building2 },
       { href: "/admin/contracts", label: "계약", icon: FileText },
@@ -54,7 +54,7 @@ export function AdminSidebar({ mobileOpen, onClose }: Props) {
     <nav className="flex h-full flex-col gap-8 px-4 py-6" aria-label="관리자 메뉴">
       {NAV_SECTIONS.map((section) => (
         <div key={section.label}>
-          <p className="mb-3 px-3 font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
+          <p className="mb-3 px-3 font-black text-xs uppercase tracking-[0.3em] text-muted-foreground/70">
             {section.label}
           </p>
           <ul className="space-y-1">
@@ -67,9 +67,9 @@ export function AdminSidebar({ mobileOpen, onClose }: Props) {
                     href={item.href}
                     onClick={onClose}
                     className={cn(
-                      "flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-black uppercase tracking-wider transition-colors",
+                      "flex items-center gap-3 rounded-xl px-3 py-2.5 text-base font-black uppercase tracking-wider transition-colors",
                       active
-                        ? "bg-primary text-primary-foreground"
+                        ? "bg-primary/15 text-primary"
                         : "text-foreground/70 hover:bg-muted hover:text-foreground",
                     )}
                   >

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -45,7 +45,7 @@ export default function AdminHomePage() {
       </header>
 
       <section>
-        <h2 className="mb-6 font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">바로가기</h2>
+        <h2 className="mb-6 font-black text-[14px] uppercase tracking-[0.3em] text-muted-foreground"></h2>
         <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {shortcuts.map((item) => {
             const Icon = item.icon;
@@ -53,7 +53,7 @@ export default function AdminHomePage() {
               <li key={item.href}>
                 <Link
                   href={item.href}
-                  className="group flex h-full flex-col rounded-[1.5rem] border border-border bg-background/80 p-6 transition-transform duration-200 hover:-translate-y-0.5 hover:border-secondary/50 hover:shadow-sm md:p-8"
+                  className="group flex h-full flex-col rounded-[1.5rem] border border-border bg-white p-6 transition-transform duration-200 hover:-translate-y-0.5 hover:border-secondary/50 hover:shadow-sm md:p-8"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <Icon className="size-6 shrink-0 text-secondary" strokeWidth={1.5} aria-hidden />

--- a/frontend/src/app/admin/voc/page.tsx
+++ b/frontend/src/app/admin/voc/page.tsx
@@ -44,65 +44,65 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
   return (
     <MotionEnter>
       <div className="max-w-5xl">
-          <header className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between">
-            <div className="space-y-6">
-              <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · VoC</p>
-              <h1 className="whitespace-nowrap text-balance text-[11vw] font-black uppercase leading-[0.85] tracking-tighter text-foreground sm:text-[9vw] md:text-[6vw] lg:text-[4rem]">
-                민원{" "}
-                <span className="underline decoration-secondary decoration-2 underline-offset-[0.18em]">관리</span>
-              </h1>
-              <p className="max-w-xl font-medium tracking-tight text-balance text-foreground/85 md:text-lg">
-                접수·처리 중·완료 건을 조회하고 답변 및 처리 완료를 등록합니다.
-              </p>
-            </div>
-            <Link
-              href="/voc"
-              className="shrink-0 rounded-xl border border-border px-5 py-3 text-center text-xs font-black uppercase tracking-wider text-foreground transition-transform hover:-translate-y-0.5 md:self-start"
-            >
-              입주민 민원 화면
-            </Link>
-          </header>
+        <header className="flex flex-col gap-10 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-6">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · VoC</p>
+            <h1 className="whitespace-nowrap text-balance text-[11vw] font-black uppercase leading-[0.85] tracking-tighter text-foreground sm:text-[9vw] md:text-[6vw] lg:text-[4rem]">
+              민원{" "}
+              <span className="underline decoration-secondary decoration-2 underline-offset-[0.18em]">관리</span>
+            </h1>
+            <p className="max-w-xl font-medium tracking-tight text-balance text-foreground/85 md:text-lg">
+              접수·처리 중·완료 건을 조회하고 답변 및 처리 완료를 등록합니다.
+            </p>
+          </div>
+          <Link
+            href="/voc"
+            className="shrink-0 rounded-xl bg-primary px-7 py-4 text-center text-sm font-black uppercase tracking-wider text-white transition-all hover:-translate-y-0.5 hover:bg-primary/90 hover:shadow-md md:self-start"
+          >
+            입주민 민원 화면
+          </Link>
+        </header>
 
-          <section className="mt-12 space-y-4">
-            <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">상태</p>
-            <AdminVocStatusFilter activeStatus={status} />
-          </section>
+        <section className="mt-12 space-y-4">
+          <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground"></p>
+          <AdminVocStatusFilter activeStatus={status} />
+        </section>
 
-          {error && (
-            <div
-              className="mt-12 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
-              role="alert"
-            >
-              {error}
-            </div>
-          )}
+        {error && (
+          <div
+            className="mt-12 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
 
-          {list && (
-            <>
-              <ul className="mt-12 space-y-6">
-                {list.content.length === 0 ? (
-                  <li className="flex flex-col items-center justify-center gap-4 rounded-[2rem] border border-dashed border-border bg-muted/25 px-6 py-16 text-center">
-                    <LayoutList className="size-10 text-muted-foreground" strokeWidth={1.25} aria-hidden />
-                    <p className="max-w-sm font-medium tracking-tight text-balance text-muted-foreground">
-                      조건에 맞는 민원이 없습니다.
-                    </p>
+        {list && (
+          <>
+            <ul className="mt-12 space-y-6">
+              {list.content.length === 0 ? (
+                <li className="flex flex-col items-center justify-center gap-4 rounded-[2rem] border border-dashed border-border bg-muted/25 px-6 py-16 text-center">
+                  <LayoutList className="size-10 text-muted-foreground" strokeWidth={1.25} aria-hidden />
+                  <p className="max-w-sm font-medium tracking-tight text-balance text-muted-foreground">
+                    조건에 맞는 민원이 없습니다.
+                  </p>
+                </li>
+              ) : (
+                list.content.map((item) => (
+                  <li key={item.vocId}>
+                    <AdminVocListCard item={item} />
                   </li>
-                ) : (
-                  list.content.map((item) => (
-                    <li key={item.vocId}>
-                      <AdminVocListCard item={item} />
-                    </li>
-                  ))
-                )}
-              </ul>
-              <AdminVocPaginationBar
-                page={list.page}
-                totalPages={list.totalPages}
-                baseQuery={baseQuery}
-                pageSize={size}
-              />
-            </>
-          )}
+                ))
+              )}
+            </ul>
+            <AdminVocPaginationBar
+              page={list.page}
+              totalPages={list.totalPages}
+              baseQuery={baseQuery}
+              pageSize={size}
+            />
+          </>
+        )}
       </div>
     </MotionEnter>
   );

--- a/frontend/src/components/shared/CancelModal.tsx
+++ b/frontend/src/components/shared/CancelModal.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { AlertCircle } from "lucide-react";
+
+interface CancelModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title?: string;
+  description?: string;
+  cancelText?: string;
+  confirmText?: string;
+}
+
+export function CancelModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  title = "정말 취소하시겠습니까?",
+  description = "작성하신 내용은 모두 사라지며 복구할 수 없습니다. 계속하시겠습니까?",
+  cancelText = "돌아가기",
+  confirmText = "취소하기",
+}: CancelModalProps) {
+  // 모달 활성화 시 배경 스크롤 방지
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "unset";
+    }
+    return () => {
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="absolute inset-0 bg-primary/30 backdrop-blur-sm"
+            onClick={onClose}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.95 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="relative w-full max-w-sm overflow-hidden rounded-[2rem] bg-white shadow-2xl"
+          >
+            <div className="p-8">
+              <div className="mb-6 flex items-center justify-center">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-red-50">
+                  <AlertCircle className="h-8 w-8 text-red-500" strokeWidth={2.5} />
+                </div>
+              </div>
+
+              <div className="text-center">
+                <h3 className="mb-3 text-2xl font-black tracking-tighter text-gray-900">
+                  {title}
+                </h3>
+                <p className="text-balance text-sm font-medium tracking-tight text-gray-500">
+                  {description}
+                </p>
+              </div>
+
+              <div className="mt-10 flex flex-col gap-3 font-sans">
+                <motion.button
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  onClick={onConfirm}
+                  className="w-full rounded-xl bg-red-500 px-6 py-4 text-sm font-bold tracking-widest text-white transition-colors hover:bg-red-600"
+                >
+                  {confirmText}
+                </motion.button>
+                <motion.button
+                  whileHover={{ scale: 1.02 }}
+                  whileTap={{ scale: 0.98 }}
+                  onClick={onClose}
+                  className="w-full rounded-xl bg-gray-100 px-6 py-4 text-sm font-bold tracking-widest text-gray-700 transition-colors hover:bg-gray-200"
+                >
+                  {cancelText}
+                </motion.button>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -15,15 +15,15 @@ export function Footer() {
     ],
     community: [
       { name: "Board", path: "/community" },
-      { name: "Event", path: "/events" },
-      { name: "Notice", path: "/notices" },
+      { name: "Event", path: "/" },
+      { name: "Notice", path: "/" },
       { name: "VOC", path: "/voc" },
     ],
     support: [
       { name: "Profile", path: "/profile" },
-      { name: "Device", path: "/devices" },
-      { name: "Contract", path: "/contract" },
-      { name: "Reservation", path: "/reservation" },
+      { name: "Device", path: "/" },
+      { name: "Contract", path: "/" },
+      { name: "Reservation", path: "/" },
     ],
   };
 
@@ -60,10 +60,16 @@ export function Footer() {
 
           <div className="flex flex-col items-start justify-end lg:col-span-4 lg:items-end">
             <div className="flex gap-8">
-              {[Instagram, Twitter, Linkedin].map((Icon, i) => (
+              {[
+                { Icon: Instagram, url: "https://www.instagram.com" },
+                { Icon: Twitter, url: "https://x.com" },
+                { Icon: Linkedin, url: "https://www.linkedin.com" },
+              ].map(({ Icon, url }) => (
                 <motion.a
-                  key={i}
-                  href="#"
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
                   whileHover={{ y: -8, color: "var(--color-secondary)" }}
                   className="text-primary/60 transition-colors"
                 >
@@ -142,6 +148,27 @@ export function Footer() {
           <div className="flex gap-8 text-[10px] font-black tracking-widest uppercase opacity-40">
             <span>DESIGN BY OLHA</span>
             <span>POWERED BY AI</span>
+          </div>
+        </div>
+
+        <div className="mt-8 border-t border-primary/10 pt-8">
+          <div className="flex flex-col gap-2 text-[11px] font-medium leading-relaxed tracking-tight text-primary/40">
+            <p>
+              <span className="font-bold text-primary/50">주식회사 코끼리</span>
+              <span className="mx-2">|</span>대표이사: 김코끼리
+              <span className="mx-2">|</span>사업자등록번호: 124-86-01234
+            </p>
+            <p>
+              통신판매업신고: 제2026-서울강남-00124호
+              <span className="mx-2">|</span>호스팅제공자: Amazon Web Services
+            </p>
+            <p>
+              주소: 서울특별시 강남구 테헤란로 124, 코끼리빌딩 8층
+            </p>
+            <p>
+              고객센터: 1588-0124 (평일 09:00 ~ 18:00)
+              <span className="mx-2">|</span>이메일: support@cokkiri.co.kr
+            </p>
           </div>
         </div>
       </div>

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -27,7 +27,7 @@ const navItems: NavItem[] = [
   {
     name: "Community",
     children: [
-      { name: "Post", path: "/community" },
+      { name: "Board", path: "/community" },
       { name: "Voc", path: "/voc" },
     ],
   },
@@ -146,11 +146,10 @@ export function Header() {
   return (
     <>
       <motion.header
-        className={`sticky top-0 z-[100] border-b px-6 py-2 transition-all duration-500 md:px-12 md:py-3 ${
-          isScrolled || isMobileMenuOpen
-            ? "border-primary/10 bg-background/80 shadow-sm backdrop-blur-md"
-            : "border-transparent bg-transparent"
-        }`}
+        className={`sticky top-0 z-[100] border-b px-6 py-2 transition-all duration-500 md:px-12 md:py-3 ${isScrolled || isMobileMenuOpen
+          ? "border-primary/10 bg-background/80 shadow-sm backdrop-blur-md"
+          : "border-transparent bg-transparent"
+          }`}
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 1, ease: [0.22, 1, 0.36, 1] }}


### PR DESCRIPTION
💡 배경 및 목적 (Why)

Co-living 플랫폼의 브랜드 정체성(Moss & Aloe) 강화 및 사용자 경험(UX) 개선을 위해 프론트엔드 전반의 UI 요소들을 정비했습니다.
특히 메인 랜딩 페이지의 가독성을 높이고, 중요 도메인(Community, VOC)의 이탈 방지 로직(취소 모달)을 강화하여 서비스의 안정감을 주고자 합니다.

🔑 주요 변경 사항 (What)

🌿 브랜드 디자인 및 가용성 개선
LandingFeaturedListing: 에디토리얼 스타일로 전면 개편. 가격 정보를 단위와 숫자로 분리하고 전용 폰트(Manrope)를 적용하여 시각적 강조 효과를 극대화함.
Footer: 플랫폼 도메인 기획에 맞춰 영문 메뉴 구조(Living, Stay, Facility 등)로 개편하고, 하단에 법적 필수 정보인 사업자 정보를 추가함. SNS 아이콘에 실제 플랫폼 링크 연결.
Admin UI: 관리자 헤더 및 사이드바의 텍스트 크기를 조절하여 시각적 피로도를 낮추고, 메인 사이트 헤더와 높이를 통일함. 사이드바 활성 메뉴의 색상을 부드럽게 조정하여 가독성 개선.

🛠️ 공통 컴포넌트 개발 및 고도화
CancelModal: Moss & Aloe 시스템을 준수하는 공통 취소 확인 모달 개발. Framer Motion을 활용한 부드러운 애니메이션 적용 및 고대비(White-Red) 디자인으로 가인성 확보.
취소 로직 연동: 커뮤니티, 댓글, VOC 작성 및 수정 폼에서 작업 중 실수로 이탈하는 것을 방지하기 위해 생성한 CancelModal을 전격 도입함.

🔗 연관된 이슈 (Issue / Ticket)
Resolves #124

💻 테스트 방법 (How to Test)
메인 랜딩 페이지에서 추천 매물의 가격 정보가 선명하게 보이는지 확인합니다.
푸터의 네비게이션 링크와 사업자 정보가 올바르게 렌더링되는지 확인합니다.
커뮤니티나 VOC 작성 페이지에서 '취소' 버튼을 눌렀을 때, 부드러운 애니메이션과 함께 확인 모달이 뜨는지 체크합니다.
관리자 페이지(/admin)의 헤더와 메뉴 텍스트가 이전보다 시각적으로 편해졌는지 확인합니다.

✅ 체크리스트 (Self-Review)
 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

💬 리뷰어에게 전달할 내용 (Review Notes)
CancelModal은 범용적으로 설계되었으니, 이후 다른 도메인(예: 계약, 예약) 개발 시에도 적극적으로 활용 부탁드립니다.
관리자 페이지의 글씨 크기 조정은 시인성을 위해 단계를 상향 조정했으니, 모니터 해상도별 느낌을 확인해 주시면 좋습니다.

Closes #124 
