### PR TITLE
fix(security): GET /api/facilities 비로그인 접근 허용

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/facilities").permitAll() // §6.1 🔓 Public
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
 
                         // ADMIN only


### PR DESCRIPTION
[원인]
api-specification.md §6.1 — GET /api/facilities는 🔓 Public으로 정의되어 있으나 SecurityConfig에서 /api/facilities/**를 RESIDENT/ADMIN 전용으로 설정하여 비로그인 상태에서 시설 목록 조회 시 403 반환됨

[수정]
.requestMatchers(HttpMethod.GET, "/api/facilities").permitAll() 추가

[영향]
- GET /api/facilities (시설 목록) → 비로그인 허용
- GET /api/facilities/{id}/slots (타임슬롯) → 기존과 동일하게 RESIDENT/ADMIN 유지
