### PR TITLE
🐛 stabilize BFF proxy error handling and header forwarding

### DIFF
--- a/frontend/src/app/api/bff/[...path]/route.ts
+++ b/frontend/src/app/api/bff/[...path]/route.ts
@@ -13,46 +13,75 @@ const HOP_BY_HOP_HEADERS = new Set([
   'transfer-encoding',
   'upgrade',
 ]);
+const UNSAFE_FORWARD_HEADERS = new Set([
+  // NextResponse streams body itself; forwarding upstream length/encoding can cause mismatch.
+  'content-length',
+  'content-encoding',
+]);
+const RESPONSE_HEADER_WHITELIST = new Set([
+  'content-type',
+  'content-disposition',
+  'cache-control',
+  'etag',
+  'last-modified',
+]);
 
 async function handler(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
-  const { path } = await params;
-  const backendPath = `/api/${path.join('/')}`;
-  const url = `${BACKEND_URL}${backendPath}${req.nextUrl.search}`;
+  try {
+    const { path } = await params;
+    const backendPath = `/api/${path.join('/')}`;
+    const url = `${BACKEND_URL}${backendPath}${req.nextUrl.search}`;
 
-  // httpOnly 쿠키에서 JWT 추출
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('access_token')?.value;
+    // httpOnly 쿠키에서 JWT 추출
+    const cookieStore = await cookies();
+    const accessToken = cookieStore.get('access_token')?.value;
 
-  const headers: HeadersInit = {};
-  const contentType = req.headers.get('Content-Type');
-  if (contentType) headers['Content-Type'] = contentType;
-  if (accessToken) {
-    headers['Authorization'] = `Bearer ${accessToken}`;
-  }
-
-  const body =
-    ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer();
-
-  const response = await fetch(url, {
-    method: req.method,
-    headers,
-    body,
-  });
-
-  const forwardedHeaders = new Headers();
-  response.headers.forEach((value, key) => {
-    if (!HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
-      forwardedHeaders.set(key, value);
+    const headers: HeadersInit = {};
+    const contentType = req.headers.get('Content-Type');
+    if (contentType) headers['Content-Type'] = contentType;
+    if (accessToken) {
+      headers['Authorization'] = `Bearer ${accessToken}`;
     }
-  });
-  if (!forwardedHeaders.has('Content-Type')) {
-    forwardedHeaders.set('Content-Type', 'application/json');
-  }
 
-  return new NextResponse(response.body, {
-    status: response.status,
-    headers: forwardedHeaders,
-  });
+    const body =
+      ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer();
+
+    const response = await fetch(url, {
+      method: req.method,
+      headers,
+      body,
+    });
+
+    const forwardedHeaders = new Headers();
+    response.headers.forEach((value, key) => {
+      const lower = key.toLowerCase();
+      if (
+        RESPONSE_HEADER_WHITELIST.has(lower) &&
+        !HOP_BY_HOP_HEADERS.has(lower) &&
+        !UNSAFE_FORWARD_HEADERS.has(lower)
+      ) {
+        forwardedHeaders.set(key, value);
+      }
+    });
+    if (!forwardedHeaders.has('Content-Type')) {
+      forwardedHeaders.set('Content-Type', 'application/json');
+    }
+
+    return new NextResponse(response.body, {
+      status: response.status,
+      headers: forwardedHeaders,
+    });
+  } catch (error) {
+    console.error('[BFF] proxy failed:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'BFF 프록시 처리 중 오류가 발생했습니다.',
+        errorCode: 'BFF_PROXY_ERROR',
+      },
+      { status: 502 },
+    );
+  }
 }
 
 export const GET = handler;


### PR DESCRIPTION
## Summary
- BFF 프록시(`/api/bff/[...path]`)에서 간헐적으로 500이 발생하던 구간을 안정화했습니다.
- 응답 헤더 전달 정책을 안전한 화이트리스트 기반으로 정리해 스트림/헤더 불일치 가능성을 줄였습니다.
- 프록시 실패 시 명시적인 502 응답(`BFF_PROXY_ERROR`)을 반환해 원인 추적성을 높였습니다.

## Changes
- `frontend/src/app/api/bff/[...path]/route.ts`
  - 프록시 본문을 `try/catch`로 감싸 BFF 내부 예외를 처리
  - 실패 시 JSON 형식의 표준 에러 응답 반환
    - `status: 502`
    - `errorCode: BFF_PROXY_ERROR`
  - 응답 헤더 전달을 화이트리스트로 제한
    - 허용: `content-type`, `content-disposition`, `cache-control`, `etag`, `last-modified`
    - 제외: `content-length`, `content-encoding`, hop-by-hop 헤더

## Why
- 기존에는 BFF에서 상위 응답 헤더를 폭넓게 전달하면서 스트리밍 응답과 충돌 가능성이 있었고, 내부 예외가 500으로만 보여 원인 파악이 어려웠습니다.
- 이번 수정으로 BFF 계층 오류와 백엔드 오류를 분리해서 관측할 수 있습니다.

## Test Plan
- [ ] 프론트에서 `POST /api/bff/posts` 요청 시 기존 500 재현 여부 확인
- [ ] 프록시 실패 시 응답이 `502` + `BFF_PROXY_ERROR`로 내려오는지 확인
- [ ] 첨부 파일/JSON 응답에서 `Content-Type`, `Content-Disposition`이 정상 전달되는지 확인
- [ ] `docker compose logs frontend`에서 `[BFF] proxy failed:` 로그 확인 가능 여부 점검