### PR TITLE
🐛 remove duplicate bff rewrite to prevent localhost proxy lock

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,15 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // BFF: /api/bff/* 요청을 백엔드로 프록시 (개발 환경용)
-  async rewrites() {
-    return [
-      {
-        source: '/api/bff/:path*',
-        destination: `${process.env.INTERNAL_BACKEND_URL || 'http://localhost:8080'}/api/:path*`,
-      },
-    ];
-  },
+  // NOTE:
+  // /api/bff/*는 App Router Route Handler(src/app/api/bff/[...path]/route.ts)에서 프록시한다.
+  // rewrites로 동일 경로를 다시 프록시하면 배포 빌드 시점 값(localhost)으로 고정되어
+  // 컨테이너 환경에서 ECONNREFUSED를 유발할 수 있어 제거한다.
 
   // 이미지 도메인 허용 (Space 이미지 등)
   images: {


### PR DESCRIPTION
## Summary
- 배포 환경에서 `/api/bff/*` 요청이 `localhost:8080`으로 고정 프록시되며 `ECONNREFUSED`가 발생하던 문제를 수정했습니다.
- `next.config.ts`의 `/api/bff/*` rewrite를 제거하고, App Router BFF route handler만 단일 진입점으로 사용하도록 정리했습니다.

## Problem
- 프론트 컨테이너 로그에서 다음 오류가 반복 발생:
  - `Failed to proxy http://localhost:8080/...`
  - `ECONNREFUSED`
- 원인: `/api/bff/*`가
  1) `next.config.ts rewrites`와
  2) `src/app/api/bff/[...path]/route.ts`
  두 경로로 중복 처리되고 있었음.
- rewrites destination이 빌드 시점 값으로 고정되어 런타임 환경변수(`INTERNAL_BACKEND_URL=http://backend:8080`)와 불일치 가능.

## Changes
- `frontend/next.config.ts`
  - `/api/bff/:path*` rewrite 제거
  - BFF는 `src/app/api/bff/[...path]/route.ts`에서만 처리하도록 주석/의도 명시

## Why this fix
- 컨테이너 배포에서는 `localhost`가 자기 자신을 가리켜 백엔드 연결이 실패합니다.
- BFF 프록시 경로를 단일화하면 빌드 시점/런타임 환경변수 불일치에 의한 프록시 오류를 방지할 수 있습니다.

## Test Plan
- [ ] `docker compose up -d --build frontend`
- [ ] `docker compose logs -f frontend`에서 `Failed to proxy http://localhost:8080/...` 미발생 확인
- [ ] `/community`, `/vocs`, `/notifications` 진입 시 BFF 호출 정상 응답 확인
- [ ] 게시글 등록(`POST /api/bff/posts`) 성공 여부 확인