### PR TITLE
[CS/feat] 인증 필요 동작에 로그인 유도 모달 추가

### DIFF
--- a/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
@@ -5,12 +5,14 @@ import { useState, useTransition } from "react";
 import { motion } from "framer-motion";
 import { Send } from "lucide-react";
 import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
 import { cn } from "@/lib/utils";
 
 export function CommentComposer({ postId }: { postId: number }) {
   const router = useRouter();
   const [content, setContent] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [pending, startTransition] = useTransition();
 
   function submit(e: React.FormEvent) {
@@ -27,6 +29,10 @@ export function CommentComposer({ postId }: { postId: number }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
+        if (res.status === 401) {
+          setShowLoginModal(true);
+          return;
+        }
         if (res.ok) {
           setContent("");
           router.refresh();
@@ -44,6 +50,7 @@ export function CommentComposer({ postId }: { postId: number }) {
       onSubmit={submit}
       className="mt-8 rounded-[2rem] border border-border bg-background/80 p-6 backdrop-blur-sm md:p-8"
     >
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <label htmlFor={`comment-${postId}`} className="sr-only">
         댓글 작성
       </label>

--- a/frontend/src/app/(common)/comment/_components/CommentItem.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentItem.tsx
@@ -7,6 +7,7 @@ import { Edit3, Trash2 } from "lucide-react";
 import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
 import { formatDateTimeKo } from "@/lib/format-date";
 import { CancelModal } from "@/components/shared/CancelModal";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
 
 type CurrentUser = {
   userId: number;
@@ -39,6 +40,7 @@ export function CommentItem({
   const [error, setError] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   useEffect(() => {
     if (!editing) setDraft(content);
@@ -70,6 +72,10 @@ export function CommentItem({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
+        if (res.status === 401) {
+          setShowLoginModal(true);
+          return;
+        }
         if (res.ok) {
           setEditing(false);
           router.refresh();
@@ -93,6 +99,10 @@ export function CommentItem({
           method: "DELETE",
           credentials: "include",
         });
+        if (res.status === 401) {
+          setShowLoginModal(true);
+          return;
+        }
         if (res.ok) {
           router.refresh();
           return;
@@ -210,6 +220,7 @@ export function CommentItem({
           cancelEdit();
         }}
       />
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
     </li>
   );
 }

--- a/frontend/src/app/(common)/community/[postId]/page.tsx
+++ b/frontend/src/app/(common)/community/[postId]/page.tsx
@@ -1,4 +1,7 @@
+import Link from "next/link";
 import { notFound } from "next/navigation";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "../_api/bff-server";
 import type { ApiResponse, PostDetail } from "../_types/community";
 import { CommunityShell } from "../_components/CommunityShell";
@@ -24,7 +27,10 @@ export default async function CommunityPostDetailPage({ params }: { params: Para
     return (
       <CommunityShell>
         <MotionEnter>
-          <p className="mx-auto max-w-3xl text-center font-medium text-destructive">로그인이 필요합니다.</p>
+          <div className="mx-auto max-w-3xl text-center">
+            <LoginRequiredGate />
+            <p className="font-medium text-destructive">{LOGIN_REQUIRED_MESSAGE}</p>
+          </div>
         </MotionEnter>
       </CommunityShell>
     );

--- a/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
+++ b/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
@@ -6,6 +6,8 @@ import type Toolbar from "quill/modules/toolbar";
 import "quill/dist/quill.snow.css";
 import { apiFileUrlToBffPath } from "@/lib/bff-file-url";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { POST_BODY_HTML_MAX_LENGTH } from "@/lib/post-html";
 import type { ApiResponse } from "@/types/api";
 
@@ -27,6 +29,7 @@ export function CommunityRichTextEditor({ value, onChange, placeholder, id }: Pr
   onChangeRef.current = onChange;
   const lastEmittedRef = useRef("");
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -69,6 +72,11 @@ export function CommunityRichTextEditor({ value, onChange, placeholder, id }: Pr
             body: fd,
             credentials: "include",
           });
+          if (res.status === 401) {
+            setUploadError(LOGIN_REQUIRED_MESSAGE);
+            setShowLoginModal(true);
+            return;
+          }
           let json: ApiResponse<{ url: string } | null>;
           try {
             json = await res.json();
@@ -141,6 +149,7 @@ export function CommunityRichTextEditor({ value, onChange, placeholder, id }: Pr
 
   return (
     <div className="space-y-2">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <div
         className="community-quill [&_.ql-toolbar]:rounded-t-xl [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-surface [&_.ql-container]:rounded-b-xl [&_.ql-container]:border-border [&_.ql-container]:font-sans [&_.ql-editor]:min-h-[240px] [&_.ql-editor]:px-4 [&_.ql-editor]:py-3 [&_.ql-editor]:font-medium [&_.ql-editor]:text-base [&_.ql-editor]:text-foreground [&_.ql-stroke]:stroke-muted-foreground [&_.ql-fill]:fill-muted-foreground"
         ref={wrapperRef}

--- a/frontend/src/app/(common)/community/_components/LikeToggle.tsx
+++ b/frontend/src/app/(common)/community/_components/LikeToggle.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { motion } from "framer-motion";
 import { Heart } from "lucide-react";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
 import { cn } from "@/lib/utils";
 
 type Props = {
@@ -17,6 +18,7 @@ export function LikeToggle({ postId, initialLiked, initialCount }: Props) {
   const [liked, setLiked] = useState(initialLiked);
   const [count, setCount] = useState(initialCount);
   const [pending, startTransition] = useTransition();
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   function toggle() {
     startTransition(async () => {
@@ -26,6 +28,10 @@ export function LikeToggle({ postId, initialLiked, initialCount }: Props) {
           credentials: "include",
           headers: { "Content-Type": "application/json" },
         });
+        if (res.status === 401) {
+          setShowLoginModal(true);
+          return;
+        }
         const json = await res.json();
         if (!res.ok || !json.success) return;
         const d = json.data as { liked: boolean; likeCount: number };
@@ -39,22 +45,25 @@ export function LikeToggle({ postId, initialLiked, initialCount }: Props) {
   }
 
   return (
-    <motion.button
-      type="button"
-      onClick={toggle}
-      disabled={pending}
-      whileHover={{ scale: 1.02 }}
-      whileTap={{ scale: 0.98 }}
-      className={cn(
-        "inline-flex items-center gap-2 rounded-xl border px-5 py-2.5 text-xs font-black uppercase tracking-wider",
-        liked
-          ? "border-secondary bg-secondary/15 text-secondary"
-          : "border-border bg-background text-foreground hover:border-secondary/50",
-        pending && "opacity-60",
-      )}
-    >
-      <Heart className={cn("size-4", liked && "fill-current")} aria-hidden />
-      좋아요 {count}
-    </motion.button>
+    <>
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      <motion.button
+        type="button"
+        onClick={toggle}
+        disabled={pending}
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        className={cn(
+          "inline-flex items-center gap-2 rounded-xl border px-5 py-2.5 text-xs font-black uppercase tracking-wider",
+          liked
+            ? "border-secondary bg-secondary/15 text-secondary"
+            : "border-border bg-background text-foreground hover:border-secondary/50",
+          pending && "opacity-60",
+        )}
+      >
+        <Heart className={cn("size-4", liked && "fill-current")} aria-hidden />
+        좋아요 {count}
+      </motion.button>
+    </>
   );
 }

--- a/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
+++ b/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
@@ -8,6 +8,8 @@ import { ChevronDown, Edit3, Loader2, Trash2 } from "lucide-react";
 import { POST_CATEGORIES, type PostAttachment, type PostLink } from "../_types/community";
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import {
   POST_BODY_HTML_MAX_LENGTH,
   POST_TITLE_MAX_LENGTH,
@@ -98,6 +100,7 @@ export function PostEditDeleteActions({
   const [newFiles, setNewFiles] = useState<FileList | null>(null);
   const [editSession, setEditSession] = useState(0);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   useEffect(() => {
     if (editing) return;
@@ -121,6 +124,11 @@ export function PostEditDeleteActions({
         method: "DELETE",
         credentials: "include",
       });
+      if (res.status === 401) {
+        setSubmitError(LOGIN_REQUIRED_MESSAGE);
+        setShowLoginModal(true);
+        return;
+      }
       if (res.ok) router.push("/community");
     });
   }
@@ -181,6 +189,11 @@ export function PostEditDeleteActions({
           credentials: "include",
           body: formData,
         });
+        if (res.status === 401) {
+          setSubmitError(LOGIN_REQUIRED_MESSAGE);
+          setShowLoginModal(true);
+          return;
+        }
         let json: ApiResponse<unknown>;
         try {
           json = await res.json();
@@ -206,6 +219,7 @@ export function PostEditDeleteActions({
 
   return (
     <section className="mt-8 rounded-[2rem] border border-border bg-background/80 p-4 backdrop-blur-sm md:p-6">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       {!editing ? (
         <div className="flex flex-wrap items-center gap-3">
           <motion.button

--- a/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
+++ b/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
@@ -8,6 +8,8 @@ import { motion } from "framer-motion";
 import { ArrowLeft, ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import {
   POST_BODY_HTML_MAX_LENGTH,
   POST_TITLE_MAX_LENGTH,
@@ -45,6 +47,7 @@ export function NewPostForm() {
   const [files, setFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   function submit(e: React.FormEvent) {
@@ -93,6 +96,11 @@ export function NewPostForm() {
           credentials: "include",
           body: formData,
         });
+        if (res.status === 401) {
+          setSubmitError(LOGIN_REQUIRED_MESSAGE);
+          setShowLoginModal(true);
+          return;
+        }
         let json: ApiResponse<{ postId: number } | null>;
         try {
           json = await res.json();
@@ -119,6 +127,7 @@ export function NewPostForm() {
 
   return (
     <form onSubmit={submit} className="mx-auto max-w-2xl space-y-10">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <Link
         href="/community"
         className="group inline-flex items-center gap-2 font-black text-xs uppercase tracking-[0.3em] text-secondary transition-colors hover:text-foreground"

--- a/frontend/src/app/(common)/community/page.tsx
+++ b/frontend/src/app/(common)/community/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { Search } from "lucide-react";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "./_api/bff-server";
 import type { ApiResponse, PostListData } from "./_types/community";
 import { CommunityShell } from "./_components/CommunityShell";
@@ -31,7 +33,7 @@ export default async function CommunityPage({ searchParams }: { searchParams: Se
   let error: string | null = null;
 
   if (res.status === 401) {
-    error = "로그인이 필요합니다.";
+    error = LOGIN_REQUIRED_MESSAGE;
   } else if (!res.ok) {
     error = "목록을 불러오지 못했습니다.";
   } else {
@@ -75,12 +77,22 @@ export default async function CommunityPage({ searchParams }: { searchParams: Se
           </section>
 
           {error && (
+            <>
+            {error === LOGIN_REQUIRED_MESSAGE ? <LoginRequiredGate /> : null}
             <div
               className="mt-12 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
               role="alert"
             >
-              {error}
+              <p>{error}</p>
+              {error === LOGIN_REQUIRED_MESSAGE ? (
+                <p className="mt-2 text-sm">
+                  <Link href="/login" className="font-black text-secondary underline underline-offset-4">
+                    로그인 페이지로 이동
+                  </Link>
+                </p>
+              ) : null}
             </div>
+            </>
           )}
 
           {list && (

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { Bell } from "lucide-react";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "./_api/bff-server";
 
 type ApiResponse<T> = {
@@ -51,7 +53,7 @@ export default async function NotificationsPage({ searchParams }: { searchParams
   let error: string | null = null;
 
   if (res.status === 401) {
-    error = "로그인이 필요합니다.";
+    error = LOGIN_REQUIRED_MESSAGE;
   } else if (!res.ok) {
     error = "알림을 불러오지 못했습니다.";
   } else {
@@ -73,12 +75,22 @@ export default async function NotificationsPage({ searchParams }: { searchParams
       </header>
 
       {error && (
+        <>
+        {error === LOGIN_REQUIRED_MESSAGE ? <LoginRequiredGate /> : null}
         <div
           className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
           role="alert"
         >
-          {error}
+          <p>{error}</p>
+          {error === LOGIN_REQUIRED_MESSAGE ? (
+            <p className="mt-2 text-sm">
+              <Link href="/login" className="font-black text-secondary underline underline-offset-4">
+                로그인 페이지로 이동
+              </Link>
+            </p>
+          ) : null}
         </div>
+        </>
       )}
 
       {list && (

--- a/frontend/src/app/(common)/vocs/[vocId]/edit/_components/VocEditForm.tsx
+++ b/frontend/src/app/(common)/vocs/[vocId]/edit/_components/VocEditForm.tsx
@@ -8,6 +8,8 @@ import { motion } from "framer-motion";
 import { ArrowLeft, ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { plainTextFromHtml } from "@/lib/post-html";
 import type { ApiResponse } from "@/types/api";
 import {
@@ -55,6 +57,7 @@ export function VocEditForm({ initial }: Props) {
   const [newFiles, setNewFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   function removeAttachment(index: number) {
@@ -109,6 +112,11 @@ export function VocEditForm({ initial }: Props) {
           credentials: "include",
           body: formData,
         });
+        if (res.status === 401) {
+          setError(LOGIN_REQUIRED_MESSAGE);
+          setShowLoginModal(true);
+          return;
+        }
         let json: ApiResponse<unknown>;
         try {
           json = await res.json();
@@ -132,6 +140,7 @@ export function VocEditForm({ initial }: Props) {
 
   return (
     <form onSubmit={submit} className="mx-auto max-w-2xl space-y-10">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <Link
         href={`/vocs/${initial.vocId}`}
         className="group inline-flex items-center gap-2 font-black text-xs uppercase tracking-[0.3em] text-secondary transition-colors hover:text-foreground"

--- a/frontend/src/app/(common)/vocs/[vocId]/edit/page.tsx
+++ b/frontend/src/app/(common)/vocs/[vocId]/edit/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "../../_api/bff-server";
 import type { ApiResponse, VocDetail } from "../../_types/vocs";
 import { VocShell } from "../../_components/VocShell";
@@ -23,7 +25,10 @@ export default async function VocEditPage({ params }: { params: Params }) {
     return (
       <VocShell>
         <MotionEnter>
-          <p className="mx-auto max-w-3xl text-center font-medium text-destructive">로그인이 필요합니다.</p>
+          <div className="mx-auto max-w-3xl text-center">
+            <LoginRequiredGate />
+            <p className="font-medium text-destructive">{LOGIN_REQUIRED_MESSAGE}</p>
+          </div>
         </MotionEnter>
       </VocShell>
     );

--- a/frontend/src/app/(common)/vocs/[vocId]/page.tsx
+++ b/frontend/src/app/(common)/vocs/[vocId]/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "../_api/bff-server";
 import type { ApiResponse, VocDetail } from "../_types/vocs";
 import { VocShell } from "../_components/VocShell";
@@ -46,7 +48,10 @@ export default async function VocDetailPage({ params }: { params: Params }) {
     return (
       <VocShell>
         <MotionEnter>
-          <p className="mx-auto max-w-3xl text-center font-medium text-destructive">로그인이 필요합니다.</p>
+          <div className="mx-auto max-w-3xl text-center">
+            <LoginRequiredGate />
+            <p className="font-medium text-destructive">{LOGIN_REQUIRED_MESSAGE}</p>
+          </div>
         </MotionEnter>
       </VocShell>
     );

--- a/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
@@ -2,15 +2,17 @@
 
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { motion } from "framer-motion";
 import { Loader2, Pencil, Ban } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
 
 export function VocDetailActions({ vocId, status }: { vocId: number; status: string }) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const canMutate = status === "OPEN";
 
   function cancelVoc() {
@@ -23,6 +25,10 @@ export function VocDetailActions({ vocId, status }: { vocId: number; status: str
           method: "POST",
           credentials: "include",
         });
+        if (res.status === 401) {
+          setShowLoginModal(true);
+          return;
+        }
         if (res.ok) {
           router.refresh();
           return;
@@ -37,28 +43,31 @@ export function VocDetailActions({ vocId, status }: { vocId: number; status: str
   if (!canMutate) return null;
 
   return (
-    <div className="mt-10 flex flex-wrap items-center justify-end gap-3 border-t border-border pt-10">
-      <Link
-        href={`/vocs/${vocId}/edit`}
-        className="inline-flex items-center gap-2 rounded-xl border border-secondary bg-secondary/15 px-5 py-2.5 text-[11px] font-black uppercase tracking-wider text-secondary transition-transform hover:-translate-y-0.5"
-      >
-        <Pencil className="size-4" aria-hidden />
-        수정
-      </Link>
-      <motion.button
-        type="button"
-        disabled={pending}
-        whileHover={{ scale: 1.02 }}
-        whileTap={{ scale: 0.98 }}
-        onClick={cancelVoc}
-        className={cn(
-          "inline-flex items-center gap-2 rounded-xl border border-destructive/40 bg-destructive/10 px-5 py-2.5 text-[11px] font-black uppercase tracking-wider text-destructive",
-          pending && "opacity-60",
-        )}
-      >
-        {pending ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <Ban className="size-4" aria-hidden />}
-        민원 취소
-      </motion.button>
-    </div>
+    <>
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      <div className="mt-10 flex flex-wrap items-center justify-end gap-3 border-t border-border pt-10">
+        <Link
+          href={`/vocs/${vocId}/edit`}
+          className="inline-flex items-center gap-2 rounded-xl border border-secondary bg-secondary/15 px-5 py-2.5 text-[11px] font-black uppercase tracking-wider text-secondary transition-transform hover:-translate-y-0.5"
+        >
+          <Pencil className="size-4" aria-hidden />
+          수정
+        </Link>
+        <motion.button
+          type="button"
+          disabled={pending}
+          whileHover={{ scale: 1.02 }}
+          whileTap={{ scale: 0.98 }}
+          onClick={cancelVoc}
+          className={cn(
+            "inline-flex items-center gap-2 rounded-xl border border-destructive/40 bg-destructive/10 px-5 py-2.5 text-[11px] font-black uppercase tracking-wider text-destructive",
+            pending && "opacity-60",
+          )}
+        >
+          {pending ? <Loader2 className="size-4 animate-spin" aria-hidden /> : <Ban className="size-4" aria-hidden />}
+          민원 취소
+        </motion.button>
+      </div>
+    </>
   );
 }

--- a/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
@@ -6,6 +6,8 @@ import type Toolbar from "quill/modules/toolbar";
 import "quill/dist/quill.snow.css";
 import { apiFileUrlToBffPath } from "@/lib/bff-file-url";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { VOC_BODY_HTML_MAX_LENGTH } from "@/lib/vocs-html";
 import type { ApiResponse } from "@/types/api";
 
@@ -27,6 +29,7 @@ export function VocRichTextEditor({ value, onChange, placeholder, id }: Props) {
   onChangeRef.current = onChange;
   const lastEmittedRef = useRef("");
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
 
   useEffect(() => {
     const wrapper = wrapperRef.current;
@@ -69,6 +72,11 @@ export function VocRichTextEditor({ value, onChange, placeholder, id }: Props) {
             body: fd,
             credentials: "include",
           });
+          if (res.status === 401) {
+            setUploadError(LOGIN_REQUIRED_MESSAGE);
+            setShowLoginModal(true);
+            return;
+          }
           let json: ApiResponse<{ url: string } | null>;
           try {
             json = await res.json();
@@ -141,6 +149,7 @@ export function VocRichTextEditor({ value, onChange, placeholder, id }: Props) {
 
   return (
     <div className="space-y-2">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <div
         className="voc-quill [&_.ql-toolbar]:rounded-t-xl [&_.ql-toolbar]:border-border [&_.ql-toolbar]:bg-surface [&_.ql-container]:rounded-b-xl [&_.ql-container]:border-border [&_.ql-container]:font-sans [&_.ql-editor]:min-h-[220px] [&_.ql-editor]:px-4 [&_.ql-editor]:py-3 [&_.ql-editor]:font-medium [&_.ql-editor]:text-base [&_.ql-editor]:text-foreground [&_.ql-stroke]:stroke-muted-foreground [&_.ql-fill]:fill-muted-foreground"
         ref={wrapperRef}

--- a/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
+++ b/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
@@ -8,6 +8,8 @@ import { motion } from "framer-motion";
 import { ArrowLeft, ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { plainTextFromHtml } from "@/lib/post-html";
 import type { ApiResponse } from "@/types/api";
 import {
@@ -42,6 +44,7 @@ export function NewVocForm() {
   const [files, setFiles] = useState<FileList | null>(null);
   const [pending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   function submit(e: React.FormEvent) {
@@ -82,6 +85,11 @@ export function NewVocForm() {
           credentials: "include",
           body: formData,
         });
+        if (res.status === 401) {
+          setError(LOGIN_REQUIRED_MESSAGE);
+          setShowLoginModal(true);
+          return;
+        }
         let json: ApiResponse<{ vocId: number } | null>;
         try {
           json = await res.json();
@@ -110,6 +118,7 @@ export function NewVocForm() {
 
   return (
     <form onSubmit={submit} className="mx-auto max-w-2xl space-y-10">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
       <Link
         href="/vocs"
         className="group inline-flex items-center gap-2 font-black text-xs uppercase tracking-[0.3em] text-secondary transition-colors hover:text-foreground"

--- a/frontend/src/app/(common)/vocs/page.tsx
+++ b/frontend/src/app/(common)/vocs/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import { ClipboardList } from "lucide-react";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "./_api/bff-server";
 import type { ApiResponse, VocListData } from "./_types/vocs";
 import { VocShell } from "./_components/VocShell";
@@ -28,7 +30,7 @@ export default async function VocPage({ searchParams }: { searchParams: SearchPa
   let error: string | null = null;
 
   if (res.status === 401) {
-    error = "로그인이 필요합니다.";
+    error = LOGIN_REQUIRED_MESSAGE;
   } else if (!res.ok) {
     error = "목록을 불러오지 못했습니다.";
   } else {
@@ -61,12 +63,22 @@ export default async function VocPage({ searchParams }: { searchParams: SearchPa
           </header>
 
           {error && (
+            <>
+            {error === LOGIN_REQUIRED_MESSAGE ? <LoginRequiredGate /> : null}
             <div
               className="mt-12 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
               role="alert"
             >
-              {error}
+              <p>{error}</p>
+              {error === LOGIN_REQUIRED_MESSAGE ? (
+                <p className="mt-2 text-sm">
+                  <Link href="/login" className="font-black text-secondary underline underline-offset-4">
+                    로그인 페이지로 이동
+                  </Link>
+                </p>
+              ) : null}
             </div>
+            </>
           )}
 
           {list && (

--- a/frontend/src/components/shared/LoginRequiredGate.tsx
+++ b/frontend/src/components/shared/LoginRequiredGate.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useState } from "react";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+
+export function LoginRequiredGate() {
+  const [open, setOpen] = useState(true);
+  return <LoginRequiredModal isOpen={open} onClose={() => setOpen(false)} />;
+}

--- a/frontend/src/components/shared/LoginRequiredModal.tsx
+++ b/frontend/src/components/shared/LoginRequiredModal.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
+import { ShieldAlert } from "lucide-react";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+
+type LoginRequiredModalProps = {
+  isOpen: boolean;
+  onClose?: () => void;
+  title?: string;
+  description?: string;
+  loginHref?: string;
+};
+
+export function LoginRequiredModal({
+  isOpen,
+  onClose,
+  title = LOGIN_REQUIRED_MESSAGE,
+  description = "로그인 후 커뮤니티·댓글·민원·알림 기능을 이용할 수 있습니다.",
+  loginHref = "/login",
+}: LoginRequiredModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <div className="fixed inset-0 z-[120] flex items-center justify-center p-6">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-primary/30 backdrop-blur-sm"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 12, scale: 0.97 }}
+            transition={{ type: "spring", damping: 24, stiffness: 280 }}
+            className="relative w-full max-w-sm rounded-[1.75rem] border border-border bg-background p-7 shadow-2xl"
+          >
+            <div className="mx-auto mb-5 flex size-14 items-center justify-center rounded-full bg-destructive/10">
+              <ShieldAlert className="size-7 text-destructive" aria-hidden />
+            </div>
+            <h3 className="text-center text-2xl font-black tracking-tight text-foreground">{title}</h3>
+            <p className="mt-3 text-center text-sm font-medium tracking-tight text-muted-foreground">{description}</p>
+            <div className="mt-7 flex flex-col gap-2">
+              <Link
+                href={loginHref}
+                className="w-full rounded-xl bg-primary px-5 py-3 text-center text-sm font-black uppercase tracking-wider text-primary-foreground"
+              >
+                로그인 페이지로 이동
+              </Link>
+              {onClose ? (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="w-full rounded-xl border border-border bg-muted/30 px-5 py-3 text-sm font-black uppercase tracking-wider text-foreground"
+                >
+                  닫기
+                </button>
+              ) : null}
+            </div>
+          </motion.div>
+        </div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,6 +3,14 @@ import { ApiResponse } from '@/types/api';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
 
+function parseApiJson<T>(text: string): ApiResponse<T> {
+  try {
+    return JSON.parse(text) as ApiResponse<T>;
+  } catch {
+    throw new ApiError('서버 응답을 처리하지 못했습니다.', undefined);
+  }
+}
+
 export async function apiFetch<T>(
   path: string,
   options?: RequestInit
@@ -16,7 +24,32 @@ export async function apiFetch<T>(
     credentials: 'include',   // httpOnly 쿠키 자동 전달
   });
 
-  const data: ApiResponse<T> = await response.json();
+  const text = await response.text();
+  const trimmed = text.trim();
+  const looksJson = trimmed.startsWith('{') || trimmed.startsWith('[');
+
+  if (!response.ok) {
+    if (response.status === 403) {
+      throw new ApiError(
+        '이 작업을 수행할 권한이 없습니다. DB에 role이 ADMIN인 계정으로 로그인했는지 확인해 주세요.',
+        'FORBIDDEN',
+      );
+    }
+    if (response.status === 401) {
+      throw new ApiError('로그인이 필요합니다.', 'UNAUTHORIZED');
+    }
+    if (looksJson && trimmed.length > 0) {
+      const data = parseApiJson<T>(trimmed);
+      throw new ApiError(data.message || '요청에 실패했습니다', data.error_code);
+    }
+    throw new ApiError(`요청에 실패했습니다 (${response.status})`, undefined);
+  }
+
+  if (!looksJson || trimmed.length === 0) {
+    throw new ApiError('서버 응답 형식이 올바르지 않습니다.', undefined);
+  }
+
+  const data = parseApiJson<T>(trimmed);
 
   if (!data.success) {
     throw new ApiError(data.message || '요청에 실패했습니다', data.error_code);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,5 +1,6 @@
 // src/lib/api.ts
 import { ApiResponse } from '@/types/api';
+import { LOGIN_REQUIRED_MESSAGE } from '@/lib/auth-messages';
 
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
 
@@ -36,7 +37,7 @@ export async function apiFetch<T>(
       );
     }
     if (response.status === 401) {
-      throw new ApiError('로그인이 필요합니다.', 'UNAUTHORIZED');
+      throw new ApiError(LOGIN_REQUIRED_MESSAGE, 'UNAUTHORIZED');
     }
     if (looksJson && trimmed.length > 0) {
       const data = parseApiJson<T>(trimmed);

--- a/frontend/src/lib/auth-messages.ts
+++ b/frontend/src/lib/auth-messages.ts
@@ -1,0 +1,2 @@
+/** 인증이 필요할 때 UI·API 오류 메시지로 사용합니다. */
+export const LOGIN_REQUIRED_MESSAGE = "로그인이 필요합니다.";

--- a/frontend/src/lib/bff-error-message.ts
+++ b/frontend/src/lib/bff-error-message.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from "@/types/api";
+import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 
 const DEFAULT_SAVE_FAIL = "저장하지 못했습니다. 잠시 후 다시 시도해 주세요.";
 
@@ -7,6 +8,9 @@ export function messageFromBffResponse<T>(
   json: ApiResponse<T>,
   fallback: string = DEFAULT_SAVE_FAIL,
 ): string {
+  if (json.error_code === "UNAUTHORIZED") {
+    return LOGIN_REQUIRED_MESSAGE;
+  }
   const m = json.message?.trim();
   if (m) return m;
   return fallback;
@@ -20,6 +24,9 @@ export async function bffErrorMessageFromResponse(
   res: Response,
   fallback: string = DEFAULT_SAVE_FAIL,
 ): Promise<string> {
+  if (res.status === 401) {
+    return LOGIN_REQUIRED_MESSAGE;
+  }
   try {
     const json = (await res.json()) as ApiResponse<unknown>;
     return messageFromBffResponse(json, fallback);


### PR DESCRIPTION
### Summary

community/comment/voc/notification에서 인증이 필요한 요청이 401로 실패할 때, 사용자에게 원인을 명확히 전달하도록 로그인 안내 UX를 통일했습니다.
공통 LoginRequiredModal/LoginRequiredGate를 추가하고, 조회(서버 페이지)와 등록/수정/액션(클라이언트 컴포넌트) 경로에 적용했습니다.
api/bff-error-message에서 401 처리와 메시지를 공통 상수(LOGIN_REQUIRED_MESSAGE)로 통일해 일관된 안내가 나오도록 정리했습니다.
추가로 에디터 이미지 업로드(community, voc) 경로에도 401 분기를 넣어, 빈 응답 파싱 오류 대신 로그인 모달이 뜨도록 보완했습니다.

### 주요 변경 파일

frontend/src/components/shared/LoginRequiredModal.tsx
frontend/src/components/shared/LoginRequiredGate.tsx
frontend/src/lib/auth-messages.ts
frontend/src/lib/api.ts
frontend/src/lib/bff-error-message.ts
frontend/src/app/(common)/community/**
frontend/src/app/(common)/comment/**
frontend/src/app/(common)/vocs/**
frontend/src/app/(common)/notifications/page.tsx

### Test Plan

 비로그인 상태에서 community 목록/상세 접근 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 댓글 작성/수정/삭제 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 community 좋아요 클릭 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 community 글 등록/수정/삭제 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 voc 목록/상세/수정 페이지 접근 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 voc 등록/수정/취소 시 로그인 안내 모달 노출 확인

 비로그인 상태에서 community/voc 에디터 이미지 업로드 시 로그인 안내 모달 노출 확인

 모달의 로그인 페이지로 이동 버튼이 /login으로 이동하는지 확인

 로그인 상태에서는 기존 정상 플로우(조회/등록/수정/액션)가 회귀 없이 동작하는지 확인