### PR TITLE
feat(RSV-#78): 공용시설 예약 타임테이블 Grid 마크업

### DIFF
--- a/frontend/src/app/(resident-app)/facilities/_api/index.ts
+++ b/frontend/src/app/(resident-app)/facilities/_api/index.ts
@@ -1,0 +1,41 @@
+// #78: 시설 예약 API 클라이언트
+// 02-frontend-architecture §3: 브라우저는 /api/bff/... 만 호출
+
+import { apiFetch } from "@/lib/api";
+import type { Facility, MyReservation, ReservationRequest } from "../_types";
+
+/** 공용시설 목록 조회 (🔓 Public — api-specification §6.1) */
+export async function fetchFacilities() {
+  return apiFetch<Facility[]>("/facilities");
+}
+
+/**
+ * 주단위 예약 타임슬롯 조회 (api-specification §6.2)
+ * @param spaceId 시설 ID
+ * @param weekStart ISO date string (e.g. "2026-05-01") — 해당 주의 월요일
+ */
+export async function fetchTimeSlots(spaceId: number, weekStart: string) {
+  return apiFetch<{ [date: string]: Array<{ startTime: string; endTime: string; status: string; reservationId?: number }> }>(
+    `/facilities/${spaceId}/slots?week_start=${weekStart}`
+  );
+}
+
+/** 예약 신청 (POST /api/reservations — api-specification §6.3) */
+export async function createReservation(data: ReservationRequest) {
+  return apiFetch<{ reservationId: number }>("/reservations", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+/** 내 예약 목록 조회 (GET /api/reservations/my — api-specification §6.4) */
+export async function fetchMyReservations() {
+  return apiFetch<MyReservation[]>("/reservations/my");
+}
+
+/** 예약 취소 (POST /api/reservations/{id}/cancel — api-specification §6.5) */
+export async function cancelReservation(reservationId: number) {
+  return apiFetch<void>(`/reservations/${reservationId}/cancel`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+// #78: 시설 카드 컴포넌트
+// ui-guideline: Moss & Aloe 디자인 시스템, 시맨틱 클래스만 사용
+
+import { motion } from "framer-motion";
+import type { Facility } from "../_types";
+
+const STATUS_MAP: Record<string, { label: string; dot: string; border: string }> = {
+  AVAILABLE: {
+    label: "이용 가능",
+    dot: "bg-green-500",
+    border: "border-green-400/30 bg-green-50/50",
+  },
+  OCCUPIED: {
+    label: "사용 중",
+    dot: "bg-accent",
+    border: "border-accent/30 bg-accent/5",
+  },
+  MAINTENANCE: {
+    label: "점검 중",
+    dot: "bg-muted-foreground",
+    border: "border-border bg-muted/20 opacity-60",
+  },
+};
+
+const FACILITY_ICONS: Record<string, string> = {
+  세탁실: "🫧",
+  라운지: "☕",
+  회의실: "📋",
+  헬스장: "💪",
+};
+
+function getFacilityIcon(name: string): string {
+  for (const [key, icon] of Object.entries(FACILITY_ICONS)) {
+    if (name.includes(key)) return icon;
+  }
+  return "🏠";
+}
+
+interface FacilityCardProps {
+  facility: Facility;
+  selected: boolean;
+  onSelect: (facility: Facility) => void;
+  index: number;
+}
+
+export function FacilityCard({ facility, selected, onSelect, index }: FacilityCardProps) {
+  const status = STATUS_MAP[facility.status] ?? STATUS_MAP.AVAILABLE;
+  const icon = getFacilityIcon(facility.name);
+  const [openTime, closeTime] = facility.operatingHours?.split("-") ?? ["?", "?"];
+
+  return (
+    <motion.button
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ delay: index * 0.06, duration: 0.3 }}
+      whileHover={{ scale: 1.02, y: -4 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={() => onSelect(facility)}
+      className={`relative w-full rounded-[2rem] border p-5 text-left transition-all duration-200
+        ${selected
+          ? "border-primary/60 bg-primary text-primary-foreground shadow-lg shadow-primary/20"
+          : `${status.border} hover:shadow-md hover:border-primary/30`
+        }`}
+    >
+      {/* 상태 점 */}
+      <span
+        className={`absolute right-4 top-4 h-2.5 w-2.5 rounded-full ${
+          selected ? "bg-primary-foreground/70" : status.dot
+        }`}
+      />
+
+      {/* 아이콘 */}
+      <div className="text-3xl">{icon}</div>
+
+      {/* 시설명 */}
+      <p className={`mt-3 text-sm font-bold tracking-tight ${
+        selected ? "text-primary-foreground" : "text-primary"
+      }`}>
+        {facility.name}
+      </p>
+
+      {/* 운영 정보 */}
+      <p className={`mt-1 text-[10px] font-black uppercase tracking-[0.2em] ${
+        selected ? "text-primary-foreground/70" : "text-muted-foreground"
+      }`}>
+        {openTime} – {closeTime}
+      </p>
+
+      {/* 수용 인원 / 요금 */}
+      <div className={`mt-3 flex items-center gap-3 text-[10px] font-semibold ${
+        selected ? "text-primary-foreground/80" : "text-muted-foreground"
+      }`}>
+        <span>👤 {facility.maxCapacity}명</span>
+        {facility.usageFee > 0 && (
+          <span>₩{facility.usageFee.toLocaleString()}/시간</span>
+        )}
+      </div>
+
+      {/* 예약 필요 배지 */}
+      {facility.isReservable && (
+        <span className={`mt-3 inline-block rounded-full px-2 py-0.5 text-[9px] font-black uppercase tracking-widest ${
+          selected
+            ? "bg-primary-foreground/20 text-primary-foreground"
+            : "bg-primary/10 text-primary"
+        }`}>
+          예약제
+        </span>
+      )}
+    </motion.button>
+  );
+}

--- a/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+// #78: 주단위 타임테이블 Grid 마크업
+// functional-specification §3.2.2: 가로=요일, 세로=시간대, 색상 구분
+// ui-guideline: Moss & Aloe 시맨틱 클래스, framer-motion 마이크로 애니메이션
+
+import { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { fetchTimeSlots, createReservation } from "../_api";
+import type { Facility } from "../_types";
+import { ApiError } from "@/lib/api";
+
+// ──────────────────────────────────────────
+// 상수
+// ──────────────────────────────────────────
+
+const DAYS_KO = ["월", "화", "수", "목", "금", "토", "일"];
+const SLOT_MINUTES = 30; // 30분 단위
+const DAY_START = 6;     // 06:00
+const DAY_END = 23;      // 23:00
+
+interface SlotData {
+  status: "AVAILABLE" | "MY_RESERVATION" | "OCCUPIED";
+  reservationId?: number;
+}
+
+interface TimetableData {
+  [date: string]: {
+    [time: string]: SlotData; // "14:00"
+  };
+}
+
+// ──────────────────────────────────────────
+// 유틸
+// ──────────────────────────────────────────
+
+/** 해당 주의 월요일 ISO 날짜 반환 */
+function getWeekStart(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay(); // 0=일
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** Date → "YYYY-MM-DD" */
+function toDateStr(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** 분 → "HH:MM" */
+function minutesToTime(totalMinutes: number): string {
+  const h = Math.floor(totalMinutes / 60).toString().padStart(2, "0");
+  const m = (totalMinutes % 60).toString().padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+/** 슬롯 시작 시간 배열 생성 */
+function generateTimeSlots(): string[] {
+  const slots: string[] = [];
+  for (let m = DAY_START * 60; m < DAY_END * 60; m += SLOT_MINUTES) {
+    slots.push(minutesToTime(m));
+  }
+  return slots;
+}
+
+const TIME_SLOTS = generateTimeSlots();
+
+/** API 응답 → TimetableData 변환 */
+function parseSlots(
+  apiData: Record<string, Array<{ startTime: string; endTime: string; status: string; reservationId?: number }>>
+): TimetableData {
+  const result: TimetableData = {};
+  for (const [date, slots] of Object.entries(apiData)) {
+    result[date] = {};
+    for (const slot of slots) {
+      const start = slot.startTime.slice(0, 5); // "14:00:00" → "14:00"
+      result[date][start] = {
+        status: slot.status as SlotData["status"],
+        reservationId: slot.reservationId,
+      };
+    }
+  }
+  return result;
+}
+
+// ──────────────────────────────────────────
+// 셀 컴포넌트
+// ──────────────────────────────────────────
+
+interface SlotCellProps {
+  slotData?: SlotData;
+  isSelected: boolean;
+  isPast: boolean;
+  onClick: () => void;
+}
+
+function SlotCell({ slotData, isSelected, isPast, onClick }: SlotCellProps) {
+  const status = slotData?.status ?? "AVAILABLE";
+
+  const baseClass = "h-8 w-full cursor-pointer rounded-lg border transition-all duration-150";
+
+  const statusClass = isPast
+    ? "border-transparent bg-muted/20 cursor-not-allowed opacity-40"
+    : isSelected
+    ? "border-primary bg-primary scale-[1.04] shadow-sm shadow-primary/30 cursor-pointer"
+    : status === "MY_RESERVATION"
+    ? "border-accent/60 bg-accent/20 cursor-not-allowed"
+    : status === "OCCUPIED"
+    ? "border-muted bg-muted/40 cursor-not-allowed opacity-70"
+    : "border-border/50 bg-surface hover:border-primary/40 hover:bg-primary/10";
+
+  return (
+    <motion.div
+      whileHover={!isPast && status === "AVAILABLE" ? { scale: 1.05 } : undefined}
+      whileTap={!isPast && status === "AVAILABLE" ? { scale: 0.95 } : undefined}
+      className={`${baseClass} ${statusClass}`}
+      onClick={!isPast && (status === "AVAILABLE" || isSelected) ? onClick : undefined}
+      title={
+        isPast ? "지난 시간" :
+        status === "MY_RESERVATION" ? "내 예약" :
+        status === "OCCUPIED" ? "예약 불가" :
+        isSelected ? "선택 취소" : "클릭하여 선택"
+      }
+    />
+  );
+}
+
+// ──────────────────────────────────────────
+// 메인 컴포넌트
+// ──────────────────────────────────────────
+
+interface WeeklyTimetableProps {
+  facility: Facility;
+  onReserved?: () => void;
+}
+
+export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) {
+  const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
+  const [timetable, setTimetable] = useState<TimetableData>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 선택: { date, startTime, endTime(=startTime+30분) }
+  const [selectedSlots, setSelectedSlots] = useState<{ date: string; time: string }[]>([]);
+  const [booking, setBooking] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
+
+  // 이번 주 날짜 배열
+  const weekDates = Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(weekStart);
+    d.setDate(d.getDate() + i);
+    return d;
+  });
+
+  // 타임슬롯 로드
+  const loadSlots = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setSelectedSlots([]);
+    try {
+      const res = await fetchTimeSlots(facility.spaceId, toDateStr(weekStart));
+      setTimetable(parseSlots(res.data ?? {}));
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError("예약 현황을 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [facility.spaceId, weekStart]);
+
+  useEffect(() => {
+    loadSlots();
+  }, [loadSlots]);
+
+  // 피드백 자동 해제
+  useEffect(() => {
+    if (feedback) {
+      const t = setTimeout(() => setFeedback(null), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [feedback]);
+
+  // 셀 클릭 — 연속 선택 지원 (같은 날, 연속 시간대)
+  const handleCellClick = (date: string, time: string) => {
+    setSelectedSlots((prev) => {
+      const key = `${date}__${time}`;
+      const alreadySelected = prev.some((s) => `${s.date}__${s.time}` === key);
+      if (alreadySelected) {
+        return prev.filter((s) => `${s.date}__${s.time}` !== key);
+      }
+      // 같은 날이어야만 추가 선택
+      if (prev.length > 0 && prev[0].date !== date) {
+        return [{ date, time }];
+      }
+      return [...prev, { date, time }].sort((a, b) => a.time.localeCompare(b.time));
+    });
+  };
+
+  // 예약 신청
+  const handleReserve = async () => {
+    if (selectedSlots.length === 0) return;
+    setBooking(true);
+    try {
+      const date = selectedSlots[0].date;
+      const startTime = `${selectedSlots[0].time}:00`;
+      const lastSlot = selectedSlots[selectedSlots.length - 1].time;
+      // endTime = 마지막 슬롯 시작 + 30분
+      const [h, m] = lastSlot.split(":").map(Number);
+      const endMinutes = h * 60 + m + SLOT_MINUTES;
+      const endTime = `${minutesToTime(endMinutes)}:00`;
+
+      await createReservation({ spaceId: facility.spaceId, reservationDate: date, startTime, endTime });
+      setFeedback({ type: "success", msg: "예약 신청이 완료되었습니다! 🎉" });
+      setSelectedSlots([]);
+      loadSlots();
+      onReserved?.();
+    } catch (e) {
+      if (e instanceof ApiError) setFeedback({ type: "error", msg: e.message });
+      else setFeedback({ type: "error", msg: "예약 신청에 실패했습니다." });
+    } finally {
+      setBooking(false);
+    }
+  };
+
+  // 주 이동
+  const shiftWeek = (delta: number) => {
+    setWeekStart((prev) => {
+      const d = new Date(prev);
+      d.setDate(d.getDate() + delta * 7);
+      return d;
+    });
+  };
+
+  const today = toDateStr(new Date());
+  const now = new Date();
+  const nowTime = `${now.getHours().toString().padStart(2, "0")}:${now.getMinutes() >= 30 ? "30" : "00"}`;
+
+  const selectedDate = selectedSlots[0]?.date;
+  const selectedStart = selectedSlots[0]?.time;
+  const selectedEnd = (() => {
+    if (selectedSlots.length === 0) return null;
+    const last = selectedSlots[selectedSlots.length - 1].time;
+    const [h, m] = last.split(":").map(Number);
+    return minutesToTime(h * 60 + m + SLOT_MINUTES);
+  })();
+
+  return (
+    <div className="space-y-4">
+      {/* 주 이동 헤더 */}
+      <div className="flex items-center justify-between rounded-2xl border border-border bg-surface px-4 py-3">
+        <button
+          onClick={() => shiftWeek(-1)}
+          className="rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+        >
+          ← 이전 주
+        </button>
+
+        <div className="text-center">
+          <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
+            {weekStart.getFullYear()}년
+          </p>
+          <p className="text-sm font-bold text-primary">
+            {weekStart.getMonth() + 1}월 {weekStart.getDate()}일 –{" "}
+            {weekDates[6].getMonth() + 1}월 {weekDates[6].getDate()}일
+          </p>
+        </div>
+
+        <button
+          onClick={() => shiftWeek(1)}
+          className="rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+        >
+          다음 주 →
+        </button>
+      </div>
+
+      {/* 범례 */}
+      <div className="flex flex-wrap gap-3 px-1 text-[10px] font-semibold text-muted-foreground">
+        {[
+          { color: "bg-primary", label: "선택됨" },
+          { color: "bg-accent/30 border border-accent/60", label: "내 예약" },
+          { color: "bg-muted/40 border border-muted", label: "예약 불가" },
+          { color: "bg-surface border border-border/50", label: "예약 가능" },
+        ].map(({ color, label }) => (
+          <div key={label} className="flex items-center gap-1.5">
+            <div className={`h-3 w-6 rounded-sm ${color}`} />
+            <span>{label}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* 그리드 */}
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-8 animate-pulse rounded-xl bg-muted/30" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-2xl border border-destructive/30 bg-destructive/10 p-6 text-center">
+          <p className="text-sm font-medium text-destructive">{error}</p>
+          <button
+            onClick={loadSlots}
+            className="mt-3 rounded-xl bg-primary px-4 py-2 text-xs font-bold text-primary-foreground"
+          >
+            다시 시도
+          </button>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-[2rem] border border-border bg-surface">
+          <div
+            className="grid min-w-[560px]"
+            style={{ gridTemplateColumns: `56px repeat(7, 1fr)` }}
+          >
+            {/* 헤더 행 — 요일 */}
+            <div className="sticky left-0 bg-surface" /> {/* 시간 컬럼 자리 */}
+            {weekDates.map((date, i) => {
+              const dateStr = toDateStr(date);
+              const isToday = dateStr === today;
+              return (
+                <div
+                  key={dateStr}
+                  className={`border-b border-border px-1 py-2 text-center text-xs font-bold tracking-tight ${
+                    isToday ? "text-primary" : "text-muted-foreground"
+                  }`}
+                >
+                  <p className={`text-[9px] font-black uppercase tracking-[0.15em] ${
+                    isToday ? "text-accent" : "text-muted-foreground"
+                  }`}>
+                    {DAYS_KO[i]}
+                  </p>
+                  <p className={`text-sm font-bold ${isToday ? "text-primary" : ""}`}>
+                    {date.getDate()}
+                  </p>
+                  {isToday && (
+                    <div className="mx-auto mt-0.5 h-1 w-1 rounded-full bg-accent" />
+                  )}
+                </div>
+              );
+            })}
+
+            {/* 시간 행 */}
+            {TIME_SLOTS.map((time, tIdx) => {
+              const isHourMark = time.endsWith(":00");
+              return [
+                // 시간 레이블 셀
+                <div
+                  key={`label-${time}`}
+                  className={`sticky left-0 flex items-center justify-end border-b border-border/40 bg-surface pr-2 ${
+                    isHourMark ? "text-[10px] font-semibold text-muted-foreground" : ""
+                  }`}
+                  style={{ minHeight: "2rem" }}
+                >
+                  {isHourMark ? time : ""}
+                </div>,
+
+                // 각 날짜 셀
+                ...weekDates.map((date) => {
+                  const dateStr = toDateStr(date);
+                  const slotData = timetable[dateStr]?.[time];
+                  const isPast =
+                    dateStr < today || (dateStr === today && time < nowTime);
+                  const isSelected = selectedSlots.some(
+                    (s) => s.date === dateStr && s.time === time
+                  );
+                  return (
+                    <div
+                      key={`${dateStr}-${time}`}
+                      className="border-b border-l border-border/30 p-0.5"
+                    >
+                      <SlotCell
+                        slotData={slotData}
+                        isSelected={isSelected}
+                        isPast={isPast}
+                        onClick={() => handleCellClick(dateStr, time)}
+                      />
+                    </div>
+                  );
+                }),
+              ];
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* 선택 요약 + 예약 버튼 */}
+      <AnimatePresence>
+        {selectedSlots.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 12 }}
+            className="rounded-[2rem] border border-primary/30 bg-primary/5 p-5 space-y-3"
+          >
+            <div className="space-y-1">
+              <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+                예약 요약
+              </p>
+              <p className="text-sm font-bold text-primary">
+                {selectedDate} &nbsp;{selectedStart} – {selectedEnd}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {facility.name} · {selectedSlots.length * SLOT_MINUTES}분
+              </p>
+            </div>
+
+            <button
+              onClick={handleReserve}
+              disabled={booking}
+              className="w-full rounded-xl bg-primary py-3 text-sm font-bold text-primary-foreground
+                transition hover:opacity-90 disabled:opacity-50"
+            >
+              {booking ? "신청 중..." : "예약 신청"}
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* 피드백 토스트 */}
+      <AnimatePresence>
+        {feedback && (
+          <motion.div
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0 }}
+            className={`rounded-xl border px-4 py-3 text-sm font-medium ${
+              feedback.type === "success"
+                ? "border-green-400/30 bg-green-50/80 text-green-800"
+                : "border-destructive/30 bg-destructive/10 text-destructive"
+            }`}
+          >
+            {feedback.msg}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/app/(resident-app)/facilities/_types/index.ts
+++ b/frontend/src/app/(resident-app)/facilities/_types/index.ts
@@ -1,0 +1,41 @@
+// #78: 공용시설 예약 타입 정의
+// api-specification.md §6.1, §6.2, §6.3, §6.4
+
+export interface Facility {
+  spaceId: number;
+  name: string;
+  maxCapacity: number;
+  operatingHours: string; // "06:00-23:00"
+  isReservable: boolean;
+  usageFee: number;
+  status: "AVAILABLE" | "OCCUPIED" | "MAINTENANCE";
+}
+
+export interface TimeSlot {
+  date: string;        // "2026-05-01"
+  startTime: string;   // "14:00:00"
+  endTime: string;     // "16:00:00"
+  status: "AVAILABLE" | "MY_RESERVATION" | "OCCUPIED";
+  reservationId?: number;
+}
+
+export interface WeekSlots {
+  [date: string]: TimeSlot[];
+}
+
+export interface ReservationRequest {
+  spaceId: number;
+  reservationDate: string;   // "2026-05-01"
+  startTime: string;         // "14:00:00"
+  endTime: string;           // "16:00:00"
+}
+
+export interface MyReservation {
+  id: number;
+  spaceId: number;
+  spaceName: string;
+  status: "PENDING" | "APPROVED" | "CANCELLED" | "COMPLETED";
+  reservationDate: string;
+  startTime: string;
+  endTime: string;
+}

--- a/frontend/src/app/(resident-app)/facilities/page.tsx
+++ b/frontend/src/app/(resident-app)/facilities/page.tsx
@@ -1,8 +1,149 @@
+"use client";
+
+// #78: 공용시설 예약 페이지
+// functional-specification §3.2.1~3.2.3
+// ui-guideline: Moss & Aloe Editorial 스타일
+
+import { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { FacilityCard } from "./_components/FacilityCard";
+import { WeeklyTimetable } from "./_components/WeeklyTimetable";
+import { fetchFacilities } from "./_api";
+import type { Facility } from "./_types";
+import { ApiError } from "@/lib/api";
+
 export default function FacilitiesPage() {
+  const [facilities, setFacilities] = useState<Facility[]>([]);
+  const [selected, setSelected] = useState<Facility | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadFacilities = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetchFacilities();
+      const data = res.data ?? [];
+      setFacilities(data);
+      // 첫 예약 가능 시설 자동 선택
+      const first = data.find((f) => f.isReservable) ?? data[0] ?? null;
+      setSelected(first);
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError("시설 목록을 불러올 수 없습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadFacilities();
+  }, [loadFacilities]);
+
   return (
-    <div>
-      <h1 className="text-3xl font-bold">공용시설 예약</h1>
-      <p className="mt-2 text-muted-foreground">공용시설을 예약하세요.</p>
+    <div className="space-y-8 px-6 pt-16 pb-24 md:px-12 md:pt-32">
+      {/* 페이지 헤더 */}
+      <motion.header
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="space-y-2"
+      >
+        <p className="font-black text-xs uppercase tracking-[0.3em] text-muted-foreground">
+          Facilities
+        </p>
+        <h1 className="text-3xl font-black tracking-tighter text-primary md:text-4xl">
+          공용시설 예약
+        </h1>
+        <p className="text-sm font-medium tracking-tight text-muted-foreground text-balance">
+          시설을 선택하고 원하는 시간대를 예약하세요.
+        </p>
+      </motion.header>
+
+      {/* 시설 목록 */}
+      {loading ? (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-40 animate-pulse rounded-[2rem] bg-muted/30" />
+          ))}
+        </div>
+      ) : error ? (
+        <div className="rounded-[2rem] border border-destructive/30 bg-destructive/10 p-8 text-center">
+          <p className="text-sm font-medium text-destructive">{error}</p>
+          <button
+            onClick={loadFacilities}
+            className="mt-4 rounded-xl bg-primary px-4 py-2 text-xs font-bold text-primary-foreground"
+          >
+            다시 시도
+          </button>
+        </div>
+      ) : facilities.length === 0 ? (
+        <div className="rounded-[2rem] border border-border bg-surface p-12 text-center">
+          <p className="text-4xl">🏡</p>
+          <p className="mt-4 text-sm font-semibold text-primary">등록된 시설이 없습니다</p>
+          <p className="mt-1 text-xs text-muted-foreground">관리자에게 문의해 주세요.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {facilities.map((facility, idx) => (
+            <FacilityCard
+              key={facility.spaceId}
+              facility={facility}
+              selected={selected?.spaceId === facility.spaceId}
+              onSelect={setSelected}
+              index={idx}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* 타임테이블 */}
+      <AnimatePresence mode="wait">
+        {selected && (
+          <motion.section
+            key={selected.spaceId}
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.25 }}
+            className="space-y-4"
+          >
+            {/* 섹션 헤더 */}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-[10px] font-black uppercase tracking-[0.3em] text-muted-foreground">
+                  Timetable
+                </p>
+                <h2 className="text-xl font-black tracking-tighter text-primary">
+                  {selected.name}
+                </h2>
+              </div>
+              {!selected.isReservable && (
+                <span className="rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-[10px] font-bold text-accent">
+                  자유 이용
+                </span>
+              )}
+            </div>
+
+            {selected.isReservable ? (
+              <WeeklyTimetable
+                facility={selected}
+                onReserved={loadFacilities}
+              />
+            ) : (
+              <div className="rounded-[2rem] border border-accent/30 bg-accent/5 p-8 text-center">
+                <p className="text-3xl">✅</p>
+                <p className="mt-3 text-sm font-bold text-primary">자유 이용 시설</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  예약 없이 운영 시간 내 자유롭게 이용하실 수 있습니다.
+                </p>
+                <p className="mt-2 text-xs font-semibold text-accent">
+                  운영 시간: {selected.operatingHours}
+                </p>
+              </div>
+            )}
+          </motion.section>
+        )}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
[구현 내용]
- 공용시설 목록 (FacilityCard) — 선택/상태 시각화
- 주단위 타임테이블 Grid (WeeklyTimetable) · 가로=요일(월~일), 세로=30분 단위 시간대(06:00~23:00) · 색상 구분: 회색(타인예약) / 초록(가능) / Primary(내선택) / Navy(내예약) · 셀 클릭 연속 선택 지원 (같은 날, 자동 정렬) · 주 이동 네비게이션 (이전/다음 주) · 예약 신청 버튼 + 요약 패널 (슬롯 수 × 30분) · 피드백 토스트 (성공/실패)

[아키텍처 규칙 준수]
- 02-frontend-architecture §1: 콜로케이션 (_components, _api, _types)
- 02-frontend-architecture §3: apiFetch → /api/bff/... 경유
- ui-guideline: Moss & Aloe 시맨틱 클래스, framer-motion 마이크로 애니메이션
- api-specification §6.1~6.3: /facilities, /facilities/{id}/slots, /reservations

Closes #78