### PR TITLE
Feat/106

### DIFF
--- a/backend/src/main/java/com/coliving/CoLivingApplication.java
+++ b/backend/src/main/java/com/coliving/CoLivingApplication.java
@@ -3,10 +3,16 @@ package com.coliving;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 public class CoLivingApplication {
 
     public static void main(String[] args) {
+        // fix(#106): JVM 기본 타임존을 Asia/Seoul(KST)로 강제 설정
+        // application.yml의 jackson.time-zone 설정만으로는 JVM 타임존이 UTC로 남아
+        // @FutureOrPresent 날짜 검증, LocalDate.now() 등에서 9시간 오차 발생 가능
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         SpringApplication.run(CoLivingApplication.class, args);
     }
 }

--- a/backend/src/main/java/com/coliving/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/JacksonConfig.java
@@ -1,0 +1,74 @@
+package com.coliving.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+/**
+ * Jackson 직렬화 설정
+ *
+ * fix(#106): 타임존·시간 포맷 이슈 조치
+ *
+ * 문제 1 — Safari / 모바일 웹뷰 호환:
+ *   <input type="time"> 은 Safari에서 초(ss) 없이 "HH:mm" 포맷만 반환한다.
+ *   반면 Chrome은 step 속성에 따라 "HH:mm:ss"를 반환하기도 한다.
+ *   Jackson 기본 LocalTime 역직렬화는 "HH:mm" 을 허용하지 않아 400 에러 발생.
+ *   → 역직렬화: "HH:mm" / "HH:mm:ss" / "HH:mm:ss.SSS" 모두 허용하는 유연한 포맷 등록
+ *   → 직렬화:   응답은 항상 "HH:mm:ss" 로 통일 (프론트 파싱 일관성 확보)
+ *
+ * 문제 2 — UTC → KST 9시간 오차:
+ *   CoLivingApplication.main()에서 JVM TimeZone을 Asia/Seoul 로 강제 설정 후
+ *   Jackson 역시 동일 타임존 기준으로 동작하므로 이 설정으로 추가 보장.
+ */
+@Configuration
+public class JacksonConfig {
+
+    /**
+     * LocalTime 역직렬화 포맷:
+     *   - "14:00"         (Safari <input type="time"> 기본 출력)
+     *   - "14:00:00"      (Chrome, API 명세 권장)
+     *   - "14:00:00.000"  (밀리초 포함 엣지케이스)
+     */
+    private static final DateTimeFormatter FLEXIBLE_TIME_FORMATTER =
+            new DateTimeFormatterBuilder()
+                    .appendPattern("HH:mm")
+                    .optionalStart()
+                    .appendPattern(":ss")
+                    .optionalEnd()
+                    .optionalStart()
+                    .appendPattern(".SSS")
+                    .optionalEnd()
+                    .toFormatter();
+
+    /** 직렬화(응답) 포맷: 항상 "HH:mm:ss" 로 통일 */
+    private static final DateTimeFormatter RESPONSE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+        // LocalTime 직렬화: 응답 시 "HH:mm:ss"
+        javaTimeModule.addSerializer(LocalTime.class,
+                new LocalTimeSerializer(RESPONSE_TIME_FORMATTER));
+
+        // LocalTime 역직렬화: "HH:mm" / "HH:mm:ss" / "HH:mm:ss.SSS" 모두 허용
+        javaTimeModule.addDeserializer(LocalTime.class,
+                new LocalTimeDeserializer(FLEXIBLE_TIME_FORMATTER));
+
+        return new ObjectMapper()
+                .registerModule(javaTimeModule)
+                // LocalDate 등을 [2026,5,1] 배열이 아닌 "2026-05-01" 문자열로 직렬화
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -94,6 +94,7 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         }
 
         reservation.cancel();
+        reservationRepository.save(reservation); // fix: 더티 체킹 의존 제거 (03-backend-architecture §5)
         log.info("예약 취소 성공 - reservationId: {}, userId: {}", reservationId, userId);
     }
 
@@ -120,6 +121,7 @@ public class ReservationCommandService implements ReservationCommandUseCase {
 
         // Entity의 cancel() 메서드가 PENDING, APPROVED 상태에서 CANCELLED로 전환되도록 보장함
         reservation.cancel();
+        reservationRepository.save(reservation); // fix: 더티 체킹 의존 제거 (03-backend-architecture §5)
         log.info("예약 반려(취소) 성공 - reservationId: {}, adminId: {}", reservationId, adminId);
     }
 }

--- a/backend/src/test/java/com/coliving/admin/reservation/adapter/in/web/AdminReservationControllerTest.java
+++ b/backend/src/test/java/com/coliving/admin/reservation/adapter/in/web/AdminReservationControllerTest.java
@@ -3,7 +3,6 @@ package com.coliving.admin.reservation.adapter.in.web;
 import com.coliving.reservation.adapter.in.web.dto.AdminReservationResponse;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.application.port.in.ReservationQueryUseCase;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +54,7 @@ class AdminReservationControllerTest {
     @Test
     @WithMockUser
     @DisplayName("새로운 예약을 승인 상태로 변경할 수 있다")
+    @SuppressWarnings("null")
     void approveReservation_Success() throws Exception {
         mockMvc.perform(patch("/api/admin/reservations/1/approve")
                         .with(csrf())
@@ -66,6 +66,7 @@ class AdminReservationControllerTest {
     @Test
     @WithMockUser
     @DisplayName("예약을 반려 처리할 수 있다")
+    @SuppressWarnings("null")
     void rejectReservation_Success() throws Exception {
         mockMvc.perform(patch("/api/admin/reservations/1/reject")
                         .with(csrf())

--- a/frontend/src/app/reservation-test/page.tsx
+++ b/frontend/src/app/reservation-test/page.tsx
@@ -30,8 +30,9 @@ export default function ReservationTestPage() {
   // Form State
   const [spaceId, setSpaceId] = useState("");
   const [reservationDate, setReservationDate] = useState("2026-05-01");
-  const [startTime, setStartTime] = useState("14:00:00");
-  const [endTime, setEndTime] = useState("16:00:00");
+  // fix(#106): Safari는 <input type="time"> 초기값으로 "HH:mm:ss" 포맷을 인식 못함 → "HH:mm" 으로 통일
+  const [startTime, setStartTime] = useState("14:00");
+  const [endTime, setEndTime] = useState("16:00");
 
   const [message, setMessage] = useState("");
 


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 예약 취소·반려 시 DB 반영이 보장되지 않는 버그와, 서버(UTC)와 프론트(KST) 간 9시간 타임존 오차, Safari/모바일 환경에서 시간 입력이 동작하지 않는 문제를 QA 검수 과정에서 확인하였습니다. 기존 코드는 더티 체킹에만 의존하고 있어 트랜잭션 구현체에 따라 상태 변경이 DB에 반영되지 않을 수 있었으며, JVM 타임존이 UTC로 기동될 경우 날짜 관련 검증과 비교 로직 전반에서 오차가 발생합니다.

## 🔑 주요 변경 사항 (What)
- [BE] ReservationCommandService — save() 명시 호출 누락 수정
- [BE] CoLivingApplication — JVM 타임존 강제 설정
- [BE] JacksonConfig (신규) — LocalTime 역직렬화 포맷 유연화
- [FE] reservation-test/page.tsx — time input 초기값 포맷 수정

## 🔗 연관된 이슈 (Issue / Ticket)
- feat/106

## 💻 테스트 방법 (How to Test)
``` # 1. 브랜치 체크아웃
git checkout feat/106

# 2. Docker 기동
docker compose up -d

# 3. 타임존 검증 — 오후 2시 예약 후 재조회
# http://localhost:3111/reservation-test 접속
# → 시작시간 14:00, 종료시간 16:00 으로 예약 신청
# → "내 예약 불러오기" 클릭 후 startTime: "14:00:00" 으로 반환되는지 확인

# 4. Safari/모바일 동일 URL 접속 → 시간 입력 필드 정상 표시 확인
```

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- 화면 UI나 UX에 변경 사항이 있다면 전/후 스크린샷을 첨부해주세요.

## ✅ 체크리스트 (Self-Review)
- [ ] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [ ] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [ ] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [ ] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
JacksonConfig의 @Bean @Primary — 기존에 다른 팀원이 ObjectMapper Bean을 등록했을 경우 충돌 가능성이 있습니다. global/config 내 기존 등록 여부를 확인해 주세요.

TimeZone.setDefault()의 부작용 — JVM 전역에 영향을 주는 설정입니다. PostgreSQL JDBC 드라이버의 타임스탬프 처리 방식에도 영향을 줄 수 있으므로 OffsetDateTime 컬럼(created_at 등)의 조회값이 의도대로 동작하는지 확인이 필요합니다.

"파일명 2.java" 중복 파일 발견 — macOS 파일 시스템 충돌로 추정되는 untracked 파일들이 워크스페이스에 존재합니다. 이번 PR 범위 밖이나 별도 정리가 필요합니다.

Closes #
