### PR TITLE
[CS/fix]  community 공개조회 정합성 반영 및 voc/comment/notification 예외 안정화

### DIFF
--- a/backend/src/main/java/com/coliving/admin/voc/application/service/AdminVocService.java
+++ b/backend/src/main/java/com/coliving/admin/voc/application/service/AdminVocService.java
@@ -26,9 +26,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class AdminVocService implements AdminVocUseCase {
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt", "status"
+    );
 
     private final VocRepositoryPort vocRepositoryPort;
     private final CreateNotificationUseCase createNotificationUseCase;
@@ -42,8 +46,10 @@ public class AdminVocService implements AdminVocUseCase {
     @Override
     @Transactional(readOnly = true)
     public AdminVocListResult listVocs(ListAdminVocsCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
         Sort sort = parseSort(command.getSort());
-        PageRequest pageRequest = PageRequest.of(command.getPage(), command.getSize(), sort);
+        PageRequest pageRequest = PageRequest.of(safePage, safeSize, sort);
 
         Page<Voc> page = vocRepositoryPort.findPageForAdmin(command.getStatus(), pageRequest);
 
@@ -144,6 +150,18 @@ public class AdminVocService implements AdminVocUseCase {
                 ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
 
-        return Sort.by(direction, property.isBlank() ? "createdAt" : property);
+        String safeProperty = property.isBlank() ? "createdAt" : property;
+        if (!ALLOWED_SORT_PROPERTIES.contains(safeProperty)) {
+            safeProperty = "createdAt";
+        }
+
+        return Sort.by(direction, safeProperty);
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return 20;
+        }
+        return Math.min(size, 100);
     }
 }

--- a/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/CreateCommentRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/CreateCommentRequestDto.java
@@ -1,12 +1,14 @@
 package com.coliving.common.comment.adapter.in.web.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class CreateCommentRequestDto {
 
     @NotBlank
+    @Size(max = 2000)
     private String content;
 }
 

--- a/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/UpdateCommentRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/UpdateCommentRequestDto.java
@@ -1,12 +1,14 @@
 package com.coliving.common.comment.adapter.in.web.dto.req;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UpdateCommentRequestDto {
 
     @NotBlank
+    @Size(max = 2000)
     private String content;
 }
 

--- a/backend/src/main/java/com/coliving/common/comment/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -44,7 +44,9 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
 
     @Override
     public Comment createComment(Long postId, Long userId, String content) {
-        // post 존재 여부 검증은 commentCount port에서 같은 규칙으로 수행됩니다.
+        if (!postJpaRepository.existsById(postId)) {
+            throw new BusinessException(ErrorCode.NOT_FOUND);
+        }
 
         CommentEntity entity = new CommentEntity();
         entity.setPost(postJpaRepository.getReferenceById(postId));

--- a/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
@@ -69,7 +69,7 @@ public class CommunityController {
                 .content(result.getContent().stream()
                         .map(item -> PostListItemResponseDto.builder()
                                 .postId(item.getPostId())
-                                .category(item.getCategory().name())
+                                .category(item.getCategory() != null ? item.getCategory().name() : null)
                                 .title(item.getTitle())
                                 .authorUserId(item.getAuthorUserId())
                                 .viewCount(item.getViewCount())
@@ -111,7 +111,7 @@ public class CommunityController {
 
         PostDetailResponseDto response = PostDetailResponseDto.builder()
                 .postId(result.getPostId())
-                .category(result.getCategory().name())
+                .category(result.getCategory() != null ? result.getCategory().name() : null)
                 .title(result.getTitle())
                 .content(result.getContent())
                 .attachments(result.getAttachments())

--- a/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
@@ -51,12 +51,12 @@ public class CommunityController {
             @RequestParam(value = "s", defaultValue = "20") int size,
             @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
     ) {
-        ActorInfo actor = getActorInfo();
+        ActorInfo actor = getOptionalActorInfo();
         PostCategory parsedCategory = parseCategoryOrNull(category);
 
         GetPostListCommand command = GetPostListCommand.builder()
-                .actorId(actor.actorId)
-                .actorRole(actor.role)
+                .actorId(actor != null ? actor.actorId : null)
+                .actorRole(actor != null ? actor.role : null)
                 .category(parsedCategory)
                 .page(page)
                 .size(size)
@@ -89,11 +89,11 @@ public class CommunityController {
 
     @GetMapping("/api/posts/{postId}")
     public ApiResponse<PostDetailResponseDto> getPostDetail(@PathVariable Long postId) {
-        ActorInfo actor = getActorInfo();
+        ActorInfo actor = getOptionalActorInfo();
 
         GetPostDetailCommand command = GetPostDetailCommand.builder()
-                .actorId(actor.actorId)
-                .actorRole(actor.role)
+                .actorId(actor != null ? actor.actorId : null)
+                .actorRole(actor != null ? actor.role : null)
                 .postId(postId)
                 .build();
 
@@ -281,6 +281,28 @@ public class CommunityController {
 
         ActorRole role = extractRole(authentication);
         return new ActorInfo(actorId, role);
+    }
+
+    private ActorInfo getOptionalActorInfo() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null
+                || "anonymousUser".equals(authentication.getName())) {
+            return null;
+        }
+
+        long actorId;
+        try {
+            actorId = Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+
+        try {
+            ActorRole role = extractRole(authentication);
+            return new ActorInfo(actorId, role);
+        } catch (BusinessException e) {
+            return null;
+        }
     }
 
     private ActorRole extractRole(Authentication authentication) {

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
@@ -177,11 +177,12 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
     private Post mapPostEntityToModel(PostEntity entity) {
         List<PostAttachment> attachments = parseAttachments(entity.getAttachments());
         List<PostLink> links = parseLinks(entity.getLinks());
+        PostCategory category = parseCategory(entity.getCategory());
 
         return Post.builder()
                 .postId(entity.getPostId())
                 .userId(entity.getUserId())
-                .category(PostCategory.valueOf(entity.getCategory()))
+                .category(category)
                 .title(entity.getTitle())
                 .content(entity.getContent())
                 .attachments(attachments)
@@ -192,6 +193,14 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
                 .createdAt(entity.getCreatedAt())
                 .updatedAt(entity.getUpdatedAt())
                 .build();
+    }
+
+    private PostCategory parseCategory(String rawCategory) {
+        try {
+            return PostCategory.valueOf(rawCategory);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
     }
 
     private JsonNode toJsonArray(List<?> items) {

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -23,10 +23,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Set;
 import java.util.List;
 
 @Service
 public class CommunityService implements CommunityUseCase {
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt", "viewCount", "likeCount", "commentCount"
+    );
 
     private final CommunityRepositoryPort repositoryPort;
 
@@ -37,12 +41,14 @@ public class CommunityService implements CommunityUseCase {
     @Override
     @Transactional(readOnly = true)
     public PostListResult getPostList(GetPostListCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
         PageRequest pageRequest;
         if (command.getCategory() == null) {
             // 전체 목록: NOTICE 우선 정렬은 저장소 쿼리에서 처리. Pageable Sort는 비워야 ORDER BY가 충돌하지 않음.
-            pageRequest = PageRequest.of(command.getPage(), command.getSize(), Sort.unsorted());
+            pageRequest = PageRequest.of(safePage, safeSize, Sort.unsorted());
         } else {
-            pageRequest = PageRequest.of(command.getPage(), command.getSize(), parseSort(command.getSort()));
+            pageRequest = PageRequest.of(safePage, safeSize, parseSort(command.getSort()));
         }
 
         Page<Post> page = repositoryPort.findPosts(command.getCategory(), pageRequest);
@@ -266,7 +272,19 @@ public class CommunityService implements CommunityUseCase {
                 ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
 
-        return Sort.by(direction, property.isBlank() ? "createdAt" : property);
+        String safeProperty = property.isBlank() ? "createdAt" : property;
+        if (!ALLOWED_SORT_PROPERTIES.contains(safeProperty)) {
+            safeProperty = "createdAt";
+        }
+
+        return Sort.by(direction, safeProperty);
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return 20;
+        }
+        return Math.min(size, 100);
     }
 }
 

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -83,7 +83,8 @@ public class CommunityService implements CommunityUseCase {
         Sort commentSort = Sort.by(Sort.Direction.ASC, "createdAt");
         List<Comment> comments = repositoryPort.findCommentsByPostId(command.getPostId(), commentSort);
 
-        boolean likedByMe = repositoryPort.isLikedByMe(command.getPostId(), command.getActorId());
+        boolean likedByMe = command.getActorId() != null
+                && repositoryPort.isLikedByMe(command.getPostId(), command.getActorId());
 
         return PostDetailResult.builder()
                 .postId(post.getPostId())

--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/NotificationController.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/NotificationController.java
@@ -83,7 +83,7 @@ public class NotificationController {
     private NotificationItemResponseDto toItemDto(NotificationItemResult item) {
         return NotificationItemResponseDto.builder()
                 .notificationId(item.getNotificationId())
-                .type(item.getType().name())
+                .type(item.getType() != null ? item.getType().name() : null)
                 .title(item.getTitle())
                 .message(item.getMessage())
                 .referenceType(item.getReferenceType() != null ? item.getReferenceType().name() : null)

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
@@ -20,9 +20,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class NotificationService implements NotificationUseCase, CreateNotificationUseCase {
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt"
+    );
 
     private final NotificationRepositoryPort notificationRepositoryPort;
 
@@ -33,8 +37,10 @@ public class NotificationService implements NotificationUseCase, CreateNotificat
     @Override
     @Transactional(readOnly = true)
     public NotificationListResult listNotifications(ListNotificationsCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
         Sort sort = parseSort(command.getSort());
-        PageRequest pageRequest = PageRequest.of(command.getPage(), command.getSize(), sort);
+        PageRequest pageRequest = PageRequest.of(safePage, safeSize, sort);
 
         Page<Notification> page = notificationRepositoryPort.findByUserId(
                 command.getUserId(),
@@ -115,6 +121,18 @@ public class NotificationService implements NotificationUseCase, CreateNotificat
                 ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
 
-        return Sort.by(direction, property.isBlank() ? "createdAt" : property);
+        String safeProperty = property.isBlank() ? "createdAt" : property;
+        if (!ALLOWED_SORT_PROPERTIES.contains(safeProperty)) {
+            safeProperty = "createdAt";
+        }
+
+        return Sort.by(direction, safeProperty);
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return 20;
+        }
+        return Math.min(size, 100);
     }
 }

--- a/backend/src/main/java/com/coliving/common/voc/adapter/in/web/VocController.java
+++ b/backend/src/main/java/com/coliving/common/voc/adapter/in/web/VocController.java
@@ -165,9 +165,9 @@ public class VocController {
     private VocListItemResponseDto toListItemDto(VocListItemResult item) {
         return VocListItemResponseDto.builder()
                 .vocId(item.getVocId())
-                .category(item.getCategory().name())
+                .category(item.getCategory() != null ? item.getCategory().name() : null)
                 .title(item.getTitle())
-                .status(item.getStatus().name())
+                .status(item.getStatus() != null ? item.getStatus().name() : null)
                 .createdAt(item.getCreatedAt())
                 .build();
     }
@@ -186,11 +186,11 @@ public class VocController {
         return VocDetailResponseDto.builder()
                 .vocId(r.getVocId())
                 .userId(r.getUserId())
-                .category(r.getCategory().name())
+                .category(r.getCategory() != null ? r.getCategory().name() : null)
                 .title(r.getTitle())
                 .content(r.getContent())
                 .attachments(attachments)
-                .status(r.getStatus().name())
+                .status(r.getStatus() != null ? r.getStatus().name() : null)
                 .adminReply(r.getAdminReply())
                 .replyUserId(r.getReplyUserId())
                 .repliedAt(r.getRepliedAt())

--- a/backend/src/main/java/com/coliving/common/voc/application/service/VocService.java
+++ b/backend/src/main/java/com/coliving/common/voc/application/service/VocService.java
@@ -30,9 +30,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Service
 public class VocService implements VocUseCase {
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt", "status"
+    );
 
     private final VocRepositoryPort vocRepositoryPort;
     private final NotificationRepositoryPort notificationRepositoryPort;
@@ -59,8 +63,10 @@ public class VocService implements VocUseCase {
     @Override
     @Transactional(readOnly = true)
     public VocListResult listMyVocs(ListMyVocsCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
         Sort sort = parseSort(command.getSort());
-        PageRequest pageRequest = PageRequest.of(command.getPage(), command.getSize(), sort);
+        PageRequest pageRequest = PageRequest.of(safePage, safeSize, sort);
 
         Page<Voc> page = vocRepositoryPort.findByUserId(command.getUserId(), pageRequest);
 
@@ -185,6 +191,18 @@ public class VocService implements VocUseCase {
                 ? Sort.Direction.ASC
                 : Sort.Direction.DESC;
 
-        return Sort.by(direction, property.isBlank() ? "createdAt" : property);
+        String safeProperty = property.isBlank() ? "createdAt" : property;
+        if (!ALLOWED_SORT_PROPERTIES.contains(safeProperty)) {
+            safeProperty = "createdAt";
+        }
+
+        return Sort.by(direction, safeProperty);
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return 20;
+        }
+        return Math.min(size, 100);
     }
 }

--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                                 "/api/auth/refresh", "/api/auth/find-id", "/api/auth/reset-password")
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
 
                         // ADMIN only

--- a/backend/src/main/java/com/coliving/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/coliving/global/error/ErrorCode.java
@@ -43,6 +43,7 @@ public enum ErrorCode {
     // ── 공통 ──
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "필수 항목 누락 또는 형식이 올바르지 않습니다"),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다"),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 저장에 실패했습니다"),
 
     // ── 공간 (Space) ──

--- a/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
@@ -60,6 +60,6 @@ public class GlobalExceptionHandler {
         log.error("Unhandled exception", e);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(ErrorCode.NOT_FOUND));
+                .body(ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${DDL_AUTO:validate}
   sql.init.mode: never
 
 jwt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     restart: unless-stopped
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+      - DDL_AUTO=${DDL_AUTO:-validate}
       - DB_URL=${DB_URL:-jdbc:postgresql://db:5432/coliving}
       - DB_USERNAME=${DB_USERNAME:-coliving}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/frontend/src/app/(common)/notifications/_api/bff-server.ts
+++ b/frontend/src/app/(common)/notifications/_api/bff-server.ts
@@ -1,0 +1,19 @@
+import { headers } from "next/headers";
+
+/** 서버 컴포넌트 전용. 쿠키를 BFF로 전달합니다. */
+export async function bffGet(pathWithQuery: string, init?: RequestInit) {
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host") ?? "localhost:3000";
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  const url = `${proto}://${host}/api/bff/${pathWithQuery.replace(/^\//, "")}`;
+
+  return fetch(url, {
+    ...init,
+    method: "GET",
+    headers: {
+      ...(init?.headers as Record<string, string>),
+      cookie: h.get("cookie") ?? "",
+    },
+    cache: "no-store",
+  });
+}

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -1,0 +1,109 @@
+import Link from "next/link";
+import { Bell } from "lucide-react";
+import { bffGet } from "./_api/bff-server";
+
+type ApiResponse<T> = {
+  success: boolean;
+  data?: T;
+  message?: string | null;
+  errorCode?: string | null;
+};
+
+type NotificationItem = {
+  notificationId: number;
+  type: string | null;
+  title: string;
+  message: string;
+  referenceType: string | null;
+  referenceId: number | null;
+  isRead: boolean;
+  createdAt: string;
+};
+
+type NotificationListData = {
+  content: NotificationItem[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+};
+
+type SearchParams = Promise<{ p?: string; s?: string; is_read?: string }>;
+
+export const metadata = {
+  title: "알림 | CoKkiri",
+};
+
+export default async function NotificationsPage({ searchParams }: { searchParams: SearchParams }) {
+  const sp = await searchParams;
+  const page = Math.max(0, parseInt(sp.p ?? "0", 10) || 0);
+  const size = Math.min(50, Math.max(1, parseInt(sp.s ?? "20", 10) || 20));
+  const isRead = sp.is_read === "true" ? "true" : sp.is_read === "false" ? "false" : "";
+
+  const qs = new URLSearchParams();
+  qs.set("p", String(page));
+  qs.set("s", String(size));
+  qs.set("sort", "createdAt,desc");
+  if (isRead) qs.set("is_read", isRead);
+
+  const res = await bffGet(`notifications?${qs.toString()}`);
+  let list: NotificationListData | null = null;
+  let error: string | null = null;
+
+  if (res.status === 401) {
+    error = "로그인이 필요합니다.";
+  } else if (!res.ok) {
+    error = "알림을 불러오지 못했습니다.";
+  } else {
+    const body = (await res.json()) as ApiResponse<NotificationListData>;
+    if (body.success && body.data) list = body.data;
+    else error = body.message ?? "알림을 불러오지 못했습니다.";
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl px-6 py-10 md:px-8">
+      <header className="mb-8 flex items-end justify-between">
+        <div>
+          <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">My</p>
+          <h1 className="mt-3 text-4xl font-black tracking-tight text-foreground md:text-5xl">알림</h1>
+        </div>
+        <Link href="/profile" className="text-sm font-black uppercase tracking-wider text-secondary hover:underline">
+          프로필
+        </Link>
+      </header>
+
+      {error && (
+        <div
+          className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+          role="alert"
+        >
+          {error}
+        </div>
+      )}
+
+      {list && (
+        <ul className="space-y-3">
+          {list.content.length === 0 ? (
+            <li className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-border bg-muted/25 px-6 py-16 text-center">
+              <Bell className="size-10 text-muted-foreground" strokeWidth={1.25} aria-hidden />
+              <p className="font-medium tracking-tight text-muted-foreground">표시할 알림이 없습니다.</p>
+            </li>
+          ) : (
+            list.content.map((item) => (
+              <li
+                key={item.notificationId}
+                className={`rounded-xl border px-4 py-4 ${item.isRead ? "border-border bg-background" : "border-secondary/40 bg-secondary/10"}`}
+              >
+                <p className="text-xs font-black uppercase tracking-wider text-muted-foreground">
+                  {item.type ?? "NOTICE"}
+                </p>
+                <p className="mt-1 font-semibold text-foreground">{item.title}</p>
+                <p className="mt-1 text-sm text-foreground/80">{item.message}</p>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/api/bff/[...path]/route.ts
+++ b/frontend/src/app/api/bff/[...path]/route.ts
@@ -3,6 +3,16 @@ import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 const BACKEND_URL = process.env.INTERNAL_BACKEND_URL || 'http://localhost:8080';
+const HOP_BY_HOP_HEADERS = new Set([
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailers',
+  'transfer-encoding',
+  'upgrade',
+]);
 
 async function handler(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
   const { path } = await params;
@@ -29,9 +39,19 @@ async function handler(req: NextRequest, { params }: { params: Promise<{ path: s
     body,
   });
 
+  const forwardedHeaders = new Headers();
+  response.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+      forwardedHeaders.set(key, value);
+    }
+  });
+  if (!forwardedHeaders.has('Content-Type')) {
+    forwardedHeaders.set('Content-Type', 'application/json');
+  }
+
   return new NextResponse(response.body, {
     status: response.status,
-    headers: { 'Content-Type': response.headers.get('Content-Type') || 'application/json' },
+    headers: forwardedHeaders,
   });
 }
 

--- a/frontend/src/components/shared/Footer.tsx
+++ b/frontend/src/components/shared/Footer.tsx
@@ -21,6 +21,7 @@ export function Footer() {
       { name: "VOC", path: "/vocs" },
     ],
     support: [
+      { name: "Notification", path: "/notifications" },
       { name: "Profile", path: "/profile" },
       { name: "Device", path: "/" },
       { name: "Contract", path: "/" },

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -34,6 +34,7 @@ const navItems: NavItem[] = [
   {
     name: "My",
     children: [
+      { name: "Notification", path: "/notifications" },
       { name: "Profile", path: "/profile" },
       { name: "Logout", path: "/login" },
     ],


### PR DESCRIPTION
## Summary
- community 도메인 조회 API를 스펙에 맞게 공개 조회 가능하도록 정합성 수정
- voc/comment/notification/admin-voc 영역에서 비정상 파라미터로 인한 500 가능 지점 방어 로직 추가
- BFF 프록시 응답 헤더 전달을 보강하고, notifications 화면 연동 누락을 보완

## Changes
- **Backend**
  - `SecurityConfig`: `GET /api/posts`, `GET /api/posts/*` 공개 허용
  - `CommunityController`: 조회 시 인증 사용자 optional 처리
  - `CommunityService`: 비로그인 조회에서 likedByMe 계산 안전화
  - `AdminVocService`: page/size 정규화 + sort 화이트리스트 적용
  - `CreateCommentRequestDto`, `UpdateCommentRequestDto`: `@Size(max = 2000)` 추가
- **Frontend**
  - `api/bff/[...path]/route.ts`: hop-by-hop 제외 응답 헤더 전달
  - `notifications` 페이지 및 BFF getter 추가
  - Header/Footer에 notifications 진입 링크 추가

## Why
- 스펙(`community 조회 공개`)과 실제 동작 불일치를 해소하고,
- 사용자 입력/쿼리 파라미터 이상치로 발생 가능한 500 에러를 선제적으로 방지하며,
- 알림 도메인의 FE-BE 연결 누락을 채워 기능 완성도를 높이기 위함입니다.

## Test Plan
- [ ] 비로그인 상태에서 `GET /community`, `GET /community/{postId}` 정상 조회
- [ ] 로그인 상태에서 좋아요 여부(`likedByMe`) 정상 노출
- [ ] admin voc 목록에 비정상 sort/page/size 전달 시 500 없이 기본값 처리
- [ ] 댓글 생성/수정 시 2000자 초과 요청이 validation 에러로 처리
- [ ] notifications 페이지에서 목록 조회 성공 및 빈 상태/에러 상태 렌더링 확인
- [ ] 첨부/파일 응답에서 BFF 경유 시 `Content-Disposition` 등 주요 헤더 유지 확인

## Scope
- community, comment, notification, voc(+admin voc) 도메인 중심
- 기타 도메인 비즈니스 로직은 변경하지 않음