### PR TITLE
feat(RSV-#81): 예약 조회 및 취소 롤백 구현

### DIFF
--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/ReservationController.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/ReservationController.java
@@ -1,8 +1,8 @@
 package com.coliving.reservation.adapter.in.web;
 
 import com.coliving.global.dto.ApiResponse;
-import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
-import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
+import com.coliving.reservation.adapter.in.web.dto.req.ReservationCreateRequestDto;
+import com.coliving.reservation.adapter.in.web.dto.res.UserReservationResponseDto;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.application.port.in.ReservationQueryUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,18 +17,24 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * 예약 생성 REST Controller
+ * 입주자 예약 신청/조회/취소 REST Controller
  *
- * RSV-4.4: 예약 동시성 차단 신청 로직을 포함한 API를 제공한다.
+ * #80 예약 동시성 차단 신청 로직
+ * #81 예약 조회 및 취소 롤백
  *
  * ┌──────────────────────────────────────────────────────────────────┐
- * │ [TODO - Auth 연동 시 수정 필요]                                │
- * │ 현재 헤더(X-User-Id)로 사용자 ID를 받고 있으나,                  │
- * │ 추후 Spring Security의 @AuthenticationPrincipal 등으로 인증       │
- * │ 객체에서 userId를 추출하도록 변경해야 합니다.                    │
+ * │ [TODO - Auth 연동 시 수정 필요]                                   │
+ * │ 현재 헤더(X-User-Id)로 사용자 ID를 받고 있으나,                   │
+ * │ 추후 Spring Security의 @AuthenticationPrincipal 등으로 인증        │
+ * │ 객체에서 userId를 추출하도록 변경해야 합니다.                     │
  * └──────────────────────────────────────────────────────────────────┘
+ *
+ * api-specification.md §6:
+ *   GET  /api/reservations/my          → 내 예약 목록 조회 (🏠)
+ *   POST /api/reservations             → 예약 신청 (🏠)
+ *   POST /api/reservations/{id}/cancel → 예약 취소 (🏠)
  */
-@Tag(name = "Reservation", description = "예약 신청 및 관리 API (RSV-4.4)")
+@Tag(name = "Reservation", description = "예약 신청 및 관리 API (#80, #81)")
 @RestController
 @RequestMapping("/api/reservations")
 @RequiredArgsConstructor
@@ -38,22 +44,25 @@ public class ReservationController {
     private final ReservationQueryUseCase reservationQueryUseCase;
 
     /**
-     * 사용자 본인의 예약 목록 조회
+     * 내 예약 목록 조회
+     * GET /api/reservations/my  (api-specification.md §6.4)
+     * Query: status, p, s — TODO: 페이징 구현 (#81 이후)
      */
     @Operation(summary = "내 예약 목록 조회", description = "로그인한 사용자의 모든 예약 내역을 최신순으로 조회합니다.")
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<UserReservationResponse>>> getMyReservations(
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<UserReservationResponseDto>>> getMyReservations(
             @Parameter(description = "사용자 ID (임시)", example = "1")
             @RequestHeader("X-User-Id") Long userId) {
 
-        List<UserReservationResponse> responses = reservationQueryUseCase.getUserReservations(userId);
+        List<UserReservationResponseDto> responses = reservationQueryUseCase.getUserReservations(userId);
         return ResponseEntity.ok(ApiResponse.ok(responses));
     }
 
     /**
      * 공용시설 예약 신청
+     * POST /api/reservations  (api-specification.md §6.3)
      *
-     * @param userId 요청한 사용자 ID (임시 헤더)
+     * @param userId  요청한 사용자 ID (임시 헤더)
      * @param request 예약 생성 정보
      * @return 생성된 예약 ID
      */
@@ -65,7 +74,7 @@ public class ReservationController {
     public ResponseEntity<ApiResponse<Map<String, Long>>> createReservation(
             @Parameter(description = "사용자 ID (임시)", example = "1")
             @RequestHeader("X-User-Id") Long userId,
-            @Valid @RequestBody ReservationCreateRequest request) {
+            @Valid @RequestBody ReservationCreateRequestDto request) {
 
         Long reservationId = reservationCommandUseCase.reserveFacility(userId, request);
         return ResponseEntity.ok(ApiResponse.ok(Map.of("reservationId", reservationId)));
@@ -73,9 +82,13 @@ public class ReservationController {
 
     /**
      * 공용시설 예약 취소
+     * POST /api/reservations/{id}/cancel  (api-specification.md §6.5)
+     *
+     * PENDING 또는 APPROVED 상태의 예약만 취소 가능합니다.
+     * COMPLETED/CANCELLED 상태에서 취소 시도 시 409 INVALID_STATUS 에러 반환.
      */
-    @Operation(summary = "공용시설 예약 취소", description = "본인의 승인 또는 대기 중인 예약을 취소합니다.")
-    @PatchMapping("/{id}/cancel")
+    @Operation(summary = "공용시설 예약 취소", description = "본인의 승인 또는 대기 중인 예약을 취소합니다. COMPLETED/CANCELLED 상태에서는 취소 불가.")
+    @PostMapping("/{id}/cancel")
     public ResponseEntity<ApiResponse<Void>> cancelReservation(
             @Parameter(description = "사용자 ID (임시)", example = "1")
             @RequestHeader("X-User-Id") Long userId,

--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/req/ReservationCreateRequestDto.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/req/ReservationCreateRequestDto.java
@@ -1,0 +1,47 @@
+package com.coliving.reservation.adapter.in.web.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 예약 신청 요청 DTO
+ *
+ * POST /api/reservations
+ * 03-backend-architecture §1-7: 요청 DTO는 RequestDto 접미사 + req/ 폴더
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "예약 생성 요청 데이터")
+public class ReservationCreateRequestDto {
+
+    @NotNull(message = "예약할 시설 ID는 필수입니다.")
+    @Schema(description = "공용시설 ID", example = "1")
+    private Long spaceId;
+
+    @NotNull(message = "예약 날짜는 필수입니다.")
+    @FutureOrPresent(message = "예약 날짜는 오늘 이후여야 합니다.")
+    @Schema(description = "예약 날짜", example = "2026-05-01")
+    private LocalDate reservationDate;
+
+    @NotNull(message = "시작 시간은 필수입니다.")
+    @Schema(description = "시작 시간", type = "string", format = "time", example = "14:00:00")
+    private LocalTime startTime;
+
+    @NotNull(message = "종료 시간은 필수입니다.")
+    @Schema(description = "종료 시간", type = "string", format = "time", example = "16:00:00")
+    private LocalTime endTime;
+
+    /** 종료 시간이 시작 시간보다 늦어야 함 */
+    public boolean isValidTimeRange() {
+        if (startTime == null || endTime == null) return false;
+        return endTime.isAfter(startTime);
+    }
+}

--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/res/UserReservationResponseDto.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/res/UserReservationResponseDto.java
@@ -1,0 +1,55 @@
+package com.coliving.reservation.adapter.in.web.dto.res;
+
+import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
+import com.coliving.reservation.model.ReservationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 입주자 예약 목록 응답 DTO
+ *
+ * GET /api/reservations/my
+ * 03-backend-architecture §1-7: 응답 DTO는 ResponseDto 접미사 + res/ 폴더
+ */
+@Getter
+@Builder
+@Schema(description = "사용자의 예약 상세 응답 데이터")
+public class UserReservationResponseDto {
+
+    @Schema(description = "예약 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "공용시설 ID", example = "10")
+    private Long spaceId;
+
+    @Schema(description = "공용시설 이름", example = "회의실 A")
+    private String spaceName;
+
+    @Schema(description = "예약 상태", example = "APPROVED")
+    private ReservationStatus status;
+
+    @Schema(description = "예약 날짜", example = "2026-05-01")
+    private LocalDate reservationDate;
+
+    @Schema(description = "시작 시간", example = "14:00:00")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간", example = "16:00:00")
+    private LocalTime endTime;
+
+    public static UserReservationResponseDto fromEntity(ReservationEntity entity) {
+        return UserReservationResponseDto.builder()
+                .id(entity.getId())
+                .spaceId(entity.getSpaceId())
+                .spaceName(entity.getSpaceName())
+                .status(entity.getStatus())
+                .reservationDate(entity.getReservationDate())
+                .startTime(entity.getStartTime())
+                .endTime(entity.getEndTime())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
@@ -94,6 +94,11 @@ public class ReservationEntity extends BaseEntity {
         return this.space != null ? this.space.getSpaceId() : null;
     }
 
+    /** 시설 이름 편의 getter */
+    public String getSpaceName() {
+        return this.space != null ? this.space.getName() : null;
+    }
+
     /** 승인자 ID 편의 getter */
     public Long getApprovedById() {
         return this.approvedBy != null ? this.approvedBy.getUserId() : null;

--- a/backend/src/main/java/com/coliving/reservation/application/port/in/ReservationCommandUseCase.java
+++ b/backend/src/main/java/com/coliving/reservation/application/port/in/ReservationCommandUseCase.java
@@ -1,9 +1,11 @@
 package com.coliving.reservation.application.port.in;
 
-import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
+import com.coliving.reservation.adapter.in.web.dto.req.ReservationCreateRequestDto;
 
 /**
  * 예약 생성 유스케이스 (Inbound Port)
+ * #80 예약 동시성 차단 신청 로직
+ * #81 예약 조회 및 취소 롤백
  */
 public interface ReservationCommandUseCase {
     
@@ -11,17 +13,10 @@ public interface ReservationCommandUseCase {
      * 시설 예약을 신청한다.
      * 
      * @param userId 요청한 사용자 ID
-     * @param request 예약 요청 정보
+     * @param request 예약 요청 정보 (ReservationCreateRequestDto)
      * @return 생성된 예약 ID
      */
-    /**
-     * 시설 예약을 신청한다.
-     * 
-     * @param userId 요청한 사용자 ID
-     * @param request 예약 요청 정보
-     * @return 생성된 예약 ID
-     */
-    Long reserveFacility(Long userId, ReservationCreateRequest request);
+    Long reserveFacility(Long userId, ReservationCreateRequestDto request);
 
     /**
      * 예약을 취소한다.

--- a/backend/src/main/java/com/coliving/reservation/application/port/in/ReservationQueryUseCase.java
+++ b/backend/src/main/java/com/coliving/reservation/application/port/in/ReservationQueryUseCase.java
@@ -1,12 +1,16 @@
 package com.coliving.reservation.application.port.in;
 
 import com.coliving.reservation.adapter.in.web.dto.AdminReservationResponse;
-import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
+import com.coliving.reservation.adapter.in.web.dto.res.UserReservationResponseDto;
 
 import java.util.List;
 
 /**
  * 예약 조회 유스케이스 (Inbound Port)
+ *
+ * #81: 입주자 예약 조회 및 취소
+ * - getUserReservations: UserReservationResponseDto (res/ 폴더, Dto 접미사)
+ * - getAllReservations: AdminReservationResponse (#82에서 분리 예정)
  */
 public interface ReservationQueryUseCase {
 
@@ -14,12 +18,13 @@ public interface ReservationQueryUseCase {
      * 특정 사용자의 전체 예약 목록을 조회한다 (최신순).
      *
      * @param userId 사용자 ID
-     * @return 예약 응답 목록
+     * @return 예약 응답 목록 (UserReservationResponseDto)
      */
-    List<UserReservationResponse> getUserReservations(Long userId);
+    List<UserReservationResponseDto> getUserReservations(Long userId);
 
     /**
      * 관리자가 전체 예약 목록을 조회한다 (최신순).
+     * TODO (#82): AdminReservationResponseDto 로 전환 및 admin 모듈로 분리
      *
      * @return 예약 응답 목록
      */

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -4,7 +4,7 @@ import com.coliving.common.auth.adapter.out.jpa.UserEntity;
 import com.coliving.common.auth.adapter.out.jpa.UserJpaRepository;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
-import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
+import com.coliving.reservation.adapter.in.web.dto.req.ReservationCreateRequestDto;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
@@ -19,7 +19,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Objects;
 
 /**
- * 예약 생성 서비스
+ * 예약 쓰기(Command) 서비스
+ *
+ * #80 예약 동시성 차단 신청 로직
+ * #81 예약 조회 및 취소 롤백
+ *
+ * 03-backend-architecture §5:
+ *   - @Transactional 명시
+ *   - jpaRepository.save(entity) 명시적 호출 (더티 체킹 의존 금지)
+ *   - IllegalStateException → BusinessException(INVALID_STATUS)로 변환
  */
 @Slf4j
 @Service
@@ -31,26 +39,36 @@ public class ReservationCommandService implements ReservationCommandUseCase {
     private final UserJpaRepository userRepository;
     private final SpaceJpaRepository spaceRepository;
 
+    /**
+     * 시설 예약 신청
+     *
+     * 처리 순서:
+     * 1. 시간 범위 유효성 검사 (종료 > 시작)
+     * 2. 사용자 조회
+     * 3. 시설 조회
+     * 4. 동시성 체크 — 동일 시설/날짜/시간대에 APPROVED 예약 존재 시 ReservationOverlapException
+     * 5. 엔티티 생성(PENDING) 및 저장
+     */
     @Override
     @Transactional
-    public Long reserveFacility(Long userId, ReservationCreateRequest request) {
+    public Long reserveFacility(Long userId, ReservationCreateRequestDto request) {
         // 1. 시간 범위 유효성 검사
         if (!request.isValidTimeRange()) {
-            throw new IllegalArgumentException("종료 시간은 시작 시간보다 이후여야 합니다.");
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "종료 시간은 시작 시간보다 이후여야 합니다.");
         }
 
-        // 2. 요청 사용자 조회 (USR-1.1 ManyToOne 전환 완료)
+        // 2. 요청 사용자 조회
         Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
         @SuppressWarnings("null")
         UserEntity userEntity = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "사용자를 찾을 수 없습니다."));
 
-        // 3. 시설 조회 (SPC-2.1 @ManyToOne 전환 완료)
+        // 3. 시설 조회 (SpaceJpaRepository 직접 사용 — 04-domain-collaboration: 읽기만 허용)
         SpaceEntity spaceEntity = spaceRepository.findById(request.getSpaceId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "시설을 찾을 수 없습니다."));
 
-        // 4. 동시성 체크: 해당 시간에 승인(APPROVED)된 중복 예약이 있는지 확인
-        // TODO: (고도화) 다중 인스턴스 환경에서 완벽한 동시성 제어를 위해 Redisson 기반 분산 락, 또는 DB 유니크 제약/비관적 락 도입 고려
+        // 4. 동시성 체크: 해당 시간에 APPROVED 중복 예약 여부 확인
+        // TODO: (고도화) 다중 인스턴스 환경에서 완벽한 동시성 제어를 위해 Redisson 분산 락, DB Partial Unique Index 도입 고려
         boolean hasOverlap = reservationRepository.existsOverlappingReservation(
                 request.getSpaceId(),
                 request.getReservationDate(),
@@ -60,22 +78,22 @@ public class ReservationCommandService implements ReservationCommandUseCase {
 
         if (hasOverlap) {
             log.warn("예약 충돌 발생 - spaceId: {}, date: {}, time: {}~{}",
-                    request.getSpaceId(), request.getReservationDate(), request.getStartTime(), request.getEndTime());
+                    request.getSpaceId(), request.getReservationDate(),
+                    request.getStartTime(), request.getEndTime());
             throw new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다.");
         }
 
-        // 5. 예약 엔티티 생성 (초기 상태: PENDING)
-        ReservationEntity newReservation = ReservationEntity.builder()
-                .user(userEntity)
-                .space(spaceEntity)
-                .reservationDate(request.getReservationDate())
-                .startTime(request.getStartTime())
-                .endTime(request.getEndTime())
-                .build();
-
-        // 5. 저장 및 ID 반환
+        // 5. 예약 엔티티 생성 (초기 상태: PENDING) 및 저장
         @SuppressWarnings("null")
-        ReservationEntity savedReservation = reservationRepository.save(newReservation);
+        ReservationEntity savedReservation = reservationRepository.save(
+                ReservationEntity.builder()
+                        .user(userEntity)
+                        .space(spaceEntity)
+                        .reservationDate(request.getReservationDate())
+                        .startTime(request.getStartTime())
+                        .endTime(request.getEndTime())
+                        .build()
+        );
 
         log.info("새로운 예약 성공 - reservationId: {}, spaceId: {}, userId: {}",
                 savedReservation.getId(), savedReservation.getSpaceId(), savedReservation.getUserId());
@@ -83,45 +101,81 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         return savedReservation.getId();
     }
 
+    /**
+     * 예약 취소 (#81 핵심)
+     *
+     * - 본인 예약만 취소 가능 (소유권 검증)
+     * - PENDING/APPROVED 상태만 취소 가능
+     * - COMPLETED/CANCELLED 상태에서 시도 시 → BusinessException(INVALID_STATUS) 409
+     * - 성공 시 status=CANCELLED, jpaRepository.save() 명시 호출
+     */
     @Override
     @Transactional
     public void cancelReservation(Long userId, Long reservationId) {
         ReservationEntity reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "예약을 찾을 수 없습니다."));
 
+        // 소유권 검증
         if (!reservation.getUserId().equals(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN, "본인의 예약만 취소할 수 있습니다.");
         }
 
-        reservation.cancel();
-        reservationRepository.save(reservation); // fix: 더티 체킹 의존 제거 (03-backend-architecture §5)
+        // 상태 전환 (COMPLETED/CANCELLED → IllegalStateException → INVALID_STATUS 409)
+        try {
+            reservation.cancel();
+        } catch (IllegalStateException e) {
+            throw new BusinessException(ErrorCode.INVALID_STATUS, e.getMessage());
+        }
+
+        // 03-backend-architecture §5: 더티 체킹 의존 금지, save() 명시 호출
+        reservationRepository.save(reservation);
         log.info("예약 취소 성공 - reservationId: {}, userId: {}", reservationId, userId);
     }
 
+    /**
+     * [관리자] 예약 승인 (#82, #83에서 관리자 전용 UseCase로 분리 예정)
+     *
+     * PENDING → APPROVED + approvedBy 기록
+     */
     @Override
     @Transactional
     public void approveReservation(Long adminId, Long reservationId) {
         ReservationEntity reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "예약을 찾을 수 없습니다."));
 
-        // adminId로 관리자 UserEntity 조회 후 approve(UserEntity) 호출
         UserEntity adminEntity = userRepository.findById(adminId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "관리자를 찾을 수 없습니다."));
 
-        reservation.approve(adminEntity);
+        try {
+            reservation.approve(adminEntity);
+        } catch (IllegalStateException e) {
+            throw new BusinessException(ErrorCode.INVALID_STATUS, e.getMessage());
+        }
+
+        // 03-backend-architecture §5: save() 명시 호출
         reservationRepository.save(reservation);
         log.info("예약 승인 성공 - reservationId: {}, adminId: {}", reservationId, adminId);
     }
 
+    /**
+     * [관리자] 예약 반려 (#82, #83에서 관리자 전용 UseCase로 분리 예정)
+     *
+     * PENDING/APPROVED → CANCELLED
+     */
     @Override
     @Transactional
     public void rejectReservation(Long adminId, Long reservationId) {
         ReservationEntity reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "예약을 찾을 수 없습니다."));
 
-        // Entity의 cancel() 메서드가 PENDING, APPROVED 상태에서 CANCELLED로 전환되도록 보장함
-        reservation.cancel();
-        reservationRepository.save(reservation); // fix: 더티 체킹 의존 제거 (03-backend-architecture §5)
+        try {
+            reservation.cancel();
+        } catch (IllegalStateException e) {
+            throw new BusinessException(ErrorCode.INVALID_STATUS, e.getMessage());
+        }
+
+        // 03-backend-architecture §5: save() 명시 호출
+        reservationRepository.save(reservation);
         log.info("예약 반려(취소) 성공 - reservationId: {}, adminId: {}", reservationId, adminId);
     }
 }

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationQueryService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationQueryService.java
@@ -1,7 +1,7 @@
 package com.coliving.reservation.application.service;
 
 import com.coliving.reservation.adapter.in.web.dto.AdminReservationResponse;
-import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
+import com.coliving.reservation.adapter.in.web.dto.res.UserReservationResponseDto;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationQueryUseCase;
@@ -13,7 +13,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * 예약 조회 서비스
+ * 예약 조회(Query) 서비스
+ *
+ * #81 예약 조회 및 취소 롤백
+ *
+ * - getUserReservations: 입주자 본인 예약 목록 (UserReservationResponseDto)
+ * - getAllReservations: 관리자 전체 예약 목록 — TODO (#82): admin 모듈로 분리
  */
 @Service
 @RequiredArgsConstructor
@@ -22,21 +27,31 @@ public class ReservationQueryService implements ReservationQueryUseCase {
 
     private final ReservationJpaRepository reservationRepository;
 
+    /**
+     * 입주자 본인 예약 목록 조회 (GET /api/reservations/my)
+     *
+     * userId 기준으로 모든 예약을 최신순(날짜↓, 시작시간↓)으로 조회한다.
+     * CANCELLED 포함 전체 이력을 반환한다.
+     */
     @Override
-    public List<UserReservationResponse> getUserReservations(Long userId) {
+    public List<UserReservationResponseDto> getUserReservations(Long userId) {
         List<ReservationEntity> reservations = reservationRepository
                 .findByUser_UserIdOrderByReservationDateDescStartTimeDesc(userId);
 
         return reservations.stream()
-                .map(UserReservationResponse::fromEntity)
+                .map(UserReservationResponseDto::fromEntity)
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 관리자 전체 예약 목록 조회
+     * TODO (#82): AdminReservationResponseDto 로 전환 및 admin 모듈로 분리 예정
+     */
     @Override
     public List<AdminReservationResponse> getAllReservations() {
         List<ReservationEntity> reservations = reservationRepository
                 .findAllByOrderByReservationDateDescStartTimeDesc();
-        
+
         return reservations.stream()
                 .map(AdminReservationResponse::fromEntity)
                 .collect(Collectors.toList());

--- a/backend/src/test/java/com/coliving/reservation/adapter/in/web/ReservationControllerTest.java
+++ b/backend/src/test/java/com/coliving/reservation/adapter/in/web/ReservationControllerTest.java
@@ -1,7 +1,7 @@
 package com.coliving.reservation.adapter.in.web;
 
-import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
-import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
+import com.coliving.reservation.adapter.in.web.dto.req.ReservationCreateRequestDto;
+import com.coliving.reservation.adapter.in.web.dto.res.UserReservationResponseDto;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.application.port.in.ReservationQueryUseCase;
 import com.coliving.reservation.exception.ReservationOverlapException;
@@ -17,17 +17,28 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * ReservationController 슬라이스 테스트
+ *
+ * #80 예약 동시성 차단 신청 로직
+ * #81 예약 조회 및 취소 롤백
+ *
+ * 검증 항목:
+ * - POST /api/reservations              : 정상 예약 / 중복 예약 충돌
+ * - GET  /api/reservations/my           : 내 예약 목록 조회
+ * - POST /api/reservations/{id}/cancel  : 예약 취소 (PENDING/APPROVED → CANCELLED)
+ */
 @WebMvcTest(ReservationController.class)
 class ReservationControllerTest {
 
@@ -43,8 +54,9 @@ class ReservationControllerTest {
     @MockBean
     private ReservationQueryUseCase reservationQueryUseCase;
 
-    private ReservationCreateRequest createRequest(LocalTime startTime, LocalTime endTime) {
-        ReservationCreateRequest request = new ReservationCreateRequest();
+    /** 테스트용 예약 요청 DTO 생성 헬퍼 */
+    private ReservationCreateRequestDto createRequest(LocalTime startTime, LocalTime endTime) {
+        ReservationCreateRequestDto request = new ReservationCreateRequestDto();
         request.setSpaceId(1L);
         request.setReservationDate(LocalDate.of(2026, 5, 1));
         request.setStartTime(startTime);
@@ -56,9 +68,9 @@ class ReservationControllerTest {
     @WithMockUser
     @DisplayName("정상적인 예약 요청 시 200 응답과 함께 reservationId를 반환한다")
     void createReservation_Success() throws Exception {
-        ReservationCreateRequest request = createRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
-        
-        given(reservationCommandUseCase.reserveFacility(eq(1L), any(ReservationCreateRequest.class)))
+        ReservationCreateRequestDto request = createRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
+
+        given(reservationCommandUseCase.reserveFacility(eq(1L), any(ReservationCreateRequestDto.class)))
                 .willReturn(999L);
 
         mockMvc.perform(post("/api/reservations")
@@ -75,9 +87,9 @@ class ReservationControllerTest {
     @WithMockUser
     @DisplayName("중복 예약 발생 시 409 Conflict 에러 응답을 반환한다")
     void createReservation_Conflict() throws Exception {
-        ReservationCreateRequest request = createRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
-        
-        given(reservationCommandUseCase.reserveFacility(eq(1L), any(ReservationCreateRequest.class)))
+        ReservationCreateRequestDto request = createRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
+
+        given(reservationCommandUseCase.reserveFacility(eq(1L), any(ReservationCreateRequestDto.class)))
                 .willThrow(new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다."));
 
         mockMvc.perform(post("/api/reservations")
@@ -92,27 +104,32 @@ class ReservationControllerTest {
 
     @Test
     @WithMockUser
-    @DisplayName("본인의 예약 내역을 조회할 수 있다")
+    @DisplayName("본인의 예약 내역을 GET /api/reservations/my 로 조회할 수 있다")
     void getMyReservations_Success() throws Exception {
-        UserReservationResponse response = UserReservationResponse.builder()
+        UserReservationResponseDto response = UserReservationResponseDto.builder()
                 .id(999L)
                 .spaceId(1L)
+                .spaceName("회의실 A")
                 .build();
-                
-        given(reservationQueryUseCase.getUserReservations(1L)).willReturn(java.util.List.of(response));
 
-        mockMvc.perform(get("/api/reservations")
+        given(reservationQueryUseCase.getUserReservations(1L))
+                .willReturn(List.of(response));
+
+        // #81: GET /reservations/my (api-specification.md §6.4)
+        mockMvc.perform(get("/api/reservations/my")
                         .header("X-User-Id", 1L))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[0].id").value(999L));
+                .andExpect(jsonPath("$.data[0].id").value(999L))
+                .andExpect(jsonPath("$.data[0].spaceName").value("회의실 A"));
     }
 
     @Test
     @WithMockUser
-    @DisplayName("예약 취소 API 호출 시 상태가 전환된다")
+    @DisplayName("예약 취소 API POST /api/reservations/{id}/cancel 호출 시 200을 반환한다")
     void cancelReservation_Success() throws Exception {
-        mockMvc.perform(patch("/api/reservations/999/cancel")
+        // #81: POST /reservations/{id}/cancel (api-specification.md §6.5)
+        mockMvc.perform(post("/api/reservations/999/cancel")
                         .with(csrf())
                         .header("X-User-Id", 1L))
                 .andExpect(status().isOk())

--- a/backend/src/test/java/com/coliving/reservation/application/service/ReservationCommandServiceTest.java
+++ b/backend/src/test/java/com/coliving/reservation/application/service/ReservationCommandServiceTest.java
@@ -6,7 +6,8 @@ import com.coliving.common.auth.model.Gender;
 import com.coliving.common.auth.model.UserRole;
 import com.coliving.common.auth.model.UserStatus;
 
-import com.coliving.reservation.adapter.in.web.dto.ReservationCreateRequest;
+import com.coliving.global.error.BusinessException;
+import com.coliving.reservation.adapter.in.web.dto.req.ReservationCreateRequestDto;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.exception.ReservationOverlapException;
@@ -97,8 +98,8 @@ class ReservationCommandServiceTest {
         return space;
     }
 
-    private ReservationCreateRequest createMockRequest(LocalTime startTime, LocalTime endTime) {
-        ReservationCreateRequest request = new ReservationCreateRequest();
+    private ReservationCreateRequestDto createMockRequest(LocalTime startTime, LocalTime endTime) {
+        ReservationCreateRequestDto request = new ReservationCreateRequestDto();
         request.setSpaceId(1L);
         request.setReservationDate(LocalDate.of(2026, 5, 1));
         request.setStartTime(startTime);
@@ -113,7 +114,7 @@ class ReservationCommandServiceTest {
         Long userId = 100L;
         UserEntity user = mockUser(userId);
         SpaceEntity space = mockSpace(1L);
-        ReservationCreateRequest request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
+        ReservationCreateRequestDto request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(spaceRepository.findById(request.getSpaceId())).willReturn(Optional.of(space));
@@ -142,7 +143,7 @@ class ReservationCommandServiceTest {
         Long userId = 100L;
         UserEntity user = mockUser(userId);
         SpaceEntity space = mockSpace(1L);
-        ReservationCreateRequest request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
+        ReservationCreateRequestDto request = createMockRequest(LocalTime.of(14, 0), LocalTime.of(16, 0));
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(spaceRepository.findById(request.getSpaceId())).willReturn(Optional.of(space));
@@ -162,11 +163,12 @@ class ReservationCommandServiceTest {
         // given
         Long userId = 100L;
         // 16시 시작, 14시 종료 (잘못된 범위)
-        ReservationCreateRequest request = createMockRequest(LocalTime.of(16, 0), LocalTime.of(14, 0));
+        ReservationCreateRequestDto request = createMockRequest(LocalTime.of(16, 0), LocalTime.of(14, 0));
 
         // when & then
+        // #81: 유효하지 않은 시간 범위 → BusinessException(VALIDATION_ERROR) 발생
         assertThatThrownBy(() -> reservationCommandService.reserveFacility(userId, request))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(BusinessException.class)
                 .hasMessageContaining("종료 시간은 시작 시간보다 이후여야 합니다");
     }
 

--- a/backend/src/test/java/com/coliving/reservation/application/service/ReservationQueryServiceTest.java
+++ b/backend/src/test/java/com/coliving/reservation/application/service/ReservationQueryServiceTest.java
@@ -4,7 +4,7 @@ import com.coliving.common.auth.adapter.out.jpa.UserEntity;
 import com.coliving.common.auth.model.Gender;
 import com.coliving.common.auth.model.UserRole;
 import com.coliving.common.auth.model.UserStatus;
-import com.coliving.reservation.adapter.in.web.dto.UserReservationResponse;
+import com.coliving.reservation.adapter.in.web.dto.res.UserReservationResponseDto;
 import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.model.ReservationStatus;
@@ -89,7 +89,7 @@ class ReservationQueryServiceTest {
                 .willReturn(List.of(entity));
 
         // when
-        List<UserReservationResponse> responses = reservationQueryService.getUserReservations(userId);
+        List<UserReservationResponseDto> responses = reservationQueryService.getUserReservations(userId);
 
         // then
         assertThat(responses).hasSize(1);


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)

기존 예약 조회/취소 API가 다음과 같은 문제를 가지고 있었습니다:
- `GET /api/reservations` 엔드포인트가 명세(`api-specification.md §6.4`)와 불일치 (`/my` 누락)
- `POST /api/reservations/{id}/cancel` 이 `PATCH` 메서드로 구현되어 명세 위반
- 취소 불가 상태(COMPLETED, CANCELLED)에서 취소 시도 시 `IllegalStateException`이 처리되지 않아 **500 Internal Server Error** 반환
- DTO 파일이 `req/res` 폴더 미분리 및 `Dto` 접미사 미적용 (아키텍처 규칙 위반)

이 PR은 위 문제들을 수정하여 명세 준수, 예외 처리 안정성 확보, 아키텍처 규칙 적용을 목적으로 합니다.

---

## 🔑 주요 변경 사항 (What)

### API 엔드포인트 명세 정합화
- `GET /api/reservations` → `GET /api/reservations/my` (§6.4 준수)
- `PATCH /api/reservations/{id}/cancel` → `POST /api/reservations/{id}/cancel` (§6.5 준수)

### 예외 처리 강화 (#81 핵심)
- `ReservationEntity.cancel()` 호출 시 발생하는 `IllegalStateException` → `BusinessException(INVALID_STATUS)` 변환 (HTTP 409 반환)
- `ReservationEntity.approve()` 호출 시 동일 처리
- 시간 범위 유효성 오류 → `BusinessException(VALIDATION_ERROR)` (HTTP 400 반환)

### DTO 아키텍처 규칙 준수 (`03-backend-architecture.md §1-7`)
- `ReservationCreateRequest` → `ReservationCreateRequestDto` (`dto/req/` 폴더)
- `UserReservationResponse` → `UserReservationResponseDto` (`dto/res/` 폴더)
- 응답 DTO에 `spaceName` 필드 추가 (시설명 표시 지원)

### 기타
- `ReservationEntity`에 `getSpaceName()` 편의 getter 추가
- `jpaRepository.save()` 명시적 호출 유지 (`03-backend-architecture.md §5`)
- 관련 테스트 전체 업데이트 (Controller / CommandService / QueryService)

---

## 🔗 연관된 이슈 (Issue / Ticket)

Closes #81

---

## 💻 테스트 방법 (How to Test)

```bash
# 1. 백엔드 빌드
cd backend
./gradlew build

# 2. 예약 관련 테스트만 실행
./gradlew test --tests "com.coliving.reservation.*"
