### PR TITLE
Feat/117

### DIFF
--- a/backend/src/main/java/com/coliving/admin/reservation/adapter/in/web/AdminReservationController.java
+++ b/backend/src/main/java/com/coliving/admin/reservation/adapter/in/web/AdminReservationController.java
@@ -1,4 +1,4 @@
-package com.coliving.reservation.adapter.in.web;
+package com.coliving.admin.reservation.adapter.in.web;
 
 import com.coliving.global.dto.ApiResponse;
 import com.coliving.reservation.adapter.in.web.dto.AdminReservationResponse;
@@ -17,6 +17,11 @@ import java.util.List;
  * 관리자용 예약 관리 REST Controller
  *
  * RSV-4.5: 예약 모든 내역 조회(82), 예약 수동 승인/반려(83)
+ *
+ * [아키텍처 규칙 준수]
+ * - 위치: admin/reservation/adapter/in/web/ (03-backend-architecture.md §1-2)
+ * - ADMIN 전용 유스케이스 진입점
+ * - SecurityConfig에서 /api/admin/** 경로 = hasRole("ADMIN") 보호
  */
 @Tag(name = "Admin-Reservation", description = "관리자 전용 예약 관리 API (#82, #83)")
 @RestController
@@ -41,7 +46,7 @@ public class AdminReservationController {
             @RequestHeader("X-Admin-Id") Long adminId,
             @Parameter(description = "예약 ID", example = "100")
             @PathVariable("id") Long reservationId) {
-        
+
         reservationCommandUseCase.approveReservation(adminId, reservationId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
@@ -53,7 +58,7 @@ public class AdminReservationController {
             @RequestHeader("X-Admin-Id") Long adminId,
             @Parameter(description = "예약 ID", example = "100")
             @PathVariable("id") Long reservationId) {
-        
+
         reservationCommandUseCase.rejectReservation(adminId, reservationId);
         return ResponseEntity.ok(ApiResponse.ok(null));
     }

--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -46,13 +46,13 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
 
-                // ADMIN only (임시 테스트 허용)
-                .requestMatchers("/api/admin/**").permitAll()
+                // ADMIN only
+                .requestMatchers("/api/admin/**").hasRole("ADMIN")
 
-                // RESIDENT or ADMIN (임시 테스트 허용)
+                // RESIDENT or ADMIN
                 .requestMatchers("/api/devices/**", "/api/facilities/**",
                         "/api/reservations/**", "/api/control-logs/**")
-                    .permitAll()
+                    .hasAnyRole("RESIDENT", "ADMIN")
 
                 // authenticated
                 .anyRequest().authenticated()

--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/FacilityController.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/FacilityController.java
@@ -3,7 +3,7 @@ package com.coliving.reservation.adapter.in.web;
 import com.coliving.global.dto.ApiResponse;
 import com.coliving.reservation.adapter.out.dto.FacilityDetailResponse;
 import com.coliving.reservation.adapter.out.dto.ReservableFacilityResponse;
-import com.coliving.reservation.application.service.FacilityQueryService;
+import com.coliving.reservation.application.port.in.FacilityQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,7 +36,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FacilityController {
 
-    private final FacilityQueryService facilityQueryService;
+    private final FacilityQueryUseCase facilityQueryUseCase;
 
     /**
      * 예약 가능한 공용시설 전체 목록 조회
@@ -54,7 +54,7 @@ public class FacilityController {
     )
     @GetMapping
     public ResponseEntity<ApiResponse<List<ReservableFacilityResponse>>> getReservableFacilities() {
-        List<ReservableFacilityResponse> facilities = facilityQueryService.getReservableFacilities();
+        List<ReservableFacilityResponse> facilities = facilityQueryUseCase.getReservableFacilities();
         return ResponseEntity.ok(ApiResponse.ok(facilities));
     }
 
@@ -76,7 +76,7 @@ public class FacilityController {
     public ResponseEntity<ApiResponse<FacilityDetailResponse>> getFacilityDetail(
             @Parameter(description = "공용시설 ID", example = "1")
             @PathVariable Long spaceId) {
-        FacilityDetailResponse detail = facilityQueryService.getFacilityDetail(spaceId);
+        FacilityDetailResponse detail = facilityQueryUseCase.getFacilityDetail(spaceId);
         return ResponseEntity.ok(ApiResponse.ok(detail));
     }
 }

--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/AdminReservationResponse.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/AdminReservationResponse.java
@@ -50,7 +50,7 @@ public class AdminReservationResponse {
                 .reservationDate(entity.getReservationDate())
                 .startTime(entity.getStartTime())
                 .endTime(entity.getEndTime())
-                .approvedBy(entity.getApprovedBy())
+                .approvedBy(entity.getApprovedById())
                 .build();
     }
 }

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
@@ -3,6 +3,7 @@ package com.coliving.reservation.adapter.out.jpa;
 import com.coliving.common.auth.adapter.out.jpa.UserEntity;
 import com.coliving.global.entity.BaseEntity;
 import com.coliving.reservation.model.ReservationStatus;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,15 +21,15 @@ import java.time.LocalTime;
  * schema.sql의 reservation 테이블에 매핑된다.
  *
  * ┌──────────────────────────────────────────────────────────────────┐
- * │ 관계 전환 현황 (USR-1.1 머지 완료)                                 │
+ * │ 관계 전환 현황 (SPC-2.1 머지 완료)                                 │
  * │                                                                  │
- * │ ✅ user    → @ManyToOne UserEntity (USR-1.1 머지 완료)            │
- * │ ⏳ spaceId → Long FK 유지 (SPC-2.1 SpaceEntity 미완성)            │
- * │ ⏳ approvedBy → Long FK 유지 (도메인 분리 원칙 유지)               │
+ * │ ✅ user       → @ManyToOne UserEntity (USR-1.1 머지 완료)         │
+ * │ ✅ space      → @ManyToOne SpaceEntity (SPC-2.1 머지 완료)        │
+ * │ ✅ approvedBy → @ManyToOne UserEntity (nullable, 관리자 참조)      │
  * └──────────────────────────────────────────────────────────────────┘
  */
 @Entity
-@Table(name = "reservation")
+@Table(name = "reservations")
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,9 +45,10 @@ public class ReservationEntity extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
-    // SPC-2.1 미완성 → 도메인 분리 원칙으로 Long FK 유지
-    @Column(name = "space_id", nullable = false)
-    private Long spaceId;
+    // SPC-2.1 머지 완료 → @ManyToOne 전환
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "space_id", nullable = false)
+    private SpaceEntity space;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 15)
@@ -61,22 +63,23 @@ public class ReservationEntity extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
-    // 도메인 분리 원칙으로 Long FK 유지 (승인자 ID만 저장)
-    @Column(name = "approved_by")
-    private Long approvedBy;
+    // 승인자 (관리자) 참조 — nullable (PENDING 상태에서는 null)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "approved_by")
+    private UserEntity approvedBy;
 
     @Builder
-    public ReservationEntity(UserEntity user, Long spaceId, LocalDate reservationDate,
+    public ReservationEntity(UserEntity user, SpaceEntity space, LocalDate reservationDate,
                              LocalTime startTime, LocalTime endTime) {
         this.user = user;
-        this.spaceId = spaceId;
+        this.space = space;
         this.reservationDate = reservationDate;
         this.startTime = startTime;
         this.endTime = endTime;
         this.status = ReservationStatus.PENDING;
     }
 
-    /** 예약자 ID 편의 getter (FK 직접 노출 없이 ID만 반환) */
+    /** 예약자 ID 편의 getter */
     public Long getUserId() {
         return this.user != null ? this.user.getUserId() : null;
     }
@@ -84,6 +87,16 @@ public class ReservationEntity extends BaseEntity {
     /** 예약자 이름 편의 getter */
     public String getUserName() {
         return this.user != null ? this.user.getName() : null;
+    }
+
+    /** 시설 ID 편의 getter */
+    public Long getSpaceId() {
+        return this.space != null ? this.space.getSpaceId() : null;
+    }
+
+    /** 승인자 ID 편의 getter */
+    public Long getApprovedById() {
+        return this.approvedBy != null ? this.approvedBy.getUserId() : null;
     }
 
     // ── 상태 전환 비즈니스 메서드 ──
@@ -95,10 +108,10 @@ public class ReservationEntity extends BaseEntity {
      * @param adminId 승인한 관리자 ID
      * @throws IllegalStateException PENDING 상태가 아닌 경우
      */
-    public void approve(Long adminId) {
+    public void approve(UserEntity admin) {
         validateStatus(ReservationStatus.PENDING, "승인");
         this.status = ReservationStatus.APPROVED;
-        this.approvedBy = adminId;
+        this.approvedBy = admin;
     }
 
     /**

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
@@ -1,5 +1,6 @@
 package com.coliving.reservation.adapter.out.jpa;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
 import com.coliving.global.entity.BaseEntity;
 import com.coliving.reservation.model.ReservationStatus;
 import jakarta.persistence.*;
@@ -19,24 +20,11 @@ import java.time.LocalTime;
  * schema.sql의 reservation 테이블에 매핑된다.
  *
  * ┌──────────────────────────────────────────────────────────────────┐
- * │ [TODO - SPC-2.1/USR-1.1 머지 시 수정 필요]                       │
+ * │ 관계 전환 현황 (USR-1.1 머지 완료)                                 │
  * │                                                                  │
- * │ 현재 user_id, space_id, approved_by 필드가 Long 타입으로          │
- * │ 선언되어 있습니다. User/Space 엔티티가 완성되면 아래와 같이          │
- * │ @ManyToOne 관계로 변경해야 합니다:                                 │
- * │                                                                  │
- * │ [변경 전]                                                         │
- * │   @Column(name = "user_id", nullable = false)                    │
- * │   private Long userId;                                           │
- * │                                                                  │
- * │ [변경 후]                                                         │
- * │   @ManyToOne(fetch = FetchType.LAZY)                             │
- * │   @JoinColumn(name = "user_id", nullable = false)                │
- * │   private User user;                                             │
- * │                                                                  │
- * │ space_id → SpaceEntity, approved_by → User 도 동일하게 변경       │
- * │                                                                  │
- * │ 관련 담당: User(이우석 USR-1.1), Space(정찬우 SPC-2.1)             │
+ * │ ✅ user    → @ManyToOne UserEntity (USR-1.1 머지 완료)            │
+ * │ ⏳ spaceId → Long FK 유지 (SPC-2.1 SpaceEntity 미완성)            │
+ * │ ⏳ approvedBy → Long FK 유지 (도메인 분리 원칙 유지)               │
  * └──────────────────────────────────────────────────────────────────┘
  */
 @Entity
@@ -51,13 +39,12 @@ public class ReservationEntity extends BaseEntity {
     @Column(name = "reservation_id")
     private Long id;
 
-    // TODO: User 엔티티 완성 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    // USR-1.1 머지 완료 → @ManyToOne 전환
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private UserEntity user;
 
-    // TODO: SpaceEntity 통합 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
-    // 현재 SpaceEntity는 com.coliving.user.room.adapter.out.jpa 패키지에 존재하나,
-    // 모듈 간 직접 참조를 피하기 위해 Long FK를 유지합니다.
+    // SPC-2.1 미완성 → 도메인 분리 원칙으로 Long FK 유지
     @Column(name = "space_id", nullable = false)
     private Long spaceId;
 
@@ -74,19 +61,29 @@ public class ReservationEntity extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
-    // TODO: User 엔티티 완성 후 @ManyToOne(fetch = LAZY) + @JoinColumn 으로 변경
+    // 도메인 분리 원칙으로 Long FK 유지 (승인자 ID만 저장)
     @Column(name = "approved_by")
     private Long approvedBy;
 
     @Builder
-    public ReservationEntity(Long userId, Long spaceId, LocalDate reservationDate,
+    public ReservationEntity(UserEntity user, Long spaceId, LocalDate reservationDate,
                              LocalTime startTime, LocalTime endTime) {
-        this.userId = userId;
+        this.user = user;
         this.spaceId = spaceId;
         this.reservationDate = reservationDate;
         this.startTime = startTime;
         this.endTime = endTime;
         this.status = ReservationStatus.PENDING;
+    }
+
+    /** 예약자 ID 편의 getter (FK 직접 노출 없이 ID만 반환) */
+    public Long getUserId() {
+        return this.user != null ? this.user.getUserId() : null;
+    }
+
+    /** 예약자 이름 편의 getter */
+    public String getUserName() {
+        return this.user != null ? this.user.getName() : null;
     }
 
     // ── 상태 전환 비즈니스 메서드 ──

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
@@ -16,13 +16,10 @@ import java.util.List;
  * 주요 쿼리 메서드는 비즈니스 규칙(ERD)에 기반한다.
  *
  * ┌──────────────────────────────────────────────────────────────────┐
- * │ [TODO - SPC-2.1/USR-1.1 머지 시 수정 필요]                       │
+ * │ 관계 전환 현황 (USR-1.1 머지 완료)                                 │
  * │                                                                  │
- * │ User/Space 엔티티 완성 후 @ManyToOne 전환 시,                     │
- * │ 쿼리 메서드의 파라미터 타입과 반환 타입을 검토하세요.                  │
- * │ 예: findByUserId → findByUser(User user) 등                      │
- * │                                                                  │
- * │ 관련 담당: User(이우석 USR-1.1), Space(정찬우 SPC-2.1)             │
+ * │ ✅ user    → @ManyToOne UserEntity — JPQL: r.user.userId         │
+ * │ ⏳ spaceId → Long FK 유지 (SPC-2.1 SpaceEntity 미완성)            │
  * └──────────────────────────────────────────────────────────────────┘
  */
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
@@ -33,10 +30,10 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     // ── 사용자별 조회 ──
 
     /** 특정 사용자의 예약 목록 조회 (상태 필터링) */
-    List<ReservationEntity> findByUserIdAndStatusIn(Long userId, List<ReservationStatus> statuses);
+    List<ReservationEntity> findByUser_UserIdAndStatusIn(Long userId, List<ReservationStatus> statuses);
 
     /** 특정 사용자의 전체 예약 목록 조회 (최신순 정렬) */
-    List<ReservationEntity> findByUserIdOrderByReservationDateDescStartTimeDesc(Long userId);
+    List<ReservationEntity> findByUser_UserIdOrderByReservationDateDescStartTimeDesc(Long userId);
 
     // ── 시설별 조회 ──
 
@@ -86,7 +83,7 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
      * @return 활성 예약 존재 여부
      */
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +
-           "WHERE r.userId = :userId " +
+           "WHERE r.user.userId = :userId " +
            "AND r.spaceId = :spaceId " +
            "AND r.reservationDate = :date " +
            "AND r.status = 'APPROVED' " +

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
@@ -15,11 +15,10 @@ import java.util.List;
  * reservation 테이블에 대한 데이터 접근을 담당한다.
  * 주요 쿼리 메서드는 비즈니스 규칙(ERD)에 기반한다.
  *
- * ┌──────────────────────────────────────────────────────────────────┐
- * │ 관계 전환 현황 (USR-1.1 머지 완료)                                 │
+ * [관계 전환 현황 (SPC-2.1 + USR-1.1 머지 완료)]
  * │                                                                  │
- * │ ✅ user    → @ManyToOne UserEntity — JPQL: r.user.userId         │
- * │ ⏳ spaceId → Long FK 유지 (SPC-2.1 SpaceEntity 미완성)            │
+ * │ ✅ user  → @ManyToOne UserEntity — JPQL: r.user.userId           │
+ * │ ✅ space → @ManyToOne SpaceEntity — JPQL: r.space.spaceId        │
  * └──────────────────────────────────────────────────────────────────┘
  */
 public interface ReservationJpaRepository extends JpaRepository<ReservationEntity, Long> {
@@ -38,11 +37,11 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     // ── 시설별 조회 ──
 
     /** 특정 시설의 특정 날짜 예약 목록 조회 (승인된 예약만) */
-    List<ReservationEntity> findBySpaceIdAndReservationDateAndStatus(
+    List<ReservationEntity> findBySpace_SpaceIdAndReservationDateAndStatus(
             Long spaceId, LocalDate reservationDate, ReservationStatus status);
 
     /** 특정 시설의 특정 날짜 전체 예약 목록 조회 */
-    List<ReservationEntity> findBySpaceIdAndReservationDate(Long spaceId, LocalDate reservationDate);
+    List<ReservationEntity> findBySpace_SpaceIdAndReservationDate(Long spaceId, LocalDate reservationDate);
 
     // ── 비즈니스 규칙 검증 쿼리 ──
 
@@ -59,9 +58,9 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
      * @return 중복 예약 존재 여부
      */
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +
-           "WHERE r.spaceId = :spaceId " +
+           "WHERE r.space.spaceId = :spaceId " +
            "AND r.reservationDate = :date " +
-           "AND r.status = 'APPROVED' " +
+           "AND r.status = com.coliving.reservation.model.ReservationStatus.APPROVED " +
            "AND r.startTime < :endTime " +
            "AND r.endTime > :startTime")
     boolean existsOverlappingReservation(
@@ -84,9 +83,9 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
      */
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +
            "WHERE r.user.userId = :userId " +
-           "AND r.spaceId = :spaceId " +
+           "AND r.space.spaceId = :spaceId " +
            "AND r.reservationDate = :date " +
-           "AND r.status = 'APPROVED' " +
+           "AND r.status = com.coliving.reservation.model.ReservationStatus.APPROVED " +
            "AND r.startTime <= :currentTime " +
            "AND r.endTime > :currentTime")
     boolean hasActiveReservation(
@@ -107,7 +106,7 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
      * @return 날짜/시간순 정렬된 예약 목록
      */
     @Query("SELECT r FROM ReservationEntity r " +
-           "WHERE r.spaceId = :spaceId " +
+           "WHERE r.space.spaceId = :spaceId " +
            "AND r.reservationDate BETWEEN :startDate AND :endDate " +
            "ORDER BY r.reservationDate, r.startTime")
     List<ReservationEntity> findBySpaceIdAndDateRange(

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/persistence/FacilityQueryAdapter.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/persistence/FacilityQueryAdapter.java
@@ -68,9 +68,9 @@ public class FacilityQueryAdapter implements FacilityQueryPort {
                        csd.max_capacity, csd.operating_hours, csd.usage_fee,
                        si.space_image_id, si.image_url, si.image_type,
                        si.sort_order, si.is_thumbnail
-                FROM space s
-                INNER JOIN common_space_detail csd ON s.space_id = csd.space_id
-                LEFT JOIN space_image si ON s.space_id = si.space_id
+                FROM spaces s
+                INNER JOIN common_space_details csd ON s.space_id = csd.space_id
+                LEFT JOIN space_images si ON s.space_id = si.space_id
                                          AND si.deleted_at IS NULL
                 WHERE s.type = 'COMMON'
                 AND csd.is_reservable = true
@@ -103,9 +103,9 @@ public class FacilityQueryAdapter implements FacilityQueryPort {
                        csd.is_reservable,
                        si.space_image_id, si.image_url, si.image_type,
                        si.sort_order, si.is_thumbnail
-                FROM space s
-                INNER JOIN common_space_detail csd ON s.space_id = csd.space_id
-                LEFT JOIN space_image si ON s.space_id = si.space_id
+                FROM spaces s
+                INNER JOIN common_space_details csd ON s.space_id = csd.space_id
+                LEFT JOIN space_images si ON s.space_id = si.space_id
                                          AND si.deleted_at IS NULL
                 WHERE s.space_id = :spaceId
                 AND s.type = 'COMMON'
@@ -126,7 +126,7 @@ public class FacilityQueryAdapter implements FacilityQueryPort {
         // 2. 오늘 예약 건수 조회
         String countSql = """
                 SELECT COUNT(*)
-                FROM reservation r
+                FROM reservations r
                 WHERE r.space_id = :spaceId
                 AND r.reservation_date = :today
                 AND r.status IN ('PENDING', 'APPROVED')

--- a/backend/src/main/java/com/coliving/reservation/application/port/in/FacilityQueryUseCase.java
+++ b/backend/src/main/java/com/coliving/reservation/application/port/in/FacilityQueryUseCase.java
@@ -1,0 +1,33 @@
+package com.coliving.reservation.application.port.in;
+
+import com.coliving.reservation.adapter.out.dto.FacilityDetailResponse;
+import com.coliving.reservation.adapter.out.dto.ReservableFacilityResponse;
+
+import java.util.List;
+
+/**
+ * 예약 가능 시설 조회 유스케이스 (Inbound Port)
+ *
+ * RES-RSV-01: 입주자가 예약 가능한 공용시설 목록 및 상세를 조회하는 UseCase.
+ * Controller는 반드시 이 인터페이스를 통해서만 Service에 접근해야 한다.
+ */
+public interface FacilityQueryUseCase {
+
+    /**
+     * 예약 가능한 공용시설 전체 목록을 조회한다.
+     *
+     * 조건: COMMON 타입 + is_reservable = true + 삭제되지 않음 + 점검 중 아님
+     *
+     * @return 예약 가능한 공용시설 목록 (이름순 정렬)
+     */
+    List<ReservableFacilityResponse> getReservableFacilities();
+
+    /**
+     * 특정 공용시설의 상세 정보를 조회한다.
+     *
+     * @param spaceId 시설 ID
+     * @return 시설 상세 정보
+     * @throws com.coliving.global.error.BusinessException 시설 미존재 시 NOT_FOUND
+     */
+    FacilityDetailResponse getFacilityDetail(Long spaceId);
+}

--- a/backend/src/main/java/com/coliving/reservation/application/service/FacilityQueryService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/FacilityQueryService.java
@@ -2,6 +2,7 @@ package com.coliving.reservation.application.service;
 
 import com.coliving.reservation.adapter.out.dto.FacilityDetailResponse;
 import com.coliving.reservation.adapter.out.dto.ReservableFacilityResponse;
+import com.coliving.reservation.application.port.in.FacilityQueryUseCase;
 import com.coliving.reservation.application.port.out.FacilityQueryPort;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
@@ -24,7 +25,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true) // 조회 전용 서비스이므로 readOnly 최적화
-public class FacilityQueryService {
+public class FacilityQueryService implements FacilityQueryUseCase {
 
     private final FacilityQueryPort facilityQueryPort;
 
@@ -37,6 +38,7 @@ public class FacilityQueryService {
      *
      * @return 예약 가능한 공용시설 목록
      */
+    @Override
     public List<ReservableFacilityResponse> getReservableFacilities() {
         log.info("[RES-RSV-01] 예약 가능한 공용시설 목록 조회 요청");
 
@@ -56,6 +58,7 @@ public class FacilityQueryService {
      * @return 시설 상세 정보
      * @throws BusinessException 시설을 찾을 수 없는 경우 (NOT_FOUND)
      */
+    @Override
     public FacilityDetailResponse getFacilityDetail(Long spaceId) {
         log.info("[RES-RSV-01] 공용시설 상세 조회 요청 - spaceId: {}", spaceId);
 

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -9,6 +9,8 @@ import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.exception.ReservationOverlapException;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
+import com.coliving.user.room.adapter.out.jpa.SpaceJpaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,10 +24,12 @@ import java.util.Objects;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@SuppressWarnings("null")
 public class ReservationCommandService implements ReservationCommandUseCase {
 
     private final ReservationJpaRepository reservationRepository;
     private final UserJpaRepository userRepository;
+    private final SpaceJpaRepository spaceRepository;
 
     @Override
     @Transactional
@@ -41,7 +45,11 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         UserEntity userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
-        // 3. 동시성 체크: 해당 시간에 승인(APPROVED)된 중복 예약이 있는지 확인
+        // 3. 시설 조회 (SPC-2.1 @ManyToOne 전환 완료)
+        SpaceEntity spaceEntity = spaceRepository.findById(request.getSpaceId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "시설을 찾을 수 없습니다."));
+
+        // 4. 동시성 체크: 해당 시간에 승인(APPROVED)된 중복 예약이 있는지 확인
         // TODO: (고도화) 다중 인스턴스 환경에서 완벽한 동시성 제어를 위해 Redisson 기반 분산 락, 또는 DB 유니크 제약/비관적 락 도입 고려
         boolean hasOverlap = reservationRepository.existsOverlappingReservation(
                 request.getSpaceId(),
@@ -56,10 +64,10 @@ public class ReservationCommandService implements ReservationCommandUseCase {
             throw new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다.");
         }
 
-        // 4. 예약 엔티티 생성 (초기 상태: PENDING)
+        // 5. 예약 엔티티 생성 (초기 상태: PENDING)
         ReservationEntity newReservation = ReservationEntity.builder()
                 .user(userEntity)
-                .spaceId(request.getSpaceId())
+                .space(spaceEntity)
                 .reservationDate(request.getReservationDate())
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
@@ -95,7 +103,12 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         ReservationEntity reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "예약을 찾을 수 없습니다."));
 
-        reservation.approve(adminId);
+        // adminId로 관리자 UserEntity 조회 후 approve(UserEntity) 호출
+        UserEntity adminEntity = userRepository.findById(adminId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "관리자를 찾을 수 없습니다."));
+
+        reservation.approve(adminEntity);
+        reservationRepository.save(reservation);
         log.info("예약 승인 성공 - reservationId: {}, adminId: {}", reservationId, adminId);
     }
 

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -1,16 +1,20 @@
 package com.coliving.reservation.application.service;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
+import com.coliving.common.auth.adapter.out.jpa.UserJpaRepository;
+import com.coliving.global.error.BusinessException;
+import com.coliving.global.error.ErrorCode;
 import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.exception.ReservationOverlapException;
-import com.coliving.global.error.BusinessException;
-import com.coliving.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 /**
  * 예약 생성 서비스
@@ -21,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationCommandService implements ReservationCommandUseCase {
 
     private final ReservationJpaRepository reservationRepository;
+    private final UserJpaRepository userRepository;
 
     @Override
     @Transactional
@@ -30,7 +35,13 @@ public class ReservationCommandService implements ReservationCommandUseCase {
             throw new IllegalArgumentException("종료 시간은 시작 시간보다 이후여야 합니다.");
         }
 
-        // 2. 동시성 체크: 해당 시간에 승인(APPROVED)된 중복 예약이 있는지 확인
+        // 2. 요청 사용자 조회 (USR-1.1 ManyToOne 전환 완료)
+        Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
+        @SuppressWarnings("null")
+        UserEntity userEntity = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        // 3. 동시성 체크: 해당 시간에 승인(APPROVED)된 중복 예약이 있는지 확인
         // TODO: (고도화) 다중 인스턴스 환경에서 완벽한 동시성 제어를 위해 Redisson 기반 분산 락, 또는 DB 유니크 제약/비관적 락 도입 고려
         boolean hasOverlap = reservationRepository.existsOverlappingReservation(
                 request.getSpaceId(),
@@ -40,26 +51,27 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         );
 
         if (hasOverlap) {
-            log.warn("예약 충돌 발생 - spaceId: {}, date: {}, time: {}~{}", 
+            log.warn("예약 충돌 발생 - spaceId: {}, date: {}, time: {}~{}",
                     request.getSpaceId(), request.getReservationDate(), request.getStartTime(), request.getEndTime());
             throw new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다.");
         }
 
-        // 3. 예약 엔티티 생성 (초기 상태: PENDING)
+        // 4. 예약 엔티티 생성 (초기 상태: PENDING)
         ReservationEntity newReservation = ReservationEntity.builder()
-                .userId(userId)
+                .user(userEntity)
                 .spaceId(request.getSpaceId())
                 .reservationDate(request.getReservationDate())
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
                 .build();
 
-        // 4. 저장 및 ID 반환
+        // 5. 저장 및 ID 반환
+        @SuppressWarnings("null")
         ReservationEntity savedReservation = reservationRepository.save(newReservation);
-        
-        log.info("새로운 예약 성공 - reservationId: {}, spaceId: {}, userId: {}", 
+
+        log.info("새로운 예약 성공 - reservationId: {}, spaceId: {}, userId: {}",
                 savedReservation.getId(), savedReservation.getSpaceId(), savedReservation.getUserId());
-        
+
         return savedReservation.getId();
     }
 

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationQueryService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationQueryService.java
@@ -25,8 +25,8 @@ public class ReservationQueryService implements ReservationQueryUseCase {
     @Override
     public List<UserReservationResponse> getUserReservations(Long userId) {
         List<ReservationEntity> reservations = reservationRepository
-                .findByUserIdOrderByReservationDateDescStartTimeDesc(userId);
-        
+                .findByUser_UserIdOrderByReservationDateDescStartTimeDesc(userId);
+
         return reservations.stream()
                 .map(UserReservationResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/backend/src/test/java/com/coliving/reservation/adapter/out/jpa/ReservationEntityTest.java
+++ b/backend/src/test/java/com/coliving/reservation/adapter/out/jpa/ReservationEntityTest.java
@@ -1,6 +1,13 @@
 package com.coliving.reservation.adapter.out.jpa;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
+import com.coliving.common.auth.model.Gender;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
 import com.coliving.reservation.model.ReservationStatus;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
+import com.coliving.user.room.model.SpaceStatus;
+import com.coliving.user.room.model.SpaceType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,21 +23,64 @@ import static org.junit.jupiter.api.Assertions.*;
  * DB 없이 순수 Java 로직만 검증한다.
  * 상태 전환 비즈니스 메서드(approve, cancel, complete)와
  * Builder 생성을 테스트한다.
+ *
+ * [SPC-2.1 + USR-1.1 머지 완료]
+ * - user, space, approvedBy 모두 @ManyToOne 전환
+ * - 테스트용 UserEntity/SpaceEntity는 Reflection 없이 Builder로 생성
  */
 class ReservationEntityTest {
 
     // ── 테스트 데이터 상수 ──
-    private static final Long USER_ID = 1L;
-    private static final Long SPACE_ID = 10L;
-    private static final Long ADMIN_ID = 99L;
     private static final LocalDate DATE = LocalDate.of(2026, 4, 10);
     private static final LocalTime START = LocalTime.of(10, 0);
     private static final LocalTime END = LocalTime.of(12, 0);
 
+    /** 테스트용 UserEntity 생성 헬퍼 */
+    private UserEntity createUser() {
+        return UserEntity.builder()
+                .loginId("testuser")
+                .passwordHash("hash")
+                .name("테스트유저")
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-0000-0000")
+                .email("test@coliving.com")
+                .role(UserRole.RESIDENT)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    /** 테스트용 관리자 UserEntity 생성 헬퍼 */
+    private UserEntity createAdmin() {
+        return UserEntity.builder()
+                .loginId("admin")
+                .passwordHash("hash")
+                .name("관리자")
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-9999-9999")
+                .email("admin@coliving.com")
+                .role(UserRole.ADMIN)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    /** 테스트용 SpaceEntity 생성 헬퍼 */
+    private SpaceEntity createSpace() {
+        return SpaceEntity.builder()
+                .name("공용 라운지")
+                .type(SpaceType.COMMON)
+                .status(SpaceStatus.AVAILABLE)
+                .floor(1)
+                .build();
+    }
+
     private ReservationEntity createReservation() {
         return ReservationEntity.builder()
-                .userId(USER_ID)
-                .spaceId(SPACE_ID)
+                .user(createUser())
+                .space(createSpace())
                 .reservationDate(DATE)
                 .startTime(START)
                 .endTime(END)
@@ -42,18 +92,18 @@ class ReservationEntityTest {
     class BuilderTest {
 
         @Test
-        @DisplayName("예약 생성 시 PENDING 상태, userId/spaceId 매핑, approvedBy null")
+        @DisplayName("예약 생성 시 PENDING 상태, user/space 매핑, approvedBy null")
         void shouldCreateWithPendingStatus() {
             ReservationEntity reservation = createReservation();
 
             assertAll(
                     () -> assertEquals(ReservationStatus.PENDING, reservation.getStatus()),
-                    () -> assertEquals(USER_ID, reservation.getUserId()),
-                    () -> assertEquals(SPACE_ID, reservation.getSpaceId()),
+                    () -> assertNotNull(reservation.getUser()),
+                    () -> assertNotNull(reservation.getSpace()),
                     () -> assertEquals(DATE, reservation.getReservationDate()),
                     () -> assertEquals(START, reservation.getStartTime()),
                     () -> assertEquals(END, reservation.getEndTime()),
-                    () -> assertNull(reservation.getApprovedBy())
+                    () -> assertNull(reservation.getApprovedById())
             );
         }
     }
@@ -66,11 +116,12 @@ class ReservationEntityTest {
         @DisplayName("PENDING → APPROVED 전환 성공, approvedBy 설정")
         void shouldApproveFromPending() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
 
             assertAll(
                     () -> assertEquals(ReservationStatus.APPROVED, reservation.getStatus()),
-                    () -> assertEquals(ADMIN_ID, reservation.getApprovedBy())
+                    () -> assertEquals(admin, reservation.getApprovedBy())
             );
         }
 
@@ -78,9 +129,10 @@ class ReservationEntityTest {
         @DisplayName("APPROVED 상태에서 승인 시 예외 발생")
         void shouldThrowWhenApproveFromApproved() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
 
-            assertThrows(IllegalStateException.class, () -> reservation.approve(ADMIN_ID));
+            assertThrows(IllegalStateException.class, () -> reservation.approve(admin));
         }
 
         @Test
@@ -89,17 +141,19 @@ class ReservationEntityTest {
             ReservationEntity reservation = createReservation();
             reservation.cancel();
 
-            assertThrows(IllegalStateException.class, () -> reservation.approve(ADMIN_ID));
+            UserEntity admin = createAdmin();
+            assertThrows(IllegalStateException.class, () -> reservation.approve(admin));
         }
 
         @Test
         @DisplayName("COMPLETED 상태에서 승인 시 예외 발생")
         void shouldThrowWhenApproveFromCompleted() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
             reservation.complete();
 
-            assertThrows(IllegalStateException.class, () -> reservation.approve(ADMIN_ID));
+            assertThrows(IllegalStateException.class, () -> reservation.approve(admin));
         }
     }
 
@@ -120,7 +174,8 @@ class ReservationEntityTest {
         @DisplayName("APPROVED → CANCELLED 전환 성공")
         void shouldCancelFromApproved() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
             reservation.cancel();
 
             assertEquals(ReservationStatus.CANCELLED, reservation.getStatus());
@@ -130,7 +185,8 @@ class ReservationEntityTest {
         @DisplayName("COMPLETED 상태에서 취소 시 예외 발생")
         void shouldThrowWhenCancelFromCompleted() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
             reservation.complete();
 
             assertThrows(IllegalStateException.class, reservation::cancel);
@@ -154,7 +210,8 @@ class ReservationEntityTest {
         @DisplayName("APPROVED → COMPLETED 전환 성공")
         void shouldCompleteFromApproved() {
             ReservationEntity reservation = createReservation();
-            reservation.approve(ADMIN_ID);
+            UserEntity admin = createAdmin();
+            reservation.approve(admin);
             reservation.complete();
 
             assertEquals(ReservationStatus.COMPLETED, reservation.getStatus());

--- a/backend/src/test/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepositoryTest.java
+++ b/backend/src/test/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepositoryTest.java
@@ -1,7 +1,16 @@
 package com.coliving.reservation.adapter.out.jpa;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
+import com.coliving.common.auth.adapter.out.jpa.UserJpaRepository;
+import com.coliving.common.auth.model.Gender;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
 import com.coliving.reservation.config.TestJpaConfig;
 import com.coliving.reservation.model.ReservationStatus;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
+import com.coliving.user.room.adapter.out.jpa.SpaceJpaRepository;
+import com.coliving.user.room.model.SpaceStatus;
+import com.coliving.user.room.model.SpaceType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,34 +31,92 @@ import static org.junit.jupiter.api.Assertions.*;
  *
  * H2 인메모리 DB + @DataJpaTest로 JPA 쿼리를 검증한다.
  * TestJpaConfig를 Import하여 OffsetDateTime Auditing을 지원한다.
+ *
+ * [SPC-2.1 + USR-1.1 머지 완료]
+ * - UserEntity, SpaceEntity를 실제 JPA 저장 후 연관관계 매핑 테스트
  */
 @DataJpaTest
 @Import(TestJpaConfig.class)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@SuppressWarnings("null")
 class ReservationJpaRepositoryTest {
 
     @Autowired
     private ReservationJpaRepository repository;
 
-    // ── 테스트 상수 ──
-    private static final Long USER_A = 1L;
-    private static final Long USER_B = 2L;
-    private static final Long SPACE_1 = 10L;
-    private static final Long SPACE_2 = 20L;
-    private static final Long ADMIN_ID = 99L;
+    @Autowired
+    private UserJpaRepository userRepository;
+
+    @Autowired
+    private SpaceJpaRepository spaceRepository;
+
+    // ── 테스트 픽스처 ──
+    private UserEntity userA;
+    private UserEntity userB;
+    private UserEntity admin;
+    private SpaceEntity space1;
+
     private static final LocalDate TODAY = LocalDate.of(2026, 4, 10);
     private static final LocalDate TOMORROW = LocalDate.of(2026, 4, 11);
 
     @BeforeEach
     void setUp() {
         repository.deleteAllInBatch();
+        spaceRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+
+        userA = userRepository.save(UserEntity.builder()
+                .loginId("userA")
+                .passwordHash("hash")
+                .name("유저A")
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-0000-0001")
+                .email("a@coliving.com")
+                .role(UserRole.RESIDENT)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        userB = userRepository.save(UserEntity.builder()
+                .loginId("userB")
+                .passwordHash("hash")
+                .name("유저B")
+                .birthDate("000101")
+                .gender(Gender.FEMALE)
+                .nationality("Korean")
+                .phone("010-0000-0002")
+                .email("b@coliving.com")
+                .role(UserRole.RESIDENT)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        admin = userRepository.save(UserEntity.builder()
+                .loginId("admin")
+                .passwordHash("hash")
+                .name("관리자")
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-9999-9999")
+                .email("admin@coliving.com")
+                .role(UserRole.ADMIN)
+                .status(UserStatus.ACTIVE)
+                .build());
+
+        space1 = spaceRepository.save(SpaceEntity.builder()
+                .name("회의실 A")
+                .type(SpaceType.COMMON)
+                .status(SpaceStatus.AVAILABLE)
+                .floor(1)
+                .build());
     }
 
-    private ReservationEntity createAndSave(Long userId, Long spaceId, LocalDate date,
+    private ReservationEntity createAndSave(UserEntity user, SpaceEntity space, LocalDate date,
                                             LocalTime start, LocalTime end) {
         return repository.save(ReservationEntity.builder()
-                .userId(userId)
-                .spaceId(spaceId)
+                .user(user)
+                .space(space)
                 .reservationDate(date)
                 .startTime(start)
                 .endTime(end)
@@ -63,7 +130,7 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("저장 시 ID 자동 생성 및 초기 상태 PENDING")
         void shouldSaveAndGenerateId() {
-            ReservationEntity saved = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity saved = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
 
             assertAll(
@@ -81,22 +148,22 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("상태 필터링 조회: PENDING/APPROVED만 반환")
         void shouldFilterByStatus() {
-            // USER_A의 예약 3건: PENDING, APPROVED, CANCELLED
-            ReservationEntity pending = createAndSave(USER_A, SPACE_1, TODAY,
+            // userA의 예약 3건: PENDING, APPROVED, CANCELLED
+            createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(11, 0));
 
-            ReservationEntity approved = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity approved = createAndSave(userA, space1, TODAY,
                     LocalTime.of(13, 0), LocalTime.of(14, 0));
-            approved.approve(ADMIN_ID);
+            approved.approve(admin);
             repository.save(approved);
 
-            ReservationEntity cancelled = createAndSave(USER_A, SPACE_1, TOMORROW,
+            ReservationEntity cancelled = createAndSave(userA, space1, TOMORROW,
                     LocalTime.of(10, 0), LocalTime.of(11, 0));
             cancelled.cancel();
             repository.save(cancelled);
 
-            List<ReservationEntity> result = repository.findByUserIdAndStatusIn(
-                    USER_A, List.of(ReservationStatus.PENDING, ReservationStatus.APPROVED));
+            List<ReservationEntity> result = repository.findByUser_UserIdAndStatusIn(
+                    userA.getUserId(), List.of(ReservationStatus.PENDING, ReservationStatus.APPROVED));
 
             assertEquals(2, result.size());
         }
@@ -104,13 +171,13 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("최신순 정렬 조회")
         void shouldOrderByDateDesc() {
-            createAndSave(USER_A, SPACE_1, TODAY,
+            createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(11, 0));
-            createAndSave(USER_A, SPACE_1, TOMORROW,
+            createAndSave(userA, space1, TOMORROW,
                     LocalTime.of(14, 0), LocalTime.of(15, 0));
 
             List<ReservationEntity> result =
-                    repository.findByUserIdOrderByReservationDateDescStartTimeDesc(USER_A);
+                    repository.findByUser_UserIdOrderByReservationDateDescStartTimeDesc(userA.getUserId());
 
             assertEquals(2, result.size());
             assertTrue(result.get(0).getReservationDate().isAfter(result.get(1).getReservationDate())
@@ -125,16 +192,16 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("특정 시설의 APPROVED 예약만 조회")
         void shouldFilterApprovedBySpace() {
-            ReservationEntity approved = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity approved = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(11, 0));
-            approved.approve(ADMIN_ID);
+            approved.approve(admin);
             repository.save(approved);
 
-            createAndSave(USER_B, SPACE_1, TODAY,
+            createAndSave(userB, space1, TODAY,
                     LocalTime.of(13, 0), LocalTime.of(14, 0));  // PENDING
 
-            List<ReservationEntity> result = repository.findBySpaceIdAndReservationDateAndStatus(
-                    SPACE_1, TODAY, ReservationStatus.APPROVED);
+            List<ReservationEntity> result = repository.findBySpace_SpaceIdAndReservationDateAndStatus(
+                    space1.getSpaceId(), TODAY, ReservationStatus.APPROVED);
 
             assertEquals(1, result.size());
             assertEquals(ReservationStatus.APPROVED, result.get(0).getStatus());
@@ -149,14 +216,14 @@ class ReservationJpaRepositoryTest {
         @DisplayName("시간 겹침 → 중복으로 판정 (true)")
         void shouldDetectOverlap() {
             // 기존 예약: 10:00 ~ 12:00 (APPROVED)
-            ReservationEntity existing = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity existing = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
-            existing.approve(ADMIN_ID);
+            existing.approve(admin);
             repository.save(existing);
 
             // 새 예약: 11:00 ~ 13:00 (겹침)
             boolean overlap = repository.existsOverlappingReservation(
-                    SPACE_1, TODAY, LocalTime.of(11, 0), LocalTime.of(13, 0));
+                    space1.getSpaceId(), TODAY, LocalTime.of(11, 0), LocalTime.of(13, 0));
 
             assertTrue(overlap);
         }
@@ -165,14 +232,14 @@ class ReservationJpaRepositoryTest {
         @DisplayName("경계값 연속 → 중복 아님 (false)")
         void shouldNotDetectOverlapAtBoundary() {
             // 기존 예약: 10:00 ~ 12:00 (APPROVED)
-            ReservationEntity existing = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity existing = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
-            existing.approve(ADMIN_ID);
+            existing.approve(admin);
             repository.save(existing);
 
             // 새 예약: 12:00 ~ 14:00 (경계값, 겹치지 않음)
             boolean overlap = repository.existsOverlappingReservation(
-                    SPACE_1, TODAY, LocalTime.of(12, 0), LocalTime.of(14, 0));
+                    space1.getSpaceId(), TODAY, LocalTime.of(12, 0), LocalTime.of(14, 0));
 
             assertFalse(overlap);
         }
@@ -181,11 +248,11 @@ class ReservationJpaRepositoryTest {
         @DisplayName("PENDING 상태 예약은 중복 체크에서 제외 (false)")
         void shouldIgnorePendingReservations() {
             // 기존 예약: 10:00 ~ 12:00 (PENDING)
-            createAndSave(USER_A, SPACE_1, TODAY,
+            createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
 
             boolean overlap = repository.existsOverlappingReservation(
-                    SPACE_1, TODAY, LocalTime.of(11, 0), LocalTime.of(13, 0));
+                    space1.getSpaceId(), TODAY, LocalTime.of(11, 0), LocalTime.of(13, 0));
 
             assertFalse(overlap);
         }
@@ -198,13 +265,13 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("시간 범위 내 → 활성 예약 존재 (true)")
         void shouldDetectActiveReservation() {
-            ReservationEntity reservation = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity reservation = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
-            reservation.approve(ADMIN_ID);
+            reservation.approve(admin);
             repository.save(reservation);
 
             boolean active = repository.hasActiveReservation(
-                    USER_A, SPACE_1, TODAY, LocalTime.of(11, 0));
+                    userA.getUserId(), space1.getSpaceId(), TODAY, LocalTime.of(11, 0));
 
             assertTrue(active);
         }
@@ -212,13 +279,13 @@ class ReservationJpaRepositoryTest {
         @Test
         @DisplayName("시간 범위 외 → 활성 예약 없음 (false)")
         void shouldNotDetectActiveReservationOutside() {
-            ReservationEntity reservation = createAndSave(USER_A, SPACE_1, TODAY,
+            ReservationEntity reservation = createAndSave(userA, space1, TODAY,
                     LocalTime.of(10, 0), LocalTime.of(12, 0));
-            reservation.approve(ADMIN_ID);
+            reservation.approve(admin);
             repository.save(reservation);
 
             boolean active = repository.hasActiveReservation(
-                    USER_A, SPACE_1, TODAY, LocalTime.of(13, 0));
+                    userA.getUserId(), space1.getSpaceId(), TODAY, LocalTime.of(13, 0));
 
             assertFalse(active);
         }
@@ -235,13 +302,13 @@ class ReservationJpaRepositoryTest {
             LocalDate day2 = LocalDate.of(2026, 4, 9);
             LocalDate day3 = LocalDate.of(2026, 4, 14);
 
-            createAndSave(USER_A, SPACE_1, day1, LocalTime.of(10, 0), LocalTime.of(11, 0));
-            createAndSave(USER_A, SPACE_1, day2, LocalTime.of(14, 0), LocalTime.of(15, 0));
-            createAndSave(USER_A, SPACE_1, day3, LocalTime.of(10, 0), LocalTime.of(11, 0));
+            createAndSave(userA, space1, day1, LocalTime.of(10, 0), LocalTime.of(11, 0));
+            createAndSave(userA, space1, day2, LocalTime.of(14, 0), LocalTime.of(15, 0));
+            createAndSave(userA, space1, day3, LocalTime.of(10, 0), LocalTime.of(11, 0));
 
             // 4/7 ~ 4/13 범위 조회 → 2건 (day1, day2)
             List<ReservationEntity> result = repository.findBySpaceIdAndDateRange(
-                    SPACE_1, LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 13));
+                    space1.getSpaceId(), LocalDate.of(2026, 4, 7), LocalDate.of(2026, 4, 13));
 
             assertEquals(2, result.size());
             // 날짜순 정렬 확인

--- a/backend/src/test/java/com/coliving/reservation/application/service/ReservationCommandServiceTest.java
+++ b/backend/src/test/java/com/coliving/reservation/application/service/ReservationCommandServiceTest.java
@@ -1,24 +1,31 @@
 package com.coliving.reservation.application.service;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
+import com.coliving.common.auth.adapter.out.jpa.UserJpaRepository;
+import com.coliving.common.auth.model.Gender;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
+
 import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.exception.ReservationOverlapException;
+import com.coliving.reservation.model.ReservationStatus;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
+import com.coliving.user.room.adapter.out.jpa.SpaceJpaRepository;
+import com.coliving.user.room.model.SpaceStatus;
+import com.coliving.user.room.model.SpaceType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
-import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Optional;
-
-import com.coliving.reservation.model.ReservationStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+@SuppressWarnings("null")
 @ExtendWith(MockitoExtension.class)
 class ReservationCommandServiceTest {
 
@@ -34,6 +42,60 @@ class ReservationCommandServiceTest {
 
     @Mock
     private ReservationJpaRepository reservationJpaRepository;
+
+    @Mock
+    private UserJpaRepository userRepository;
+
+    @Mock
+    private SpaceJpaRepository spaceRepository;
+
+    /** 테스트용 UserEntity 생성 */
+    private UserEntity mockUser(Long id) {
+        UserEntity user = UserEntity.builder()
+                .loginId("user" + id)
+                .passwordHash("hash")
+                .name("유저" + id)
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-0000-000" + id)
+                .email("user" + id + "@coliving.com")
+                .role(UserRole.RESIDENT)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "userId", id);
+        return user;
+    }
+
+    /** 테스트용 관리자 UserEntity 생성 */
+    private UserEntity mockAdmin(Long id) {
+        UserEntity admin = UserEntity.builder()
+                .loginId("admin" + id)
+                .passwordHash("hash")
+                .name("관리자" + id)
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-9999-" + String.format("%04d", id))
+                .email("admin" + id + "@coliving.com")
+                .role(UserRole.ADMIN)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(admin, "userId", id);
+        return admin;
+    }
+
+    /** 테스트용 SpaceEntity 생성 */
+    private SpaceEntity mockSpace(Long id) {
+        SpaceEntity space = SpaceEntity.builder()
+                .name("회의실 " + id)
+                .type(SpaceType.COMMON)
+                .status(SpaceStatus.AVAILABLE)
+                .floor(1)
+                .build();
+        ReflectionTestUtils.setField(space, "spaceId", id);
+        return space;
+    }
 
     private ReservationCreateRequest createMockRequest(LocalTime startTime, LocalTime endTime) {
         ReservationCreateRequest request = new ReservationCreateRequest();
@@ -49,29 +111,19 @@ class ReservationCommandServiceTest {
     void reserveFacility_Success() {
         // given
         Long userId = 100L;
+        UserEntity user = mockUser(userId);
+        SpaceEntity space = mockSpace(1L);
         ReservationCreateRequest request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(spaceRepository.findById(request.getSpaceId())).willReturn(Optional.of(space));
         given(reservationJpaRepository.existsOverlappingReservation(
                 request.getSpaceId(), request.getReservationDate(), request.getStartTime(), request.getEndTime()
         )).willReturn(false);
 
-        ReservationEntity savedEntity = ReservationEntity.builder()
-                .userId(userId)
-                .spaceId(request.getSpaceId())
-                .reservationDate(request.getReservationDate())
-                .endTime(request.getEndTime())
-                .build();
-                
-        // ReflectionTestUtils 등으로 Id를 주입할 수도 있으나 여기서는 단순화하여 spy 하거나 stubbing
-        // JPA save 이후 ID가 생긴 것을 가정
-        ReservationEntity returnedEntity = ReservationEntity.builder()
-                .userId(userId)
-                .spaceId(request.getSpaceId())
-                .build();
-        // ID 강제 설정 코드 없이 단순히 mock 반환
         given(reservationJpaRepository.save(any(ReservationEntity.class))).willAnswer(invocation -> {
             ReservationEntity entity = invocation.getArgument(0);
-            org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 999L);
+            ReflectionTestUtils.setField(entity, "id", 999L);
             return entity;
         });
 
@@ -88,8 +140,12 @@ class ReservationCommandServiceTest {
     void reserveFacility_OverlapException() {
         // given
         Long userId = 100L;
+        UserEntity user = mockUser(userId);
+        SpaceEntity space = mockSpace(1L);
         ReservationCreateRequest request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
 
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(spaceRepository.findById(request.getSpaceId())).willReturn(Optional.of(space));
         given(reservationJpaRepository.existsOverlappingReservation(
                 request.getSpaceId(), request.getReservationDate(), request.getStartTime(), request.getEndTime()
         )).willReturn(true);
@@ -120,9 +176,11 @@ class ReservationCommandServiceTest {
         // given
         Long reservationId = 100L;
         Long adminId = 999L;
+        UserEntity admin = mockAdmin(adminId);
+
         ReservationEntity pending = ReservationEntity.builder()
-                .userId(1L)
-                .spaceId(10L)
+                .user(mockUser(1L))
+                .space(mockSpace(10L))
                 .reservationDate(LocalDate.of(2026, 5, 1))
                 .startTime(LocalTime.of(14, 0))
                 .endTime(LocalTime.of(16, 0))
@@ -130,13 +188,15 @@ class ReservationCommandServiceTest {
         ReflectionTestUtils.setField(pending, "status", ReservationStatus.PENDING);
 
         given(reservationJpaRepository.findById(reservationId)).willReturn(Optional.of(pending));
+        given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+        given(reservationJpaRepository.save(any(ReservationEntity.class))).willReturn(pending);
 
         // when
         reservationCommandService.approveReservation(adminId, reservationId);
 
         // then
         assertThat(pending.getStatus()).isEqualTo(ReservationStatus.APPROVED);
-        assertThat(pending.getApprovedBy()).isEqualTo(adminId);
+        assertThat(pending.getApprovedById()).isEqualTo(adminId);
     }
 
     @Test
@@ -145,9 +205,10 @@ class ReservationCommandServiceTest {
         // given
         Long reservationId = 100L;
         Long adminId = 999L;
+
         ReservationEntity pending = ReservationEntity.builder()
-                .userId(1L)
-                .spaceId(10L)
+                .user(mockUser(1L))
+                .space(mockSpace(10L))
                 .reservationDate(LocalDate.of(2026, 5, 1))
                 .startTime(LocalTime.of(14, 0))
                 .endTime(LocalTime.of(16, 0))

--- a/backend/src/test/java/com/coliving/reservation/application/service/ReservationQueryServiceTest.java
+++ b/backend/src/test/java/com/coliving/reservation/application/service/ReservationQueryServiceTest.java
@@ -1,15 +1,23 @@
 package com.coliving.reservation.application.service;
 
+import com.coliving.common.auth.adapter.out.jpa.UserEntity;
+import com.coliving.common.auth.model.Gender;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
 import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.model.ReservationStatus;
+import com.coliving.user.room.adapter.out.jpa.SpaceEntity;
+import com.coliving.user.room.model.SpaceStatus;
+import com.coliving.user.room.model.SpaceType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -18,6 +26,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+@SuppressWarnings("null")
 @ExtendWith(MockitoExtension.class)
 class ReservationQueryServiceTest {
 
@@ -27,24 +36,56 @@ class ReservationQueryServiceTest {
     @Mock
     private ReservationJpaRepository reservationRepository;
 
+    /** 테스트용 UserEntity 생성 */
+    private UserEntity mockUser(Long id) {
+        UserEntity user = UserEntity.builder()
+                .loginId("user" + id)
+                .passwordHash("hash")
+                .name("유저" + id)
+                .birthDate("000101")
+                .gender(Gender.MALE)
+                .nationality("Korean")
+                .phone("010-0000-" + String.format("%04d", id))
+                .email("user" + id + "@coliving.com")
+                .role(UserRole.RESIDENT)
+                .status(UserStatus.ACTIVE)
+                .build();
+        ReflectionTestUtils.setField(user, "userId", id);
+        return user;
+    }
+
+    /** 테스트용 SpaceEntity 생성 */
+    private SpaceEntity mockSpace(Long id) {
+        SpaceEntity space = SpaceEntity.builder()
+                .name("회의실 " + id)
+                .type(SpaceType.COMMON)
+                .status(SpaceStatus.AVAILABLE)
+                .floor(1)
+                .build();
+        ReflectionTestUtils.setField(space, "spaceId", id);
+        return space;
+    }
+
     @Test
     @DisplayName("사용자 ID로 예약 역순 목록을 조회한다.")
     void getUserReservations_Success() {
         // given
         Long userId = 1L;
+        UserEntity user = mockUser(userId);
+        SpaceEntity space = mockSpace(10L);
+
         ReservationEntity entity = ReservationEntity.builder()
-                .userId(userId)
-                .spaceId(10L)
+                .user(user)
+                .space(space)
                 .reservationDate(LocalDate.of(2026, 5, 1))
                 .startTime(LocalTime.of(14, 0))
                 .endTime(LocalTime.of(16, 0))
                 .build();
-        
-        // Use reflection to set private field 'id' if needed, or rely on null id for test
-        org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 100L);
-        org.springframework.test.util.ReflectionTestUtils.setField(entity, "status", ReservationStatus.APPROVED);
 
-        given(reservationRepository.findByUserIdOrderByReservationDateDescStartTimeDesc(userId))
+        ReflectionTestUtils.setField(entity, "id", 100L);
+        ReflectionTestUtils.setField(entity, "status", ReservationStatus.APPROVED);
+
+        given(reservationRepository.findByUser_UserIdOrderByReservationDateDescStartTimeDesc(userId))
                 .willReturn(List.of(entity));
 
         // when
@@ -61,16 +102,19 @@ class ReservationQueryServiceTest {
     @DisplayName("관리자가 모든 예약을 역순으로 조회한다.")
     void getAllReservations_Success() {
         // given
+        UserEntity user = mockUser(2L);
+        SpaceEntity space = mockSpace(11L);
+
         ReservationEntity entity = ReservationEntity.builder()
-                .userId(2L)
-                .spaceId(11L)
+                .user(user)
+                .space(space)
                 .reservationDate(LocalDate.of(2026, 5, 2))
                 .startTime(LocalTime.of(10, 0))
                 .endTime(LocalTime.of(12, 0))
                 .build();
 
-        org.springframework.test.util.ReflectionTestUtils.setField(entity, "id", 200L);
-        org.springframework.test.util.ReflectionTestUtils.setField(entity, "status", ReservationStatus.PENDING);
+        ReflectionTestUtils.setField(entity, "id", 200L);
+        ReflectionTestUtils.setField(entity, "status", ReservationStatus.PENDING);
 
         given(reservationRepository.findAllByOrderByReservationDateDescStartTimeDesc())
                 .willReturn(List.of(entity));


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)

타 팀원이 담당한 `UserEntity`(USR-1.1)와 `SpaceEntity`(SPC-2.1) 모듈이 머지됨에 따라,
`Reservation` 모듈의 외래키 필드(`Long userId`, `Long spaceId`, `Long approvedBy`)를
실제 JPA 엔티티와 `@ManyToOne` 연관관계로 전환할 수 있는 환경이 갖춰졌습니다.

아울러 코드 리뷰 과정에서 발견된 아키텍처 규칙 위반 사항(테이블명 단수형, Admin 모듈 경로 미분리, Controller의 Service 직접 의존 등)을
함께 수정하여 프로젝트 공통 컨벤션(`rules/`)을 준수하도록 개선합니다.

---

## 🔑 주요 변경 사항 (What)

### 1. 엔티티 연관관계 전환 (`ReservationEntity`)
- `Long userId` → `@ManyToOne(LAZY) UserEntity user`
- `Long spaceId` → `@ManyToOne(LAZY) SpaceEntity space`
- `Long approvedBy` → `@ManyToOne(nullable, LAZY) UserEntity approvedBy`
- 편의 getter 추가: `getUserId()`, `getSpaceId()`, `getApprovedById()`
- `approve(Long)` → `approve(UserEntity)` 시그니처 변경
- `@Table(name = "reservation")` → `@Table(name = "reservations")` (복수형 네이밍 규칙)

### 2. 아키텍처 규칙 위반 수정 (Critical 4건)

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| `@Table(name)` | `"reservation"` | `"reservations"` |
| `AdminReservationController` 위치 | `reservation/adapter/in/web/` | `admin/reservation/adapter/in/web/` |
| `FacilityController` 의존 | `FacilityQueryService` 직접 주입 | `FacilityQueryUseCase` 인터페이스 주입 |
| Native Query 테이블명 | `FROM reservation r` | `FROM reservations r` |

### 3. `FacilityQueryUseCase` 인터페이스 신규 생성
- `application/port/in/FacilityQueryUseCase.java` 추가
- `FacilityQueryService`가 해당 UseCase를 `implements`하도록 수정
- Controller가 구현체 대신 UseCase에 의존하도록 변경 (DIP 준수)

### 4. JPQL / Native Query 수정 (`ReservationJpaRepository`, `FacilityQueryAdapter`)
- 파생 쿼리 메서드: `findBySpaceId…` → `findBySpace_SpaceId…`
- JPQL: `r.spaceId` → `r.space.spaceId`
- 상태 비교: 문자열 리터럴 `'APPROVED'` → `ReservationStatus.APPROVED` Enum 참조

### 5. 서비스 로직 수정 (`ReservationCommandService`)
- `SpaceJpaRepository` DI 추가 → 예약 생성 시 `SpaceEntity` 직접 조회 후 Builder 주입
- `approveReservation()`: `adminId`로 `UserEntity` 조회 후 `approve(UserEntity)` 호출
- `cancelReservation()` / `rejectReservation()`: `cancel()` 이후 `save()` 명시적 호출 추가

### 6. 보안 설정 복구 (`SecurityConfig`)
- 개발 편의를 위해 임시로 허용했던 `permitAll()` 제거
- `/api/admin/**` → `hasRole("ADMIN")` 복구
- `/api/reservations/**`, `/api/facilities/**` → `hasAnyRole("RESIDENT", "ADMIN")` 복구

### 7. 테스트 코드 리팩터링
- `ReservationEntityTest`: 미사용 상수 제거, `UserEntity`/`SpaceEntity` Builder 방식으로 픽스처 교체
- `ReservationJpaRepositoryTest`: 실 엔티티 저장 후 연관관계 테스트, 미사용 `space2` 제거
- `ReservationCommandServiceTest`: `@Mock UserJpaRepository`, `@Mock SpaceJpaRepository` 추가
- `ReservationQueryServiceTest`: 메서드명 `findByUserId…` → `findByUser_UserId…` 반영

---

## 🔗 연관된 이슈 (Issue / Ticket)

- Resolves #117

---

## 💻 테스트 방법 (How to Test)

### 1. 빌드 확인
```bash
cd backend
./gradlew compileJava compileTestJava
# → BUILD SUCCESSFUL 확인
```

### 2. API 동작 확인 (Swagger UI)
서버 기동 후 `http://localhost:8080/swagger-ui.html` 접속

#### 시설 조회 — `/api/facilities` (접근: `RESIDENT`, `ADMIN`)
| Method | URL | 설명 |
|--------|-----|------|
| `GET` | `/api/facilities` | 예약 가능한 공용시설 목록 조회 |
| `GET` | `/api/facilities/{spaceId}` | 공용시설 상세 조회 |

#### 예약 신청/관리 — `/api/reservations` (접근: `RESIDENT`, `ADMIN`)
| Method | URL | 설명 |
|--------|-----|------|
| `GET` | `/api/reservations` | 내 예약 목록 조회 |
| `POST` | `/api/reservations` | 공용시설 예약 신청 |
| `PATCH` | `/api/reservations/{id}/cancel` | 예약 취소 |

#### 관리자 예약 관리 — `/api/admin/reservations` (접근: `ADMIN` only)
| Method | URL | 설명 |
|--------|-----|------|
| `GET` | `/api/admin/reservations` | 전체 예약 내역 조회 |
| `PATCH` | `/api/admin/reservations/{id}/approve` | 예약 승인 |
| `PATCH` | `/api/admin/reservations/{id}/reject` | 예약 반려 |

---

해당 없음 (백엔드 전용 변경)

---

## 💬 리뷰어에게 전달할 내용 (Review Notes)

- `AdminReservationController`의 패키지 이동(`reservation/` → `admin/reservation/`)으로 인해 import 경로가 달라졌으나, 엔드포인트 URL(`/api/admin/reservations`)은 동일합니다.
- `FacilityQueryUseCase` 인터페이스 신설로 `FacilityController`의 의존 대상이 Service 구현체에서 UseCase 인터페이스로 바뀌었습니다. DI는 Spring이 자동으로 처리합니다.
- `ReservationCommandService`에 `SpaceJpaRepository`가 추가됐습니다. 도메인 간 결합을 최소화하기 위해 ID만 주고받는 원칙을 유지하면서, Entity 조회는 서비스 내부에서 수행합니다.
- 현재 `@RequestHeader("X-Admin-Id")`로 관리자 ID를 받는 방식은 임시 구현입니다. JWT `@AuthenticationPrincipal` 연동 시 해당 파라미터 제거가 필요합니다.
