### PR TITLE
[CS/feat] 관리자 커뮤니티 관리 기능 및 상세 화면 보완

### DIFF
--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/AdminCommunityController.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/AdminCommunityController.java
@@ -27,9 +27,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
 @RestController
 @RequestMapping("/api/admin")
 public class AdminCommunityController {
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
     private final AdminCommunityUseCase adminCommunityUseCase;
 
     public AdminCommunityController(AdminCommunityUseCase adminCommunityUseCase) {
@@ -41,14 +47,20 @@ public class AdminCommunityController {
             @RequestParam(required = false) String category,
             @RequestParam(value = "author_user_id", required = false) Long authorUserId,
             @RequestParam(required = false) String keyword,
+            @RequestParam(value = "created_from", required = false) LocalDate createdFrom,
+            @RequestParam(value = "created_to", required = false) LocalDate createdTo,
             @RequestParam(value = "p", defaultValue = "0") int page,
             @RequestParam(value = "s", defaultValue = "20") int size,
             @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
     ) {
+        OffsetDateTime fromAt = toStartOfDay(createdFrom);
+        OffsetDateTime toAt = toEndOfDay(createdTo);
         AdminPostListResult result = adminCommunityUseCase.listPosts(ListAdminPostsCommand.builder()
                 .category(category)
                 .authorUserId(authorUserId)
                 .keyword(keyword)
+                .createdFrom(fromAt)
+                .createdTo(toAt)
                 .page(page)
                 .size(size)
                 .sort(sort)
@@ -81,13 +93,19 @@ public class AdminCommunityController {
     public ApiResponse<AdminCommentListResponseDto> listComments(
             @RequestParam(value = "post_id", required = false) Long postId,
             @RequestParam(value = "author_user_id", required = false) Long authorUserId,
+            @RequestParam(value = "created_from", required = false) LocalDate createdFrom,
+            @RequestParam(value = "created_to", required = false) LocalDate createdTo,
             @RequestParam(value = "p", defaultValue = "0") int page,
             @RequestParam(value = "s", defaultValue = "20") int size,
             @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
     ) {
+        OffsetDateTime fromAt = toStartOfDay(createdFrom);
+        OffsetDateTime toAt = toEndOfDay(createdTo);
         AdminCommentListResult result = adminCommunityUseCase.listComments(ListAdminCommentsCommand.builder()
                 .postId(postId)
                 .authorUserId(authorUserId)
+                .createdFrom(fromAt)
+                .createdTo(toAt)
                 .page(page)
                 .size(size)
                 .sort(sort)
@@ -169,5 +187,19 @@ public class AdminCommunityController {
                 .createdAt(r.getCreatedAt())
                 .updatedAt(r.getUpdatedAt())
                 .build();
+    }
+
+    private OffsetDateTime toStartOfDay(LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+        return date.atStartOfDay(DEFAULT_ZONE).toOffsetDateTime();
+    }
+
+    private OffsetDateTime toEndOfDay(LocalDate date) {
+        if (date == null) {
+            return null;
+        }
+        return date.plusDays(1).atStartOfDay(DEFAULT_ZONE).minusNanos(1).toOffsetDateTime();
     }
 }

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/AdminCommunityController.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/AdminCommunityController.java
@@ -1,0 +1,173 @@
+package com.coliving.admin.community.adapter.in.web;
+
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminCommentDetailResponseDto;
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminCommentListItemResponseDto;
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminCommentListResponseDto;
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminPostDetailResponseDto;
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminPostListItemResponseDto;
+import com.coliving.admin.community.adapter.in.web.dto.res.AdminPostListResponseDto;
+import com.coliving.admin.community.application.command.DeleteAdminCommentCommand;
+import com.coliving.admin.community.application.command.DeleteAdminPostCommand;
+import com.coliving.admin.community.application.command.GetAdminCommentDetailCommand;
+import com.coliving.admin.community.application.command.GetAdminPostDetailCommand;
+import com.coliving.admin.community.application.command.ListAdminCommentsCommand;
+import com.coliving.admin.community.application.command.ListAdminPostsCommand;
+import com.coliving.admin.community.application.port.in.AdminCommunityUseCase;
+import com.coliving.admin.community.application.result.AdminCommentDetailResult;
+import com.coliving.admin.community.application.result.AdminCommentListItemResult;
+import com.coliving.admin.community.application.result.AdminCommentListResult;
+import com.coliving.admin.community.application.result.AdminPostDetailResult;
+import com.coliving.admin.community.application.result.AdminPostListItemResult;
+import com.coliving.admin.community.application.result.AdminPostListResult;
+import com.coliving.global.dto.ApiResponse;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminCommunityController {
+    private final AdminCommunityUseCase adminCommunityUseCase;
+
+    public AdminCommunityController(AdminCommunityUseCase adminCommunityUseCase) {
+        this.adminCommunityUseCase = adminCommunityUseCase;
+    }
+
+    @GetMapping("/posts")
+    public ApiResponse<AdminPostListResponseDto> listPosts(
+            @RequestParam(required = false) String category,
+            @RequestParam(value = "author_user_id", required = false) Long authorUserId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(value = "p", defaultValue = "0") int page,
+            @RequestParam(value = "s", defaultValue = "20") int size,
+            @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
+    ) {
+        AdminPostListResult result = adminCommunityUseCase.listPosts(ListAdminPostsCommand.builder()
+                .category(category)
+                .authorUserId(authorUserId)
+                .keyword(keyword)
+                .page(page)
+                .size(size)
+                .sort(sort)
+                .build());
+
+        return ApiResponse.ok(AdminPostListResponseDto.builder()
+                .content(result.getContent().stream().map(this::toPostListItemDto).toList())
+                .page(result.getPage())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .build());
+    }
+
+    @GetMapping("/posts/{postId}")
+    public ApiResponse<AdminPostDetailResponseDto> getPostDetail(@PathVariable Long postId) {
+        AdminPostDetailResult result = adminCommunityUseCase.getPostDetail(GetAdminPostDetailCommand.builder()
+                .postId(postId)
+                .build());
+        return ApiResponse.ok(toPostDetailDto(result));
+    }
+
+    @DeleteMapping("/posts/{postId}")
+    public ApiResponse<Void> deletePost(@PathVariable Long postId) {
+        adminCommunityUseCase.deletePost(DeleteAdminPostCommand.builder().postId(postId).build());
+        return ApiResponse.ok(null, "게시글이 삭제되었습니다.");
+    }
+
+    @GetMapping("/comments")
+    public ApiResponse<AdminCommentListResponseDto> listComments(
+            @RequestParam(value = "post_id", required = false) Long postId,
+            @RequestParam(value = "author_user_id", required = false) Long authorUserId,
+            @RequestParam(value = "p", defaultValue = "0") int page,
+            @RequestParam(value = "s", defaultValue = "20") int size,
+            @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
+    ) {
+        AdminCommentListResult result = adminCommunityUseCase.listComments(ListAdminCommentsCommand.builder()
+                .postId(postId)
+                .authorUserId(authorUserId)
+                .page(page)
+                .size(size)
+                .sort(sort)
+                .build());
+
+        return ApiResponse.ok(AdminCommentListResponseDto.builder()
+                .content(result.getContent().stream().map(this::toCommentListItemDto).toList())
+                .page(result.getPage())
+                .size(result.getSize())
+                .totalElements(result.getTotalElements())
+                .totalPages(result.getTotalPages())
+                .build());
+    }
+
+    @GetMapping("/comments/{commentId}")
+    public ApiResponse<AdminCommentDetailResponseDto> getCommentDetail(@PathVariable Long commentId) {
+        AdminCommentDetailResult result = adminCommunityUseCase.getCommentDetail(GetAdminCommentDetailCommand.builder()
+                .commentId(commentId)
+                .build());
+        return ApiResponse.ok(toCommentDetailDto(result));
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ApiResponse<Void> deleteComment(@PathVariable Long commentId) {
+        adminCommunityUseCase.deleteComment(DeleteAdminCommentCommand.builder().commentId(commentId).build());
+        return ApiResponse.ok(null, "댓글이 삭제되었습니다.");
+    }
+
+    private AdminPostListItemResponseDto toPostListItemDto(AdminPostListItemResult r) {
+        return AdminPostListItemResponseDto.builder()
+                .postId(r.getPostId())
+                .category(r.getCategory())
+                .title(r.getTitle())
+                .authorUserId(r.getAuthorUserId())
+                .viewCount(r.getViewCount())
+                .likeCount(r.getLikeCount())
+                .commentCount(r.getCommentCount())
+                .createdAt(r.getCreatedAt())
+                .updatedAt(r.getUpdatedAt())
+                .build();
+    }
+
+    private AdminPostDetailResponseDto toPostDetailDto(AdminPostDetailResult r) {
+        return AdminPostDetailResponseDto.builder()
+                .postId(r.getPostId())
+                .category(r.getCategory())
+                .title(r.getTitle())
+                .content(r.getContent())
+                .authorUserId(r.getAuthorUserId())
+                .attachments(r.getAttachments())
+                .links(r.getLinks())
+                .viewCount(r.getViewCount())
+                .likeCount(r.getLikeCount())
+                .commentCount(r.getCommentCount())
+                .createdAt(r.getCreatedAt())
+                .updatedAt(r.getUpdatedAt())
+                .build();
+    }
+
+    private AdminCommentListItemResponseDto toCommentListItemDto(AdminCommentListItemResult r) {
+        return AdminCommentListItemResponseDto.builder()
+                .commentId(r.getCommentId())
+                .postId(r.getPostId())
+                .postTitle(r.getPostTitle())
+                .authorUserId(r.getAuthorUserId())
+                .content(r.getContent())
+                .createdAt(r.getCreatedAt())
+                .updatedAt(r.getUpdatedAt())
+                .build();
+    }
+
+    private AdminCommentDetailResponseDto toCommentDetailDto(AdminCommentDetailResult r) {
+        return AdminCommentDetailResponseDto.builder()
+                .commentId(r.getCommentId())
+                .postId(r.getPostId())
+                .postTitle(r.getPostTitle())
+                .authorUserId(r.getAuthorUserId())
+                .content(r.getContent())
+                .createdAt(r.getCreatedAt())
+                .updatedAt(r.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentDetailResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentDetailResponseDto.java
@@ -1,0 +1,18 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminCommentDetailResponseDto {
+    private final Long commentId;
+    private final Long postId;
+    private final String postTitle;
+    private final Long authorUserId;
+    private final String content;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentListItemResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentListItemResponseDto.java
@@ -1,0 +1,18 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminCommentListItemResponseDto {
+    private final Long commentId;
+    private final Long postId;
+    private final String postTitle;
+    private final Long authorUserId;
+    private final String content;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentListResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminCommentListResponseDto.java
@@ -1,0 +1,16 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminCommentListResponseDto {
+    private final List<AdminCommentListItemResponseDto> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostDetailResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import com.coliving.common.community.model.PostAttachment;
+import com.coliving.common.community.model.PostLink;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminPostDetailResponseDto {
+    private final Long postId;
+    private final String category;
+    private final String title;
+    private final String content;
+    private final Long authorUserId;
+    private final List<PostAttachment> attachments;
+    private final List<PostLink> links;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Integer commentCount;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostListItemResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostListItemResponseDto.java
@@ -1,0 +1,20 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminPostListItemResponseDto {
+    private final Long postId;
+    private final String category;
+    private final String title;
+    private final Long authorUserId;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Integer commentCount;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostListResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/in/web/dto/res/AdminPostListResponseDto.java
@@ -1,0 +1,16 @@
+package com.coliving.admin.community.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminPostListResponseDto {
+    private final List<AdminPostListItemResponseDto> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/out/persistence/AdminCommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/out/persistence/AdminCommunityPersistenceAdapter.java
@@ -1,0 +1,153 @@
+package com.coliving.admin.community.adapter.out.persistence;
+
+import com.coliving.admin.community.application.port.out.AdminCommunityRepositoryPort;
+import com.coliving.admin.community.application.result.AdminCommentDetailResult;
+import com.coliving.admin.community.application.result.AdminCommentListItemResult;
+import com.coliving.admin.community.application.result.AdminPostDetailResult;
+import com.coliving.admin.community.application.result.AdminPostListItemResult;
+import com.coliving.common.comment.adapter.out.jpa.CommentEntity;
+import com.coliving.common.comment.adapter.out.jpa.CommentJpaRepository;
+import com.coliving.common.community.adapter.out.jpa.PostEntity;
+import com.coliving.common.community.adapter.out.jpa.PostJpaRepository;
+import com.coliving.common.community.model.PostAttachment;
+import com.coliving.common.community.model.PostLink;
+import com.coliving.global.html.PlainTextHtmlSanitizer;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositoryPort {
+    private final PostJpaRepository postJpaRepository;
+    private final CommentJpaRepository commentJpaRepository;
+    private final ObjectMapper objectMapper;
+
+    public AdminCommunityPersistenceAdapter(PostJpaRepository postJpaRepository,
+                                            CommentJpaRepository commentJpaRepository,
+                                            ObjectMapper objectMapper) {
+        this.postJpaRepository = postJpaRepository;
+        this.commentJpaRepository = commentJpaRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Page<AdminPostListItemResult> findPosts(String category, Long authorUserId, String keyword, Pageable pageable) {
+        Specification<PostEntity> spec = Specification.where(null);
+        if (category != null && !category.isBlank()) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("category"), category.trim().toUpperCase()));
+        }
+        if (authorUserId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("userId"), authorUserId));
+        }
+        if (keyword != null && !keyword.isBlank()) {
+            String pattern = "%" + keyword.trim().toLowerCase() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(cb.lower(root.get("title")), pattern),
+                    cb.like(cb.lower(root.get("content")), pattern)
+            ));
+        }
+
+        return postJpaRepository.findAll(spec, pageable).map(this::toPostListItem);
+    }
+
+    @Override
+    public Optional<AdminPostDetailResult> findPostDetail(Long postId) {
+        return postJpaRepository.findById(postId).map(this::toPostDetail);
+    }
+
+    @Override
+    public Page<AdminCommentListItemResult> findComments(Long postId, Long authorUserId, Pageable pageable) {
+        Specification<CommentEntity> spec = Specification.where(null);
+        if (postId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("post").get("postId"), postId));
+        }
+        if (authorUserId != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("userId"), authorUserId));
+        }
+        return commentJpaRepository.findAll(spec, pageable).map(this::toCommentListItem);
+    }
+
+    @Override
+    public Optional<AdminCommentDetailResult> findCommentDetail(Long commentId) {
+        return commentJpaRepository.findById(commentId).map(this::toCommentDetail);
+    }
+
+    private AdminPostListItemResult toPostListItem(PostEntity entity) {
+        return AdminPostListItemResult.builder()
+                .postId(entity.getPostId())
+                .category(entity.getCategory())
+                .title(PlainTextHtmlSanitizer.sanitizeTitle(entity.getTitle()))
+                .authorUserId(entity.getUserId())
+                .viewCount(entity.getViewCount())
+                .likeCount(entity.getLikeCount())
+                .commentCount(entity.getCommentCount())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    private AdminPostDetailResult toPostDetail(PostEntity entity) {
+        return AdminPostDetailResult.builder()
+                .postId(entity.getPostId())
+                .category(entity.getCategory())
+                .title(PlainTextHtmlSanitizer.sanitizeTitle(entity.getTitle()))
+                .content(entity.getContent())
+                .authorUserId(entity.getUserId())
+                .attachments(parseAttachments(entity))
+                .links(parseLinks(entity))
+                .viewCount(entity.getViewCount())
+                .likeCount(entity.getLikeCount())
+                .commentCount(entity.getCommentCount())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    private AdminCommentListItemResult toCommentListItem(CommentEntity entity) {
+        return AdminCommentListItemResult.builder()
+                .commentId(entity.getCommentId())
+                .postId(entity.getPostId())
+                .postTitle(entity.getPost() == null ? "" : PlainTextHtmlSanitizer.sanitizeTitle(entity.getPost().getTitle()))
+                .authorUserId(entity.getUserId())
+                .content(PlainTextHtmlSanitizer.stripToPlain(entity.getContent()))
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    private AdminCommentDetailResult toCommentDetail(CommentEntity entity) {
+        return AdminCommentDetailResult.builder()
+                .commentId(entity.getCommentId())
+                .postId(entity.getPostId())
+                .postTitle(entity.getPost() == null ? "" : PlainTextHtmlSanitizer.sanitizeTitle(entity.getPost().getTitle()))
+                .authorUserId(entity.getUserId())
+                .content(entity.getContent())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+
+    private List<PostAttachment> parseAttachments(PostEntity entity) {
+        try {
+            return objectMapper.convertValue(entity.getAttachments(), new TypeReference<>() {
+            });
+        } catch (IllegalArgumentException e) {
+            return List.of();
+        }
+    }
+
+    private List<PostLink> parseLinks(PostEntity entity) {
+        try {
+            return objectMapper.convertValue(entity.getLinks(), new TypeReference<>() {
+            });
+        } catch (IllegalArgumentException e) {
+            return List.of();
+        }
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/community/adapter/out/persistence/AdminCommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/community/adapter/out/persistence/AdminCommunityPersistenceAdapter.java
@@ -19,8 +19,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 
+import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Component
 public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositoryPort {
@@ -37,7 +42,12 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
     }
 
     @Override
-    public Page<AdminPostListItemResult> findPosts(String category, Long authorUserId, String keyword, Pageable pageable) {
+    public Page<AdminPostListItemResult> findPosts(String category,
+                                                   Long authorUserId,
+                                                   String keyword,
+                                                   OffsetDateTime createdFrom,
+                                                   OffsetDateTime createdTo,
+                                                   Pageable pageable) {
         Specification<PostEntity> spec = Specification.where(null);
         if (category != null && !category.isBlank()) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("category"), category.trim().toUpperCase()));
@@ -52,6 +62,12 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
                     cb.like(cb.lower(root.get("content")), pattern)
             ));
         }
+        if (createdFrom != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), createdFrom));
+        }
+        if (createdTo != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), createdTo));
+        }
 
         return postJpaRepository.findAll(spec, pageable).map(this::toPostListItem);
     }
@@ -62,7 +78,11 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
     }
 
     @Override
-    public Page<AdminCommentListItemResult> findComments(Long postId, Long authorUserId, Pageable pageable) {
+    public Page<AdminCommentListItemResult> findComments(Long postId,
+                                                         Long authorUserId,
+                                                         OffsetDateTime createdFrom,
+                                                         OffsetDateTime createdTo,
+                                                         Pageable pageable) {
         Specification<CommentEntity> spec = Specification.where(null);
         if (postId != null) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("post").get("postId"), postId));
@@ -70,7 +90,16 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
         if (authorUserId != null) {
             spec = spec.and((root, query, cb) -> cb.equal(root.get("userId"), authorUserId));
         }
-        return commentJpaRepository.findAll(spec, pageable).map(this::toCommentListItem);
+        if (createdFrom != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("createdAt"), createdFrom));
+        }
+        if (createdTo != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("createdAt"), createdTo));
+        }
+
+        Page<CommentEntity> page = commentJpaRepository.findAll(spec, pageable);
+        Map<Long, String> postTitleMap = buildPostTitleMap(page.getContent());
+        return page.map(entity -> toCommentListItem(entity, postTitleMap));
     }
 
     @Override
@@ -109,11 +138,13 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
                 .build();
     }
 
-    private AdminCommentListItemResult toCommentListItem(CommentEntity entity) {
+    private AdminCommentListItemResult toCommentListItem(CommentEntity entity, Map<Long, String> postTitleMap) {
+        Long postId = entity.getPostId();
+        String postTitle = postId == null ? "" : postTitleMap.getOrDefault(postId, "");
         return AdminCommentListItemResult.builder()
                 .commentId(entity.getCommentId())
-                .postId(entity.getPostId())
-                .postTitle(entity.getPost() == null ? "" : PlainTextHtmlSanitizer.sanitizeTitle(entity.getPost().getTitle()))
+                .postId(postId)
+                .postTitle(postTitle)
                 .authorUserId(entity.getUserId())
                 .content(PlainTextHtmlSanitizer.stripToPlain(entity.getContent()))
                 .createdAt(entity.getCreatedAt())
@@ -122,10 +153,14 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
     }
 
     private AdminCommentDetailResult toCommentDetail(CommentEntity entity) {
+        String postTitle = "";
+        if (entity.getPost() != null && entity.getPost().getTitle() != null) {
+            postTitle = PlainTextHtmlSanitizer.sanitizeTitle(entity.getPost().getTitle());
+        }
         return AdminCommentDetailResult.builder()
                 .commentId(entity.getCommentId())
                 .postId(entity.getPostId())
-                .postTitle(entity.getPost() == null ? "" : PlainTextHtmlSanitizer.sanitizeTitle(entity.getPost().getTitle()))
+                .postTitle(postTitle)
                 .authorUserId(entity.getUserId())
                 .content(entity.getContent())
                 .createdAt(entity.getCreatedAt())
@@ -149,5 +184,22 @@ public class AdminCommunityPersistenceAdapter implements AdminCommunityRepositor
         } catch (IllegalArgumentException e) {
             return List.of();
         }
+    }
+
+    private Map<Long, String> buildPostTitleMap(List<CommentEntity> comments) {
+        Set<Long> postIds = comments.stream()
+                .map(CommentEntity::getPostId)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toSet());
+        if (postIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<PostEntity> posts = postJpaRepository.findAllById(postIds);
+        Map<Long, String> map = new HashMap<>();
+        for (PostEntity post : posts) {
+            map.put(post.getPostId(), PlainTextHtmlSanitizer.sanitizeTitle(post.getTitle()));
+        }
+        return map;
     }
 }

--- a/backend/src/main/java/com/coliving/admin/community/application/command/DeleteAdminCommentCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/DeleteAdminCommentCommand.java
@@ -1,0 +1,10 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteAdminCommentCommand {
+    private final Long commentId;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/DeleteAdminPostCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/DeleteAdminPostCommand.java
@@ -1,0 +1,10 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteAdminPostCommand {
+    private final Long postId;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/GetAdminCommentDetailCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/GetAdminCommentDetailCommand.java
@@ -1,0 +1,10 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetAdminCommentDetailCommand {
+    private final Long commentId;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/GetAdminPostDetailCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/GetAdminPostDetailCommand.java
@@ -1,0 +1,10 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetAdminPostDetailCommand {
+    private final Long postId;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminCommentsCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminCommentsCommand.java
@@ -3,11 +3,15 @@ package com.coliving.admin.community.application.command;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.OffsetDateTime;
+
 @Getter
 @Builder
 public class ListAdminCommentsCommand {
     private final Long postId;
     private final Long authorUserId;
+    private final OffsetDateTime createdFrom;
+    private final OffsetDateTime createdTo;
     private final int page;
     private final int size;
     private final String sort;

--- a/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminCommentsCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminCommentsCommand.java
@@ -1,0 +1,14 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ListAdminCommentsCommand {
+    private final Long postId;
+    private final Long authorUserId;
+    private final int page;
+    private final int size;
+    private final String sort;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminPostsCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminPostsCommand.java
@@ -1,0 +1,15 @@
+package com.coliving.admin.community.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ListAdminPostsCommand {
+    private final String category;
+    private final Long authorUserId;
+    private final String keyword;
+    private final int page;
+    private final int size;
+    private final String sort;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminPostsCommand.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/command/ListAdminPostsCommand.java
@@ -3,12 +3,16 @@ package com.coliving.admin.community.application.command;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.OffsetDateTime;
+
 @Getter
 @Builder
 public class ListAdminPostsCommand {
     private final String category;
     private final Long authorUserId;
     private final String keyword;
+    private final OffsetDateTime createdFrom;
+    private final OffsetDateTime createdTo;
     private final int page;
     private final int size;
     private final String sort;

--- a/backend/src/main/java/com/coliving/admin/community/application/port/in/AdminCommunityUseCase.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/port/in/AdminCommunityUseCase.java
@@ -1,0 +1,26 @@
+package com.coliving.admin.community.application.port.in;
+
+import com.coliving.admin.community.application.command.DeleteAdminCommentCommand;
+import com.coliving.admin.community.application.command.DeleteAdminPostCommand;
+import com.coliving.admin.community.application.command.GetAdminCommentDetailCommand;
+import com.coliving.admin.community.application.command.GetAdminPostDetailCommand;
+import com.coliving.admin.community.application.command.ListAdminCommentsCommand;
+import com.coliving.admin.community.application.command.ListAdminPostsCommand;
+import com.coliving.admin.community.application.result.AdminCommentDetailResult;
+import com.coliving.admin.community.application.result.AdminCommentListResult;
+import com.coliving.admin.community.application.result.AdminPostDetailResult;
+import com.coliving.admin.community.application.result.AdminPostListResult;
+
+public interface AdminCommunityUseCase {
+    AdminPostListResult listPosts(ListAdminPostsCommand command);
+
+    AdminPostDetailResult getPostDetail(GetAdminPostDetailCommand command);
+
+    void deletePost(DeleteAdminPostCommand command);
+
+    AdminCommentListResult listComments(ListAdminCommentsCommand command);
+
+    AdminCommentDetailResult getCommentDetail(GetAdminCommentDetailCommand command);
+
+    void deleteComment(DeleteAdminCommentCommand command);
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/port/out/AdminCommunityRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/port/out/AdminCommunityRepositoryPort.java
@@ -7,14 +7,28 @@ import com.coliving.admin.community.application.result.AdminPostListItemResult;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface AdminCommunityRepositoryPort {
-    Page<AdminPostListItemResult> findPosts(String category, Long authorUserId, String keyword, Pageable pageable);
+    Page<AdminPostListItemResult> findPosts(
+            String category,
+            Long authorUserId,
+            String keyword,
+            OffsetDateTime createdFrom,
+            OffsetDateTime createdTo,
+            Pageable pageable
+    );
 
     Optional<AdminPostDetailResult> findPostDetail(Long postId);
 
-    Page<AdminCommentListItemResult> findComments(Long postId, Long authorUserId, Pageable pageable);
+    Page<AdminCommentListItemResult> findComments(
+            Long postId,
+            Long authorUserId,
+            OffsetDateTime createdFrom,
+            OffsetDateTime createdTo,
+            Pageable pageable
+    );
 
     Optional<AdminCommentDetailResult> findCommentDetail(Long commentId);
 }

--- a/backend/src/main/java/com/coliving/admin/community/application/port/out/AdminCommunityRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/port/out/AdminCommunityRepositoryPort.java
@@ -1,0 +1,20 @@
+package com.coliving.admin.community.application.port.out;
+
+import com.coliving.admin.community.application.result.AdminCommentDetailResult;
+import com.coliving.admin.community.application.result.AdminCommentListItemResult;
+import com.coliving.admin.community.application.result.AdminPostDetailResult;
+import com.coliving.admin.community.application.result.AdminPostListItemResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface AdminCommunityRepositoryPort {
+    Page<AdminPostListItemResult> findPosts(String category, Long authorUserId, String keyword, Pageable pageable);
+
+    Optional<AdminPostDetailResult> findPostDetail(Long postId);
+
+    Page<AdminCommentListItemResult> findComments(Long postId, Long authorUserId, Pageable pageable);
+
+    Optional<AdminCommentDetailResult> findCommentDetail(Long commentId);
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentDetailResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentDetailResult.java
@@ -1,0 +1,18 @@
+package com.coliving.admin.community.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminCommentDetailResult {
+    private final Long commentId;
+    private final Long postId;
+    private final String postTitle;
+    private final Long authorUserId;
+    private final String content;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentListItemResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentListItemResult.java
@@ -1,0 +1,18 @@
+package com.coliving.admin.community.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminCommentListItemResult {
+    private final Long commentId;
+    private final Long postId;
+    private final String postTitle;
+    private final Long authorUserId;
+    private final String content;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentListResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminCommentListResult.java
@@ -1,0 +1,16 @@
+package com.coliving.admin.community.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminCommentListResult {
+    private final List<AdminCommentListItemResult> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostDetailResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostDetailResult.java
@@ -1,0 +1,26 @@
+package com.coliving.admin.community.application.result;
+
+import com.coliving.common.community.model.PostAttachment;
+import com.coliving.common.community.model.PostLink;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminPostDetailResult {
+    private final Long postId;
+    private final String category;
+    private final String title;
+    private final String content;
+    private final Long authorUserId;
+    private final List<PostAttachment> attachments;
+    private final List<PostLink> links;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Integer commentCount;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostListItemResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostListItemResult.java
@@ -1,0 +1,20 @@
+package com.coliving.admin.community.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class AdminPostListItemResult {
+    private final Long postId;
+    private final String category;
+    private final String title;
+    private final Long authorUserId;
+    private final Integer viewCount;
+    private final Integer likeCount;
+    private final Integer commentCount;
+    private final OffsetDateTime createdAt;
+    private final OffsetDateTime updatedAt;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostListResult.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/result/AdminPostListResult.java
@@ -1,0 +1,16 @@
+package com.coliving.admin.community.application.result;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AdminPostListResult {
+    private final List<AdminPostListItemResult> content;
+    private final int page;
+    private final int size;
+    private final long totalElements;
+    private final int totalPages;
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityAuditLogger.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityAuditLogger.java
@@ -1,0 +1,18 @@
+package com.coliving.admin.community.application.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AdminCommunityAuditLogger {
+    private static final Logger log = LoggerFactory.getLogger("AUDIT_ADMIN_COMMUNITY");
+
+    public void logDeletePost(Long actorUserId, Long postId) {
+        log.info("action=DELETE_POST actorUserId={} targetPostId={}", actorUserId, postId);
+    }
+
+    public void logDeleteComment(Long actorUserId, Long commentId) {
+        log.info("action=DELETE_COMMENT actorUserId={} targetCommentId={}", actorUserId, commentId);
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityService.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityService.java
@@ -1,0 +1,145 @@
+package com.coliving.admin.community.application.service;
+
+import com.coliving.admin.community.application.command.DeleteAdminCommentCommand;
+import com.coliving.admin.community.application.command.DeleteAdminPostCommand;
+import com.coliving.admin.community.application.command.GetAdminCommentDetailCommand;
+import com.coliving.admin.community.application.command.GetAdminPostDetailCommand;
+import com.coliving.admin.community.application.command.ListAdminCommentsCommand;
+import com.coliving.admin.community.application.command.ListAdminPostsCommand;
+import com.coliving.admin.community.application.port.in.AdminCommunityUseCase;
+import com.coliving.admin.community.application.port.out.AdminCommunityRepositoryPort;
+import com.coliving.admin.community.application.result.AdminCommentDetailResult;
+import com.coliving.admin.community.application.result.AdminCommentListItemResult;
+import com.coliving.admin.community.application.result.AdminCommentListResult;
+import com.coliving.admin.community.application.result.AdminPostDetailResult;
+import com.coliving.admin.community.application.result.AdminPostListItemResult;
+import com.coliving.admin.community.application.result.AdminPostListResult;
+import com.coliving.common.community.application.port.out.CommunityRepositoryPort;
+import com.coliving.global.error.BusinessException;
+import com.coliving.global.error.ErrorCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+public class AdminCommunityService implements AdminCommunityUseCase {
+    private static final Set<String> ALLOWED_POST_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt", "viewCount", "likeCount", "commentCount"
+    );
+    private static final Set<String> ALLOWED_COMMENT_SORT_PROPERTIES = Set.of(
+            "createdAt", "updatedAt"
+    );
+
+    private final AdminCommunityRepositoryPort adminCommunityRepositoryPort;
+    private final CommunityRepositoryPort communityRepositoryPort;
+
+    public AdminCommunityService(AdminCommunityRepositoryPort adminCommunityRepositoryPort,
+                                 CommunityRepositoryPort communityRepositoryPort) {
+        this.adminCommunityRepositoryPort = adminCommunityRepositoryPort;
+        this.communityRepositoryPort = communityRepositoryPort;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminPostListResult listPosts(ListAdminPostsCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
+        Sort sort = parseSort(command.getSort(), ALLOWED_POST_SORT_PROPERTIES);
+
+        Page<AdminPostListItemResult> page = adminCommunityRepositoryPort.findPosts(
+                command.getCategory(),
+                command.getAuthorUserId(),
+                command.getKeyword(),
+                PageRequest.of(safePage, safeSize, sort)
+        );
+
+        return AdminPostListResult.builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminPostDetailResult getPostDetail(GetAdminPostDetailCommand command) {
+        return adminCommunityRepositoryPort.findPostDetail(command.getPostId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public void deletePost(DeleteAdminPostCommand command) {
+        communityRepositoryPort.softDeletePost(command.getPostId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminCommentListResult listComments(ListAdminCommentsCommand command) {
+        int safePage = Math.max(0, command.getPage());
+        int safeSize = normalizeSize(command.getSize());
+        Sort sort = parseSort(command.getSort(), ALLOWED_COMMENT_SORT_PROPERTIES);
+
+        Page<AdminCommentListItemResult> page = adminCommunityRepositoryPort.findComments(
+                command.getPostId(),
+                command.getAuthorUserId(),
+                PageRequest.of(safePage, safeSize, sort)
+        );
+
+        return AdminCommentListResult.builder()
+                .content(page.getContent())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AdminCommentDetailResult getCommentDetail(GetAdminCommentDetailCommand command) {
+        return adminCommunityRepositoryPort.findCommentDetail(command.getCommentId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public void deleteComment(DeleteAdminCommentCommand command) {
+        communityRepositoryPort.softDeleteComment(command.getCommentId());
+    }
+
+    private int normalizeSize(int size) {
+        if (size <= 0) {
+            return 20;
+        }
+        return Math.min(size, 100);
+    }
+
+    private Sort parseSort(String sort, Set<String> allowedSortProperties) {
+        if (sort == null || sort.isBlank()) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        String[] parts = sort.split(",");
+        if (parts.length != 2) {
+            return Sort.by(Sort.Direction.DESC, "createdAt");
+        }
+
+        String property = parts[0].trim();
+        Sort.Direction direction = "asc".equalsIgnoreCase(parts[1].trim())
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        String safeProperty = property.isBlank() ? "createdAt" : property;
+        if (!allowedSortProperties.contains(safeProperty)) {
+            safeProperty = "createdAt";
+        }
+        return Sort.by(direction, safeProperty);
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityService.java
+++ b/backend/src/main/java/com/coliving/admin/community/application/service/AdminCommunityService.java
@@ -20,6 +20,8 @@ import com.coliving.global.error.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,16 +38,20 @@ public class AdminCommunityService implements AdminCommunityUseCase {
 
     private final AdminCommunityRepositoryPort adminCommunityRepositoryPort;
     private final CommunityRepositoryPort communityRepositoryPort;
+    private final AdminCommunityAuditLogger adminCommunityAuditLogger;
 
     public AdminCommunityService(AdminCommunityRepositoryPort adminCommunityRepositoryPort,
-                                 CommunityRepositoryPort communityRepositoryPort) {
+                                 CommunityRepositoryPort communityRepositoryPort,
+                                 AdminCommunityAuditLogger adminCommunityAuditLogger) {
         this.adminCommunityRepositoryPort = adminCommunityRepositoryPort;
         this.communityRepositoryPort = communityRepositoryPort;
+        this.adminCommunityAuditLogger = adminCommunityAuditLogger;
     }
 
     @Override
     @Transactional(readOnly = true)
     public AdminPostListResult listPosts(ListAdminPostsCommand command) {
+        validateDateRange(command.getCreatedFrom(), command.getCreatedTo());
         int safePage = Math.max(0, command.getPage());
         int safeSize = normalizeSize(command.getSize());
         Sort sort = parseSort(command.getSort(), ALLOWED_POST_SORT_PROPERTIES);
@@ -54,6 +60,8 @@ public class AdminCommunityService implements AdminCommunityUseCase {
                 command.getCategory(),
                 command.getAuthorUserId(),
                 command.getKeyword(),
+                command.getCreatedFrom(),
+                command.getCreatedTo(),
                 PageRequest.of(safePage, safeSize, sort)
         );
 
@@ -76,12 +84,15 @@ public class AdminCommunityService implements AdminCommunityUseCase {
     @Override
     @Transactional
     public void deletePost(DeleteAdminPostCommand command) {
+        Long actorUserId = getAuthenticatedUserId();
         communityRepositoryPort.softDeletePost(command.getPostId());
+        adminCommunityAuditLogger.logDeletePost(actorUserId, command.getPostId());
     }
 
     @Override
     @Transactional(readOnly = true)
     public AdminCommentListResult listComments(ListAdminCommentsCommand command) {
+        validateDateRange(command.getCreatedFrom(), command.getCreatedTo());
         int safePage = Math.max(0, command.getPage());
         int safeSize = normalizeSize(command.getSize());
         Sort sort = parseSort(command.getSort(), ALLOWED_COMMENT_SORT_PROPERTIES);
@@ -89,6 +100,8 @@ public class AdminCommunityService implements AdminCommunityUseCase {
         Page<AdminCommentListItemResult> page = adminCommunityRepositoryPort.findComments(
                 command.getPostId(),
                 command.getAuthorUserId(),
+                command.getCreatedFrom(),
+                command.getCreatedTo(),
                 PageRequest.of(safePage, safeSize, sort)
         );
 
@@ -111,7 +124,9 @@ public class AdminCommunityService implements AdminCommunityUseCase {
     @Override
     @Transactional
     public void deleteComment(DeleteAdminCommentCommand command) {
+        Long actorUserId = getAuthenticatedUserId();
         communityRepositoryPort.softDeleteComment(command.getCommentId());
+        adminCommunityAuditLogger.logDeleteComment(actorUserId, command.getCommentId());
     }
 
     private int normalizeSize(int size) {
@@ -141,5 +156,23 @@ public class AdminCommunityService implements AdminCommunityUseCase {
             safeProperty = "createdAt";
         }
         return Sort.by(direction, safeProperty);
+    }
+
+    private Long getAuthenticatedUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        try {
+            return Long.parseLong(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+
+    private void validateDateRange(java.time.OffsetDateTime from, java.time.OffsetDateTime to) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR);
+        }
     }
 }

--- a/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentJpaRepository.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentJpaRepository.java
@@ -3,11 +3,12 @@ package com.coliving.common.comment.adapter.out.jpa;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface CommentJpaRepository extends JpaRepository<CommentEntity, Long> {
+public interface CommentJpaRepository extends JpaRepository<CommentEntity, Long>, JpaSpecificationExecutor<CommentEntity> {
 
     Optional<CommentEntity> findByCommentId(Long commentId);
 
@@ -16,4 +17,8 @@ public interface CommentJpaRepository extends JpaRepository<CommentEntity, Long>
 
     @EntityGraph(attributePaths = {"post"})
     List<CommentEntity> findByPost_PostId(Long postId);
+
+    @Override
+    @EntityGraph(attributePaths = {"post"})
+    Optional<CommentEntity> findById(Long commentId);
 }

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/jpa/PostJpaRepository.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/jpa/PostJpaRepository.java
@@ -2,10 +2,11 @@ package com.coliving.common.community.adapter.out.jpa;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface PostJpaRepository extends JpaRepository<PostEntity, Long> {
+public interface PostJpaRepository extends JpaRepository<PostEntity, Long>, JpaSpecificationExecutor<PostEntity> {
 
     Page<PostEntity> findByCategory(String category, Pageable pageable);
 

--- a/frontend/src/app/admin/_components/AdminSidebar.tsx
+++ b/frontend/src/app/admin/_components/AdminSidebar.tsx
@@ -10,6 +10,7 @@ import {
   CalendarDays,
   CreditCard,
   MessageSquareText,
+  MessagesSquare,
   X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -31,6 +32,7 @@ const NAV_SECTIONS: {
       { href: "/admin/reservations", label: "예약", icon: CalendarDays },
       { href: "/admin/billing", label: "결제·청구", icon: CreditCard },
       { href: "/admin/vocs", label: "민원", icon: MessageSquareText },
+      { href: "/admin/community", label: "커뮤니티", icon: MessagesSquare },
     ],
   },
 ];

--- a/frontend/src/app/admin/community/_api/admin-bff-server.ts
+++ b/frontend/src/app/admin/community/_api/admin-bff-server.ts
@@ -1,0 +1,19 @@
+import { headers } from "next/headers";
+
+/** 관리자 커뮤니티 RSC 전용: 쿠키를 BFF로 전달합니다. */
+export async function adminCommunityBffGet(pathWithQuery: string, init?: RequestInit) {
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host") ?? "localhost:3000";
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  const url = `${proto}://${host}/api/bff/${pathWithQuery.replace(/^\//, "")}`;
+
+  return fetch(url, {
+    ...init,
+    method: "GET",
+    headers: {
+      ...(init?.headers as Record<string, string>),
+      cookie: h.get("cookie") ?? "",
+    },
+    cache: "no-store",
+  });
+}

--- a/frontend/src/app/admin/community/_api/communityAdminApi.ts
+++ b/frontend/src/app/admin/community/_api/communityAdminApi.ts
@@ -1,5 +1,11 @@
 import { apiFetch } from "@/lib/api";
-import type { AdminCommentItem, AdminPostItem, PageData } from "../_types/community-admin";
+import type {
+  AdminCommentDetail,
+  AdminCommentItem,
+  AdminPostDetail,
+  AdminPostItem,
+  PageData,
+} from "../_types/community-admin";
 
 export async function fetchAdminPosts(params: { p?: number; s?: number; sort?: string; keyword?: string }) {
   const qs = new URLSearchParams();
@@ -25,4 +31,12 @@ export async function deleteAdminPost(postId: number) {
 
 export async function deleteAdminComment(commentId: number) {
   return apiFetch<void>(`/admin/comments/${commentId}`, { method: "DELETE" });
+}
+
+export async function fetchAdminPostDetail(postId: number) {
+  return apiFetch<AdminPostDetail>(`/admin/posts/${postId}`);
+}
+
+export async function fetchAdminCommentDetail(commentId: number) {
+  return apiFetch<AdminCommentDetail>(`/admin/comments/${commentId}`);
 }

--- a/frontend/src/app/admin/community/_api/communityAdminApi.ts
+++ b/frontend/src/app/admin/community/_api/communityAdminApi.ts
@@ -1,0 +1,28 @@
+import { apiFetch } from "@/lib/api";
+import type { AdminCommentItem, AdminPostItem, PageData } from "../_types/community-admin";
+
+export async function fetchAdminPosts(params: { p?: number; s?: number; sort?: string; keyword?: string }) {
+  const qs = new URLSearchParams();
+  qs.set("p", String(params.p ?? 0));
+  qs.set("s", String(params.s ?? 20));
+  qs.set("sort", params.sort ?? "createdAt,desc");
+  if (params.keyword) qs.set("keyword", params.keyword);
+  return apiFetch<PageData<AdminPostItem>>(`/admin/posts?${qs.toString()}`);
+}
+
+export async function fetchAdminComments(params: { p?: number; s?: number; sort?: string; postId?: number }) {
+  const qs = new URLSearchParams();
+  qs.set("p", String(params.p ?? 0));
+  qs.set("s", String(params.s ?? 20));
+  qs.set("sort", params.sort ?? "createdAt,desc");
+  if (params.postId != null) qs.set("post_id", String(params.postId));
+  return apiFetch<PageData<AdminCommentItem>>(`/admin/comments?${qs.toString()}`);
+}
+
+export async function deleteAdminPost(postId: number) {
+  return apiFetch<void>(`/admin/posts/${postId}`, { method: "DELETE" });
+}
+
+export async function deleteAdminComment(commentId: number) {
+  return apiFetch<void>(`/admin/comments/${commentId}`, { method: "DELETE" });
+}

--- a/frontend/src/app/admin/community/_api/communityAdminApi.ts
+++ b/frontend/src/app/admin/community/_api/communityAdminApi.ts
@@ -1,27 +1,43 @@
 import { apiFetch } from "@/lib/api";
 import type {
-  AdminCommentDetail,
   AdminCommentItem,
-  AdminPostDetail,
   AdminPostItem,
   PageData,
 } from "../_types/community-admin";
 
-export async function fetchAdminPosts(params: { p?: number; s?: number; sort?: string; keyword?: string }) {
+export async function fetchAdminPosts(params: {
+  p?: number;
+  s?: number;
+  sort?: string;
+  keyword?: string;
+  createdFrom?: string;
+  createdTo?: string;
+}) {
   const qs = new URLSearchParams();
   qs.set("p", String(params.p ?? 0));
   qs.set("s", String(params.s ?? 20));
   qs.set("sort", params.sort ?? "createdAt,desc");
   if (params.keyword) qs.set("keyword", params.keyword);
+  if (params.createdFrom) qs.set("created_from", params.createdFrom);
+  if (params.createdTo) qs.set("created_to", params.createdTo);
   return apiFetch<PageData<AdminPostItem>>(`/admin/posts?${qs.toString()}`);
 }
 
-export async function fetchAdminComments(params: { p?: number; s?: number; sort?: string; postId?: number }) {
+export async function fetchAdminComments(params: {
+  p?: number;
+  s?: number;
+  sort?: string;
+  postId?: number;
+  createdFrom?: string;
+  createdTo?: string;
+}) {
   const qs = new URLSearchParams();
   qs.set("p", String(params.p ?? 0));
   qs.set("s", String(params.s ?? 20));
   qs.set("sort", params.sort ?? "createdAt,desc");
   if (params.postId != null) qs.set("post_id", String(params.postId));
+  if (params.createdFrom) qs.set("created_from", params.createdFrom);
+  if (params.createdTo) qs.set("created_to", params.createdTo);
   return apiFetch<PageData<AdminCommentItem>>(`/admin/comments?${qs.toString()}`);
 }
 
@@ -31,12 +47,4 @@ export async function deleteAdminPost(postId: number) {
 
 export async function deleteAdminComment(commentId: number) {
   return apiFetch<void>(`/admin/comments/${commentId}`, { method: "DELETE" });
-}
-
-export async function fetchAdminPostDetail(postId: number) {
-  return apiFetch<AdminPostDetail>(`/admin/posts/${postId}`);
-}
-
-export async function fetchAdminCommentDetail(commentId: number) {
-  return apiFetch<AdminCommentDetail>(`/admin/comments/${commentId}`);
 }

--- a/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
+++ b/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
@@ -15,6 +15,8 @@ type TabKey = "posts" | "comments";
 
 export function CommunityModerationPanel() {
   const [tab, setTab] = useState<TabKey>("posts");
+  const [createdFrom, setCreatedFrom] = useState("");
+  const [createdTo, setCreatedTo] = useState("");
   const [posts, setPosts] = useState<AdminPostItem[]>([]);
   const [comments, setComments] = useState<AdminCommentItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -27,11 +29,18 @@ export function CommunityModerationPanel() {
       setLoading(true);
       setError(null);
       try {
+        if (createdFrom && createdTo && createdFrom > createdTo) {
+          setError("기간 설정이 올바르지 않습니다. 시작일은 종료일보다 이후일 수 없습니다.");
+          setLoading(false);
+          return;
+        }
+        const from = createdFrom || undefined;
+        const to = createdTo || undefined;
         if (tab === "posts") {
-          const res = await fetchAdminPosts({});
+          const res = await fetchAdminPosts({ createdFrom: from, createdTo: to });
           if (mounted) setPosts(res.data?.content ?? []);
         } else {
-          const res = await fetchAdminComments({});
+          const res = await fetchAdminComments({ createdFrom: from, createdTo: to });
           if (mounted) setComments(res.data?.content ?? []);
         }
       } catch (e) {
@@ -44,7 +53,7 @@ export function CommunityModerationPanel() {
     return () => {
       mounted = false;
     };
-  }, [tab]);
+  }, [tab, createdFrom, createdTo]);
 
   function handleDeletePost(postId: number) {
     startTransition(async () => {
@@ -89,6 +98,38 @@ export function CommunityModerationPanel() {
         >
           댓글
         </button>
+      </div>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="space-y-1 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          시작일
+          <input
+            type="date"
+            value={createdFrom}
+            onChange={(e) => setCreatedFrom(e.target.value)}
+            className="block rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground"
+          />
+        </label>
+        <label className="space-y-1 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          종료일
+          <input
+            type="date"
+            value={createdTo}
+            onChange={(e) => setCreatedTo(e.target.value)}
+            className="block rounded-lg border border-border bg-background px-3 py-2 text-sm font-medium text-foreground"
+          />
+        </label>
+        {(createdFrom || createdTo) && (
+          <button
+            type="button"
+            onClick={() => {
+              setCreatedFrom("");
+              setCreatedTo("");
+            }}
+            className="rounded-lg border border-border px-3 py-2 text-xs font-bold uppercase tracking-wider text-muted-foreground hover:bg-muted"
+          >
+            초기화
+          </button>
+        )}
       </div>
 
       {error ? <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</p> : null}

--- a/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
+++ b/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { MessageSquare, Trash2 } from "lucide-react";
+import {
+  deleteAdminComment,
+  deleteAdminPost,
+  fetchAdminComments,
+  fetchAdminPosts,
+} from "../_api/communityAdminApi";
+import type { AdminCommentItem, AdminPostItem } from "../_types/community-admin";
+
+type TabKey = "posts" | "comments";
+
+export function CommunityModerationPanel() {
+  const [tab, setTab] = useState<TabKey>("posts");
+  const [posts, setPosts] = useState<AdminPostItem[]>([]);
+  const [comments, setComments] = useState<AdminCommentItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    let mounted = true;
+    async function run() {
+      setLoading(true);
+      setError(null);
+      try {
+        if (tab === "posts") {
+          const res = await fetchAdminPosts({});
+          if (mounted) setPosts(res.data?.content ?? []);
+        } else {
+          const res = await fetchAdminComments({});
+          if (mounted) setComments(res.data?.content ?? []);
+        }
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : "목록을 불러오지 못했습니다.");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    }
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, [tab]);
+
+  function handleDeletePost(postId: number) {
+    startTransition(async () => {
+      try {
+        await deleteAdminPost(postId);
+        setPosts((prev) => prev.filter((p) => p.postId !== postId));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "게시글 삭제에 실패했습니다.");
+      }
+    });
+  }
+
+  function handleDeleteComment(commentId: number) {
+    startTransition(async () => {
+      try {
+        await deleteAdminComment(commentId);
+        setComments((prev) => prev.filter((c) => c.commentId !== commentId));
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "댓글 삭제에 실패했습니다.");
+      }
+    });
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => setTab("posts")}
+          className={`rounded-xl px-4 py-2 text-sm font-black uppercase tracking-wider ${
+            tab === "posts" ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
+          }`}
+        >
+          게시글
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab("comments")}
+          className={`rounded-xl px-4 py-2 text-sm font-black uppercase tracking-wider ${
+            tab === "comments" ? "bg-primary text-primary-foreground" : "bg-muted text-foreground"
+          }`}
+        >
+          댓글
+        </button>
+      </div>
+
+      {error ? <p className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</p> : null}
+
+      {loading ? <p className="text-sm text-muted-foreground">불러오는 중...</p> : null}
+
+      {tab === "posts" && !loading && (
+        <ul className="space-y-3">
+          {posts.length === 0 ? (
+            <li className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">게시글이 없습니다.</li>
+          ) : (
+            posts.map((item) => (
+              <li key={item.postId} className="rounded-xl border border-border bg-background p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-xs font-black uppercase tracking-wider text-muted-foreground">{item.category}</p>
+                    <p className="font-bold text-foreground">{item.title}</p>
+                    <p className="text-xs text-muted-foreground">
+                      작성자 #{item.authorUserId} · 조회 {item.viewCount} · 좋아요 {item.likeCount} · 댓글 {item.commentCount}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => handleDeletePost(item.postId)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                  >
+                    <Trash2 className="size-3.5" />
+                    삭제
+                  </button>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+
+      {tab === "comments" && !loading && (
+        <ul className="space-y-3">
+          {comments.length === 0 ? (
+            <li className="rounded-xl border border-dashed border-border px-4 py-8 text-center text-sm text-muted-foreground">댓글이 없습니다.</li>
+          ) : (
+            comments.map((item) => (
+              <li key={item.commentId} className="rounded-xl border border-border bg-background p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-xs font-black uppercase tracking-wider text-muted-foreground">POST #{item.postId}</p>
+                    <p className="font-bold text-foreground">{item.postTitle}</p>
+                    <p className="text-sm text-foreground/80">{item.content}</p>
+                    <p className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                      <MessageSquare className="size-3.5" />
+                      작성자 #{item.authorUserId}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={isPending}
+                    onClick={() => handleDeleteComment(item.commentId)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                  >
+                    <Trash2 className="size-3.5" />
+                    삭제
+                  </button>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
+++ b/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useTransition } from "react";
+import Link from "next/link";
 import { MessageSquare, Trash2 } from "lucide-react";
 import {
   deleteAdminComment,
@@ -109,15 +110,23 @@ export function CommunityModerationPanel() {
                       작성자 #{item.authorUserId} · 조회 {item.viewCount} · 좋아요 {item.likeCount} · 댓글 {item.commentCount}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    disabled={isPending}
-                    onClick={() => handleDeletePost(item.postId)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                  >
-                    <Trash2 className="size-3.5" />
-                    삭제
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => handleDeletePost(item.postId)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                    >
+                      <Trash2 className="size-3.5" />
+                      삭제
+                    </button>
+                    <Link
+                      href={`/admin/community/posts/${item.postId}`}
+                      className="inline-flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-xs font-bold text-primary hover:bg-muted"
+                    >
+                      상세
+                    </Link>
+                  </div>
                 </div>
               </li>
             ))
@@ -142,15 +151,23 @@ export function CommunityModerationPanel() {
                       작성자 #{item.authorUserId}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    disabled={isPending}
-                    onClick={() => handleDeleteComment(item.commentId)}
-                    className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
-                  >
-                    <Trash2 className="size-3.5" />
-                    삭제
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      disabled={isPending}
+                      onClick={() => handleDeleteComment(item.commentId)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-destructive/40 px-3 py-1.5 text-xs font-bold text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                    >
+                      <Trash2 className="size-3.5" />
+                      삭제
+                    </button>
+                    <Link
+                      href={`/admin/community/comments/${item.commentId}`}
+                      className="inline-flex items-center gap-1 rounded-lg border border-border px-3 py-1.5 text-xs font-bold text-primary hover:bg-muted"
+                    >
+                      상세
+                    </Link>
+                  </div>
                 </div>
               </li>
             ))

--- a/frontend/src/app/admin/community/_types/community-admin.ts
+++ b/frontend/src/app/admin/community/_types/community-admin.ts
@@ -1,0 +1,36 @@
+export type ApiResponse<T> = {
+  success: boolean;
+  data?: T;
+  message?: string | null;
+  errorCode?: string | null;
+};
+
+export type AdminPostItem = {
+  postId: number;
+  category: string;
+  title: string;
+  authorUserId: number;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminCommentItem = {
+  commentId: number;
+  postId: number;
+  postTitle: string;
+  authorUserId: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PageData<T> = {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+};

--- a/frontend/src/app/admin/community/_types/community-admin.ts
+++ b/frontend/src/app/admin/community/_types/community-admin.ts
@@ -17,7 +17,32 @@ export type AdminPostItem = {
   updatedAt: string;
 };
 
+export type AdminPostDetail = {
+  postId: number;
+  category: string;
+  title: string;
+  content: string;
+  authorUserId: number;
+  attachments?: { fileUrl?: string | null; fileName?: string | null; fileSize?: number | null }[] | null;
+  links?: { url?: string | null }[] | null;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export type AdminCommentItem = {
+  commentId: number;
+  postId: number;
+  postTitle: string;
+  authorUserId: number;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type AdminCommentDetail = {
   commentId: number;
   postId: number;
   postTitle: string;

--- a/frontend/src/app/admin/community/comments/[commentId]/_components/AdminCommunityCommentActions.tsx
+++ b/frontend/src/app/admin/community/comments/[commentId]/_components/AdminCommunityCommentActions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Loader2, Trash2 } from "lucide-react";
+import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
+
+type Props = {
+  commentId: number;
+};
+
+export function AdminCommunityCommentActions({ commentId }: Props) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [success, setSuccess] = useState<string | null>(null);
+
+  function handleDelete() {
+    if (pending) return;
+    if (!confirm("이 댓글을 삭제할까요?")) return;
+
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/bff/admin/comments/${commentId}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!res.ok) {
+          setError(await bffErrorMessageFromResponse(res, "댓글 삭제에 실패했습니다."));
+          return;
+        }
+        setSuccess("댓글이 삭제되었습니다. 목록으로 이동합니다.");
+        setTimeout(() => router.push("/admin/community"), 500);
+      } catch {
+        setError("연결에 실패했습니다.");
+      }
+    });
+  }
+
+  return (
+    <div className="mt-8 space-y-3 border-t border-border pt-6">
+      {error ? <p className="text-sm font-medium text-destructive">{error}</p> : null}
+      {success ? <p className="text-sm font-medium text-primary">{success}</p> : null}
+      <button
+        type="button"
+        disabled={pending}
+        onClick={handleDelete}
+        className="inline-flex items-center gap-2 rounded-xl border border-destructive/40 px-4 py-2.5 text-sm font-black uppercase tracking-wider text-destructive hover:bg-destructive/10 disabled:opacity-50"
+      >
+        {pending ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <Trash2 className="size-4" aria-hidden />}
+        댓글 삭제
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/community/comments/[commentId]/page.tsx
+++ b/frontend/src/app/admin/community/comments/[commentId]/page.tsx
@@ -1,0 +1,56 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { adminCommunityBffGet } from "../../_api/admin-bff-server";
+import type { AdminCommentDetail, ApiResponse } from "../../_types/community-admin";
+import { formatDateTimeKo } from "@/lib/format-date";
+import { AdminCommunityCommentActions } from "./_components/AdminCommunityCommentActions";
+
+type Params = Promise<{ commentId: string }>;
+
+export async function generateMetadata({ params }: { params: Params }) {
+  const { commentId } = await params;
+  return { title: `댓글 #${commentId} | 커뮤니티 관리` };
+}
+
+export default async function AdminCommunityCommentDetailPage({ params }: { params: Params }) {
+  const { commentId } = await params;
+  const id = parseInt(commentId, 10);
+  if (Number.isNaN(id)) notFound();
+
+  const res = await adminCommunityBffGet(`admin/comments/${id}`);
+  if (!res.ok) notFound();
+  const body = (await res.json()) as ApiResponse<AdminCommentDetail>;
+  if (!body.success || !body.data) notFound();
+  const detail = body.data;
+
+  return (
+    <article className="max-w-3xl">
+      <Link
+        href="/admin/community"
+        className="inline-flex items-center gap-2 font-black text-xs uppercase tracking-[0.3em] text-secondary transition-colors hover:text-foreground"
+      >
+        ← 목록
+      </Link>
+
+      <header className="mt-8 space-y-3 border-b border-border pb-8">
+        <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
+          Admin · Community · Comment #{detail.commentId}
+        </p>
+        <p className="text-sm font-bold text-foreground">원문 게시글: {detail.postTitle}</p>
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+          POST #{detail.postId} · 작성자 #{detail.authorUserId}
+        </p>
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+          생성 {formatDateTimeKo(detail.createdAt)} · 수정 {formatDateTimeKo(detail.updatedAt)}
+        </p>
+      </header>
+
+      <section className="mt-8">
+        <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">댓글 내용</p>
+        <p className="mt-4 whitespace-pre-wrap font-medium tracking-tight text-foreground">{detail.content}</p>
+      </section>
+
+      <AdminCommunityCommentActions commentId={detail.commentId} />
+    </article>
+  );
+}

--- a/frontend/src/app/admin/community/comments/[commentId]/page.tsx
+++ b/frontend/src/app/admin/community/comments/[commentId]/page.tsx
@@ -18,7 +18,15 @@ export default async function AdminCommunityCommentDetailPage({ params }: { para
   if (Number.isNaN(id)) notFound();
 
   const res = await adminCommunityBffGet(`admin/comments/${id}`);
-  if (!res.ok) notFound();
+  if (res.status === 401 || res.status === 403) {
+    return <p className="text-sm font-medium text-destructive">관리자 권한이 필요합니다.</p>;
+  }
+  if (res.status === 404) {
+    notFound();
+  }
+  if (!res.ok) {
+    return <p className="text-sm font-medium text-destructive">상세 정보를 불러오지 못했습니다.</p>;
+  }
   const body = (await res.json()) as ApiResponse<AdminCommentDetail>;
   if (!body.success || !body.data) notFound();
   const detail = body.data;

--- a/frontend/src/app/admin/community/page.tsx
+++ b/frontend/src/app/admin/community/page.tsx
@@ -1,0 +1,22 @@
+import { CommunityModerationPanel } from "./_components/CommunityModerationPanel";
+
+export const metadata = {
+  title: "커뮤니티 관리",
+  description: "게시글 및 댓글 검수/삭제 관리",
+};
+
+export default function AdminCommunityPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="font-black text-xs uppercase tracking-[0.3em] text-muted-foreground">Community Moderation</p>
+        <h1 className="text-3xl font-black tracking-tighter text-primary md:text-4xl">커뮤니티 관리</h1>
+        <p className="text-sm font-medium tracking-tight text-muted-foreground">
+          관리자 권한으로 커뮤니티 게시글/댓글을 검수하고 삭제할 수 있습니다.
+        </p>
+      </header>
+
+      <CommunityModerationPanel />
+    </div>
+  );
+}

--- a/frontend/src/app/admin/community/posts/[postId]/_components/AdminCommunityPostActions.tsx
+++ b/frontend/src/app/admin/community/posts/[postId]/_components/AdminCommunityPostActions.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { Trash2, Loader2 } from "lucide-react";
+import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
+
+type Props = {
+  postId: number;
+};
+
+export function AdminCommunityPostActions({ postId }: Props) {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [success, setSuccess] = useState<string | null>(null);
+
+  function handleDelete() {
+    if (pending) return;
+    if (!confirm("이 게시글을 삭제할까요? 관련 댓글도 함께 숨김 처리됩니다.")) return;
+
+    setError(null);
+    setSuccess(null);
+    startTransition(async () => {
+      try {
+        const res = await fetch(`/api/bff/admin/posts/${postId}`, {
+          method: "DELETE",
+          credentials: "include",
+        });
+        if (!res.ok) {
+          setError(await bffErrorMessageFromResponse(res, "게시글 삭제에 실패했습니다."));
+          return;
+        }
+        setSuccess("게시글이 삭제되었습니다. 목록으로 이동합니다.");
+        setTimeout(() => router.push("/admin/community"), 500);
+      } catch {
+        setError("연결에 실패했습니다.");
+      }
+    });
+  }
+
+  return (
+    <div className="mt-8 space-y-3 border-t border-border pt-6">
+      {error ? <p className="text-sm font-medium text-destructive">{error}</p> : null}
+      {success ? <p className="text-sm font-medium text-primary">{success}</p> : null}
+      <button
+        type="button"
+        disabled={pending}
+        onClick={handleDelete}
+        className="inline-flex items-center gap-2 rounded-xl border border-destructive/40 px-4 py-2.5 text-sm font-black uppercase tracking-wider text-destructive hover:bg-destructive/10 disabled:opacity-50"
+      >
+        {pending ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <Trash2 className="size-4" aria-hidden />}
+        게시글 삭제
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/community/posts/[postId]/page.tsx
+++ b/frontend/src/app/admin/community/posts/[postId]/page.tsx
@@ -18,7 +18,15 @@ export default async function AdminCommunityPostDetailPage({ params }: { params:
   if (Number.isNaN(id)) notFound();
 
   const res = await adminCommunityBffGet(`admin/posts/${id}`);
-  if (!res.ok) notFound();
+  if (res.status === 401 || res.status === 403) {
+    return <p className="text-sm font-medium text-destructive">관리자 권한이 필요합니다.</p>;
+  }
+  if (res.status === 404) {
+    notFound();
+  }
+  if (!res.ok) {
+    return <p className="text-sm font-medium text-destructive">상세 정보를 불러오지 못했습니다.</p>;
+  }
   const body = (await res.json()) as ApiResponse<AdminPostDetail>;
   if (!body.success || !body.data) notFound();
   const detail = body.data;

--- a/frontend/src/app/admin/community/posts/[postId]/page.tsx
+++ b/frontend/src/app/admin/community/posts/[postId]/page.tsx
@@ -1,0 +1,80 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { adminCommunityBffGet } from "../../_api/admin-bff-server";
+import type { AdminPostDetail, ApiResponse } from "../../_types/community-admin";
+import { formatDateTimeKo } from "@/lib/format-date";
+import { AdminCommunityPostActions } from "./_components/AdminCommunityPostActions";
+
+type Params = Promise<{ postId: string }>;
+
+export async function generateMetadata({ params }: { params: Params }) {
+  const { postId } = await params;
+  return { title: `게시글 #${postId} | 커뮤니티 관리` };
+}
+
+export default async function AdminCommunityPostDetailPage({ params }: { params: Params }) {
+  const { postId } = await params;
+  const id = parseInt(postId, 10);
+  if (Number.isNaN(id)) notFound();
+
+  const res = await adminCommunityBffGet(`admin/posts/${id}`);
+  if (!res.ok) notFound();
+  const body = (await res.json()) as ApiResponse<AdminPostDetail>;
+  if (!body.success || !body.data) notFound();
+  const detail = body.data;
+
+  return (
+    <article className="max-w-4xl">
+      <Link
+        href="/admin/community"
+        className="inline-flex items-center gap-2 font-black text-xs uppercase tracking-[0.3em] text-secondary transition-colors hover:text-foreground"
+      >
+        ← 목록
+      </Link>
+
+      <header className="mt-8 space-y-3 border-b border-border pb-8">
+        <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">
+          Admin · Community · Post #{detail.postId}
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="font-black text-[10px] uppercase tracking-[0.25em] text-muted-foreground">{detail.category}</span>
+          <span className="font-black text-[10px] uppercase tracking-[0.2em] text-muted-foreground">작성자 #{detail.authorUserId}</span>
+        </div>
+        <h1 className="text-3xl font-black tracking-tight text-foreground md:text-4xl">{detail.title}</h1>
+        <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+          생성 {formatDateTimeKo(detail.createdAt)} · 수정 {formatDateTimeKo(detail.updatedAt)}
+        </p>
+      </header>
+
+      <section className="mt-8 space-y-6">
+        <div>
+          <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">본문</p>
+          <p className="mt-4 whitespace-pre-wrap font-medium tracking-tight text-foreground">{detail.content}</p>
+        </div>
+
+        {detail.links?.length ? (
+          <div>
+            <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">링크</p>
+            <ul className="mt-3 space-y-2">
+              {detail.links.map((link, idx) => (
+                <li key={`${link.url}-${idx}`}>
+                  <a href={link.url ?? "#"} target="_blank" rel="noopener noreferrer" className="text-sm text-secondary hover:underline">
+                    {link.url}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-wider text-muted-foreground">
+          <span>조회 {detail.viewCount}</span>
+          <span>좋아요 {detail.likeCount}</span>
+          <span>댓글 {detail.commentCount}</span>
+        </div>
+      </section>
+
+      <AdminCommunityPostActions postId={detail.postId} />
+    </article>
+  );
+}


### PR DESCRIPTION
### Summary
관리자 커뮤니티 관리 기능 풀스택 구현
백엔드: admin/community 모듈(게시글/댓글 목록·상세·삭제) 추가
프론트: /admin/community 목록/상세 페이지 및 삭제 액션 추가
스펙/리뷰 반영 안정화
기간 필터(created_from, created_to) 지원
날짜 필터를 서버에서 LocalDate -> OffsetDateTime으로 변환(타임존 경계 이슈 방지)
기간 역전 검증(프론트/백엔드) 추가
관리자 삭제 감사 로깅 추가 (action, actorUserId, targetId)
성능/일관성 개선
댓글 목록의 post title 조회 시 배치 조회로 N+1 리스크 완화
관리자 상세(게시글/댓글)에서 401/403/404/기타 오류 처리 분리
미사용 상세 API 함수 정리

### 주요 API
GET /api/admin/posts
GET /api/admin/posts/{postId}
DELETE /api/admin/posts/{postId}
GET /api/admin/comments
GET /api/admin/comments/{commentId}
DELETE /api/admin/comments/{commentId}

### 주요 화면
/admin/community
/admin/community/posts/[postId]
/admin/community/comments/[commentId]

### Test Plan

 관리자 로그인 상태에서 /admin/community 진입 가능

 게시글/댓글 목록 조회 정상 동작

 기간 필터(시작일/종료일) 조회 정상 동작

 시작일 > 종료일 입력 시 프론트 에러 노출 및 요청 차단

 게시글 상세/댓글 상세 페이지 진입 및 데이터 표시 확인

 상세 페이지에서 삭제 시 성공 메시지 후 목록 이동

 401/403/404 상황에서 상세 페이지 에러 처리 문구 확인

 백엔드 로그에서 삭제 감사 로그(AUDIT_ADMIN_COMMUNITY) 기록 확인