### PR TITLE
[CS/feat] 트리형 대댓글 + VOC 회원 전용 UX/권한 정비

### DIFF
--- a/backend/src/main/java/com/coliving/common/comment/adapter/in/web/CommentController.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/in/web/CommentController.java
@@ -35,6 +35,7 @@ public class CommentController {
                 .actorId(actor.actorId)
                 .actorRole(actor.actorRole)
                 .postId(postId)
+                .parentCommentId(request.getParentCommentId())
                 .content(request.getContent())
                 .build();
 

--- a/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/CreateCommentRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/in/web/dto/req/CreateCommentRequestDto.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 @Getter
 public class CreateCommentRequestDto {
 
+    private Long parentCommentId;
+
     @NotBlank
     @Size(max = 2000)
     private String content;

--- a/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentEntity.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentEntity.java
@@ -33,6 +33,10 @@ public class CommentEntity extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private PostEntity post;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private CommentEntity parentComment;
+
     @Column(name = "user_id", nullable = false)
     private Long userId;
 
@@ -43,8 +47,16 @@ public class CommentEntity extends BaseEntity {
         return post == null ? null : post.getPostId();
     }
 
+    public Long getParentCommentId() {
+        return parentComment == null ? null : parentComment.getCommentId();
+    }
+
     public void setPost(PostEntity post) {
         this.post = post;
+    }
+
+    public void setParentComment(CommentEntity parentComment) {
+        this.parentComment = parentComment;
     }
 
     public void setUserId(Long userId) {

--- a/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentJpaRepository.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/out/jpa/CommentJpaRepository.java
@@ -12,6 +12,10 @@ public interface CommentJpaRepository extends JpaRepository<CommentEntity, Long>
 
     Optional<CommentEntity> findByCommentId(Long commentId);
 
+    Optional<CommentEntity> findByCommentIdAndPost_PostId(Long commentId, Long postId);
+
+    boolean existsByParentComment_CommentId(Long parentCommentId);
+
     @EntityGraph(attributePaths = {"post"})
     List<CommentEntity> findByPost_PostId(Long postId, Sort sort);
 

--- a/backend/src/main/java/com/coliving/common/comment/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/comment/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -43,13 +43,18 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
     }
 
     @Override
-    public Comment createComment(Long postId, Long userId, String content) {
+    public Comment createComment(Long postId, Long userId, Long parentCommentId, String content) {
         if (!postJpaRepository.existsById(postId)) {
             throw new BusinessException(ErrorCode.NOT_FOUND);
         }
 
         CommentEntity entity = new CommentEntity();
         entity.setPost(postJpaRepository.getReferenceById(postId));
+        if (parentCommentId != null) {
+            CommentEntity parent = commentJpaRepository.findByCommentIdAndPost_PostId(parentCommentId, postId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+            entity.setParentComment(parent);
+        }
         entity.setUserId(userId);
         entity.setContent(content);
         entity = commentJpaRepository.save(entity);
@@ -68,6 +73,11 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
         entity = commentJpaRepository.save(entity);
 
         return mapCommentEntityToModel(entity);
+    }
+
+    @Override
+    public boolean hasActiveChildren(Long commentId) {
+        return commentJpaRepository.existsByParentComment_CommentId(commentId);
     }
 
     @Override
@@ -97,6 +107,7 @@ public class CommentPersistenceAdapter implements CommentRepositoryPort {
         return Comment.builder()
                 .commentId(entity.getCommentId())
                 .postId(entity.getPostId())
+                .parentCommentId(entity.getParentCommentId())
                 .userId(entity.getUserId())
                 .content(entity.getContent())
                 .createdAt(entity.getCreatedAt())

--- a/backend/src/main/java/com/coliving/common/comment/application/command/CreateCommentCommand.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/command/CreateCommentCommand.java
@@ -10,6 +10,7 @@ public class CreateCommentCommand {
     private final Long actorId;
     private final ActorRole actorRole;
     private final Long postId;
+    private final Long parentCommentId;
     private final String content;
 }
 

--- a/backend/src/main/java/com/coliving/common/comment/application/port/out/CommentRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/port/out/CommentRepositoryPort.java
@@ -12,9 +12,11 @@ public interface CommentRepositoryPort {
 
     Optional<Comment> findCommentById(Long commentId);
 
-    Comment createComment(Long postId, Long userId, String content);
+    Comment createComment(Long postId, Long userId, Long parentCommentId, String content);
 
     Comment updateComment(Long commentId, String content);
+
+    boolean hasActiveChildren(Long commentId);
 
     void softDeleteComment(Long commentId);
 

--- a/backend/src/main/java/com/coliving/common/comment/application/service/CommentService.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/service/CommentService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class CommentService implements CommentUseCase {
+    private static final String DELETED_WITH_REPLY_PLACEHOLDER = "[삭제된 댓글입니다.]";
 
     private final CommentRepositoryPort commentRepositoryPort;
 
@@ -26,6 +27,7 @@ public class CommentService implements CommentUseCase {
         Comment created = commentRepositoryPort.createComment(
                 command.getPostId(),
                 command.getActorId(),
+                command.getParentCommentId(),
                 command.getContent()
         );
 
@@ -41,6 +43,11 @@ public class CommentService implements CommentUseCase {
     public CommentResult updateComment(UpdateCommentCommand command) {
         Comment existing = commentRepositoryPort.findCommentById(command.getCommentId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 자식 댓글 보존을 위해 삭제 처리된 부모 댓글은 수정 불가
+        if (DELETED_WITH_REPLY_PLACEHOLDER.equals(existing.getContent())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
 
         if (command.getActorRole() != ActorRole.ADMIN && !existing.getUserId().equals(command.getActorId())) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
@@ -65,7 +72,11 @@ public class CommentService implements CommentUseCase {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        commentRepositoryPort.softDeleteComment(command.getCommentId());
+        if (commentRepositoryPort.hasActiveChildren(command.getCommentId())) {
+            commentRepositoryPort.updateComment(command.getCommentId(), DELETED_WITH_REPLY_PLACEHOLDER);
+        } else {
+            commentRepositoryPort.softDeleteComment(command.getCommentId());
+        }
 
         return CommentResult.builder()
                 .commentId(existing.getCommentId())

--- a/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/in/web/CommunityController.java
@@ -260,6 +260,7 @@ public class CommunityController {
 
         return PostCommentResponseDto.builder()
                 .commentId(comment.getCommentId())
+                .parentCommentId(comment.getParentCommentId())
                 .content(comment.getContent())
                 .author(author)
                 .createdAt(comment.getCreatedAt())

--- a/backend/src/main/java/com/coliving/common/community/adapter/in/web/dto/res/PostCommentResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/in/web/dto/res/PostCommentResponseDto.java
@@ -9,6 +9,7 @@ import java.time.OffsetDateTime;
 @Builder
 public class PostCommentResponseDto {
     private final Long commentId;
+    private final Long parentCommentId;
     private final String content;
     private final PostAuthorResponseDto author;
     private final OffsetDateTime createdAt;

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
@@ -155,8 +155,8 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
     }
 
     @Override
-    public Comment createComment(Long postId, Long userId, String content) {
-        return commentRepositoryPort.createComment(postId, userId, content);
+    public Comment createComment(Long postId, Long userId, Long parentCommentId, String content) {
+        return commentRepositoryPort.createComment(postId, userId, parentCommentId, content);
     }
 
     @Override

--- a/backend/src/main/java/com/coliving/common/community/application/command/CreateCommentCommand.java
+++ b/backend/src/main/java/com/coliving/common/community/application/command/CreateCommentCommand.java
@@ -10,6 +10,7 @@ public class CreateCommentCommand {
     private final Long actorId;
     private final ActorRole actorRole;
     private final Long postId;
+    private final Long parentCommentId;
     private final String content;
 }
 

--- a/backend/src/main/java/com/coliving/common/community/application/port/out/CommunityRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/common/community/application/port/out/CommunityRepositoryPort.java
@@ -42,7 +42,7 @@ public interface CommunityRepositoryPort {
 
     Post incrementViewCount(Long postId);
 
-    Comment createComment(Long postId, Long userId, String content);
+    Comment createComment(Long postId, Long userId, Long parentCommentId, String content);
 
     Optional<Comment> findCommentById(Long commentId);
 

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -210,6 +210,7 @@ public class CommunityService implements CommunityUseCase {
         Comment created = repositoryPort.createComment(
                 command.getPostId(),
                 command.getActorId(),
+                command.getParentCommentId(),
                 command.getContent()
         );
 

--- a/backend/src/main/java/com/coliving/common/community/model/Comment.java
+++ b/backend/src/main/java/com/coliving/common/community/model/Comment.java
@@ -10,6 +10,7 @@ import java.time.OffsetDateTime;
 public class Comment {
     private Long commentId;
     private Long postId;
+    private Long parentCommentId;
     private Long userId;
     private String content;
     private OffsetDateTime createdAt;

--- a/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
@@ -29,7 +29,7 @@ export function CommentComposer({ postId }: { postId: number }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/comment/_components/CommentItem.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentItem.tsx
@@ -72,7 +72,7 @@ export function CommentItem({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setShowLoginModal(true);
           return;
         }
@@ -99,7 +99,7 @@ export function CommentItem({
           method: "DELETE",
           credentials: "include",
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/comment/_components/CommentItem.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentItem.tsx
@@ -21,6 +21,7 @@ export function CommentItem({
   authorName,
   createdAt,
   currentUser,
+  footerSlot,
 }: {
   commentId: number;
   content: string;
@@ -28,6 +29,7 @@ export function CommentItem({
   authorName: string;
   createdAt: string;
   currentUser?: CurrentUser;
+  footerSlot?: React.ReactNode;
 }) {
   const router = useRouter();
   const canMutate =
@@ -221,6 +223,7 @@ export function CommentItem({
         }}
       />
       <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      {footerSlot ? <div className="mt-4">{footerSlot}</div> : null}
     </li>
   );
 }

--- a/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { MessageCircle, CornerDownRight } from "lucide-react";
+import { motion } from "framer-motion";
+import { CommentItem } from "./CommentItem";
+import type { PostAuthor, PostComment } from "../../community/_types/community";
+import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
+import { cn } from "@/lib/utils";
+
+type CurrentUser = {
+  userId: number;
+  role?: string | null;
+};
+
+type CommentNode = PostComment & { children: CommentNode[] };
+
+function sortById(a: PostComment, b: PostComment) {
+  return a.commentId - b.commentId;
+}
+
+function buildTree(flatComments: PostComment[]): CommentNode[] {
+  const ordered = [...flatComments].sort(sortById);
+  const byId = new Map<number, CommentNode>();
+  const roots: CommentNode[] = [];
+
+  for (const c of ordered) {
+    byId.set(c.commentId, { ...c, children: [] });
+  }
+
+  for (const c of ordered) {
+    const node = byId.get(c.commentId);
+    if (!node) continue;
+    const parentId = c.parentCommentId ?? null;
+    if (!parentId) {
+      roots.push(node);
+      continue;
+    }
+    const parent = byId.get(parentId);
+    if (!parent) roots.push(node);
+    else parent.children.push(node);
+  }
+
+  return roots;
+}
+
+export function CommentThreadSection({
+  postId,
+  initialComments,
+  currentUser,
+}: {
+  postId: number;
+  initialComments: PostComment[];
+  currentUser?: CurrentUser;
+}) {
+  const router = useRouter();
+  const [comments, setComments] = useState<PostComment[]>(initialComments);
+  const [rootDraft, setRootDraft] = useState("");
+  const [replyDraftById, setReplyDraftById] = useState<Record<number, string>>({});
+  const [openReplyForId, setOpenReplyForId] = useState<number | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  useEffect(() => {
+    setComments(initialComments);
+  }, [initialComments]);
+
+  const tree = useMemo(() => buildTree(comments), [comments]);
+
+  function optimisticAuthor(): PostAuthor {
+    if (currentUser) {
+      return { userId: currentUser.userId, name: "나" };
+    }
+    return { userId: 0, name: "회원" };
+  }
+
+  function addComment(parentCommentId: number | null, content: string) {
+    const text = content.trim();
+    if (!text || pending) return;
+    setSubmitError(null);
+
+    startTransition(async () => {
+      const tempId = Date.now();
+      const optimistic: PostComment = {
+        commentId: tempId,
+        parentCommentId,
+        content: text,
+        author: optimisticAuthor(),
+        createdAt: new Date().toISOString(),
+      };
+      setComments((prev) => [...prev, optimistic]);
+
+      if (parentCommentId == null) setRootDraft("");
+      else setReplyDraftById((prev) => ({ ...prev, [parentCommentId]: "" }));
+
+      try {
+        const res = await fetch(`/api/bff/posts/${postId}/comments`, {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: text, parentCommentId }),
+        });
+
+        if (res.status === 401 || res.status === 403) {
+          setShowLoginModal(true);
+          setComments((prev) => prev.filter((c) => c.commentId !== tempId));
+          return;
+        }
+
+        if (!res.ok) {
+          setSubmitError(await bffErrorMessageFromResponse(res));
+          setComments((prev) => prev.filter((c) => c.commentId !== tempId));
+          return;
+        }
+
+        // 서버 정렬/권한 결과를 기준으로 정확히 동기화
+        setOpenReplyForId(null);
+        router.refresh();
+      } catch {
+        setSubmitError("연결에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+        setComments((prev) => prev.filter((c) => c.commentId !== tempId));
+      }
+    });
+  }
+
+  function renderNodes(nodes: CommentNode[], depth: number): React.ReactNode {
+    return nodes.map((node) => {
+      const replyDraft = replyDraftById[node.commentId] ?? "";
+      const openReply = openReplyForId === node.commentId;
+
+      return (
+        <div key={node.commentId} className={cn(depth > 0 && "ml-5 border-l border-border pl-4 md:ml-8 md:pl-6")}>
+          <ul className="space-y-4">
+            <CommentItem
+              commentId={node.commentId}
+              content={node.content}
+              authorUserId={node.author.userId}
+              authorName={node.author.name}
+              createdAt={node.createdAt}
+              currentUser={currentUser}
+              footerSlot={
+                <div className="flex flex-col gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setOpenReplyForId(openReply ? null : node.commentId)}
+                    className="inline-flex w-fit items-center gap-1.5 text-[11px] font-black uppercase tracking-wider text-muted-foreground hover:text-foreground"
+                  >
+                    <CornerDownRight className="size-3.5" aria-hidden />
+                    답글
+                  </button>
+                  {openReply ? (
+                    <form
+                      onSubmit={(e) => {
+                        e.preventDefault();
+                        addComment(node.commentId, replyDraft);
+                      }}
+                      className="rounded-xl border border-border bg-muted/20 p-3"
+                    >
+                      <textarea
+                        value={replyDraft}
+                        onChange={(e) => setReplyDraftById((prev) => ({ ...prev, [node.commentId]: e.target.value }))}
+                        rows={2}
+                        placeholder="답글을 입력하세요"
+                        className="w-full resize-y rounded-lg border border-input bg-surface px-3 py-2 text-sm font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      />
+                      <div className="mt-2 flex justify-end gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setOpenReplyForId(null)}
+                          className="rounded-lg border border-border px-3 py-1.5 text-[11px] font-black uppercase tracking-wider text-foreground"
+                        >
+                          취소
+                        </button>
+                        <motion.button
+                          type="submit"
+                          disabled={pending || !replyDraft.trim()}
+                          whileHover={{ scale: 1.02 }}
+                          whileTap={{ scale: 0.98 }}
+                          className="rounded-lg bg-primary px-3 py-1.5 text-[11px] font-black uppercase tracking-wider text-primary-foreground disabled:opacity-50"
+                        >
+                          등록
+                        </motion.button>
+                      </div>
+                    </form>
+                  ) : null}
+                </div>
+              }
+            />
+          </ul>
+          {node.children.length > 0 ? <div className="mt-4 space-y-4">{renderNodes(node.children, depth + 1)}</div> : null}
+        </div>
+      );
+    });
+  }
+
+  return (
+    <section className="mt-14 border-t border-border pt-12">
+      <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      <h2 className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">댓글</h2>
+
+      {tree.length === 0 ? (
+        <div
+          className="mt-8 flex flex-col items-center justify-center gap-4 rounded-[2rem] border border-dashed border-border bg-background/60 px-8 py-14 text-center backdrop-blur-sm md:px-12"
+          aria-live="polite"
+        >
+          <MessageCircle className="size-10 text-muted-foreground opacity-80" strokeWidth={1.25} aria-hidden />
+          <p className="max-w-sm font-medium tracking-tight text-balance text-muted-foreground md:text-base">
+            아직 댓글이 없습니다. 첫 댓글을 남겨 대화를 시작해 보세요.
+          </p>
+        </div>
+      ) : (
+        <div className="mt-8 space-y-6">{renderNodes(tree, 0)}</div>
+      )}
+
+      {submitError ? (
+        <p
+          role="alert"
+          className="mt-6 rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm font-medium tracking-tight text-destructive"
+        >
+          {submitError}
+        </p>
+      ) : null}
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          addComment(null, rootDraft);
+        }}
+        className="mt-8 rounded-[2rem] border border-border bg-background/80 p-6 backdrop-blur-sm md:p-8"
+      >
+        <label htmlFor={`comment-root-${postId}`} className="sr-only">
+          댓글 작성
+        </label>
+        <textarea
+          id={`comment-root-${postId}`}
+          value={rootDraft}
+          onChange={(e) => setRootDraft(e.target.value)}
+          rows={3}
+          placeholder="댓글을 입력하세요"
+          className="w-full resize-y rounded-xl border border-input bg-surface px-4 py-3 font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        />
+        <div className="mt-4 flex justify-end">
+          <motion.button
+            type="submit"
+            disabled={pending || !rootDraft.trim()}
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            className="rounded-xl bg-primary px-5 py-2.5 text-xs font-black uppercase tracking-wider text-primary-foreground disabled:opacity-50"
+          >
+            등록
+          </motion.button>
+        </div>
+      </form>
+    </section>
+  );
+}
+

--- a/frontend/src/app/(common)/community/[postId]/page.tsx
+++ b/frontend/src/app/(common)/community/[postId]/page.tsx
@@ -23,7 +23,7 @@ export default async function CommunityPostDetailPage({ params }: { params: Para
   const res = await bffGet(`posts/${id}`);
 
   if (res.status === 404) notFound();
-  if (res.status === 401) {
+  if (res.status === 401 || res.status === 403) {
     return (
       <CommunityShell>
         <MotionEnter>

--- a/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
+++ b/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
@@ -72,7 +72,7 @@ export function CommunityRichTextEditor({ value, onChange, placeholder, id }: Pr
             body: fd,
             credentials: "include",
           });
-          if (res.status === 401) {
+          if (res.status === 401 || res.status === 403) {
             setUploadError(LOGIN_REQUIRED_MESSAGE);
             setShowLoginModal(true);
             return;

--- a/frontend/src/app/(common)/community/_components/LikeToggle.tsx
+++ b/frontend/src/app/(common)/community/_components/LikeToggle.tsx
@@ -28,7 +28,7 @@ export function LikeToggle({ postId, initialLiked, initialCount }: Props) {
           credentials: "include",
           headers: { "Content-Type": "application/json" },
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/community/_components/PostDetailSection.tsx
+++ b/frontend/src/app/(common)/community/_components/PostDetailSection.tsx
@@ -4,8 +4,7 @@ import type { PostDetail } from "../_types/community";
 import { POST_CATEGORIES } from "../_types/community";
 import { LikeToggle } from "./LikeToggle";
 import { PostEditDeleteActions } from "./PostEditDeleteActions";
-import { CommentComposer } from "../../comment/_components/CommentComposer";
-import { CommentItem } from "../../comment/_components/CommentItem";
+import { CommentThreadSection } from "../../comment/_components/CommentThreadSection";
 import { formatDateTimeKo } from "@/lib/format-date";
 import { apiFileUrlToBffPath } from "@/lib/bff-file-url";
 import { isRichTextBodyHtml, prepareCommunityPostBodyForDisplay } from "@/lib/post-html";
@@ -147,41 +146,11 @@ export function PostDetailSection({
         </section>
       )}
 
-      <section className="mt-14 border-t border-border pt-12">
-        <h2 className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground">
-          댓글
-        </h2>
-        {comments.length === 0 ? (
-          <div
-            className="mt-8 flex flex-col items-center justify-center gap-4 rounded-[2rem] border border-dashed border-border bg-background/60 px-8 py-14 text-center backdrop-blur-sm md:px-12"
-            aria-live="polite"
-          >
-            <MessageCircle
-              className="size-10 text-muted-foreground opacity-80"
-              strokeWidth={1.25}
-              aria-hidden
-            />
-            <p className="max-w-sm font-medium tracking-tight text-balance text-muted-foreground md:text-base">
-              아직 댓글이 없습니다. 첫 댓글을 남겨 대화를 시작해 보세요.
-            </p>
-          </div>
-        ) : (
-          <ul className="mt-8 space-y-6">
-            {comments.map((c) => (
-              <CommentItem
-                key={c.commentId}
-                commentId={c.commentId}
-                content={c.content}
-                authorUserId={c.author.userId}
-                authorName={c.author.name}
-                createdAt={c.createdAt}
-                currentUser={currentUser}
-              />
-            ))}
-          </ul>
-        )}
-        <CommentComposer postId={detail.postId} />
-      </section>
+      <CommentThreadSection
+        postId={detail.postId}
+        initialComments={comments}
+        currentUser={currentUser}
+      />
     </article>
   );
 }

--- a/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
+++ b/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
@@ -124,7 +124,7 @@ export function PostEditDeleteActions({
         method: "DELETE",
         credentials: "include",
       });
-      if (res.status === 401) {
+      if (res.status === 401 || res.status === 403) {
         setSubmitError(LOGIN_REQUIRED_MESSAGE);
         setShowLoginModal(true);
         return;
@@ -189,7 +189,7 @@ export function PostEditDeleteActions({
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setSubmitError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/app/(common)/community/_types/community.ts
+++ b/frontend/src/app/(common)/community/_types/community.ts
@@ -43,6 +43,7 @@ export type PostLink = {
 
 export type PostComment = {
   commentId: number;
+  parentCommentId?: number | null;
   content: string;
   author: PostAuthor;
   createdAt: string;

--- a/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
+++ b/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
@@ -96,7 +96,7 @@ export function NewPostForm() {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setSubmitError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/app/(common)/community/page.tsx
+++ b/frontend/src/app/(common)/community/page.tsx
@@ -32,7 +32,7 @@ export default async function CommunityPage({ searchParams }: { searchParams: Se
   let list: PostListData | null = null;
   let error: string | null = null;
 
-  if (res.status === 401) {
+  if (res.status === 401 || res.status === 403) {
     error = LOGIN_REQUIRED_MESSAGE;
   } else if (!res.ok) {
     error = "목록을 불러오지 못했습니다.";

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -52,7 +52,7 @@ export default async function NotificationsPage({ searchParams }: { searchParams
   let list: NotificationListData | null = null;
   let error: string | null = null;
 
-  if (res.status === 401) {
+  if (res.status === 401 || res.status === 403) {
     error = LOGIN_REQUIRED_MESSAGE;
   } else if (!res.ok) {
     error = "알림을 불러오지 못했습니다.";

--- a/frontend/src/app/(common)/profile/vocs/[vocId]/edit/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/[vocId]/edit/page.tsx
@@ -21,7 +21,7 @@ export default async function ProfileVocEditPage({ params }: { params: Params })
   if (Number.isNaN(id)) notFound();
 
   const res = await bffGet(`vocs/${id}`);
-  if (res.status === 401) {
+  if (res.status === 401 || res.status === 403) {
     return (
       <VocShell>
         <MotionEnter>

--- a/frontend/src/app/(common)/profile/vocs/[vocId]/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/[vocId]/page.tsx
@@ -44,7 +44,7 @@ export default async function ProfileVocDetailPage({ params }: { params: Params 
   const res = await bffGet(`vocs/${id}`);
 
   if (res.status === 404) notFound();
-  if (res.status === 401) {
+  if (res.status === 401 || res.status === 403) {
     return (
       <VocShell>
         <MotionEnter>

--- a/frontend/src/app/(common)/profile/vocs/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/page.tsx
@@ -33,7 +33,7 @@ export default async function ProfileVocsPage({ searchParams }: { searchParams: 
 
   if (showList) {
     const res = await bffGet(`vocs/my?${qs.toString()}`);
-    if (res.status === 401) {
+    if (res.status === 401 || res.status === 403) {
       listError = LOGIN_REQUIRED_MESSAGE;
     } else if (!res.ok) {
       listError = "목록을 불러오지 못했습니다.";

--- a/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
@@ -25,7 +25,7 @@ export function VocDetailActions({ vocId, status }: { vocId: number; status: str
           method: "POST",
           credentials: "include",
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/vocs/_components/VocEditForm.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocEditForm.tsx
@@ -112,7 +112,7 @@ export function VocEditForm({ initial }: Props) {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
@@ -72,7 +72,7 @@ export function VocRichTextEditor({ value, onChange, placeholder, id }: Props) {
             body: fd,
             credentials: "include",
           });
-          if (res.status === 401) {
+          if (res.status === 401 || res.status === 403) {
             setUploadError(LOGIN_REQUIRED_MESSAGE);
             setShowLoginModal(true);
             return;

--- a/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
+++ b/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
@@ -85,7 +85,7 @@ export function NewVocForm() {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401) {
+        if (res.status === 401 || res.status === 403) {
           setError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;


### PR DESCRIPTION
## Summary
- VOC 흐름을 마이페이지 중심으로 재구성했습니다. 헤더 Community에서 VOC를 제거하고 My 메뉴/마이페이지에서 `My VOC`로 진입하도록 변경했으며, `민원 등록`과 `나의 민원 내역` 탭 UX를 추가했습니다.
- 커뮤니티/민원/알림/댓글 도메인에서 인증 필요 응답을 일관되게 처리하도록 `401` 뿐 아니라 `403`도 로그인 필요 모달로 안내하도록 보강했습니다.
- 댓글 도메인을 확장해 `parentCommentId` 기반 트리형 대댓글 렌더링을 구현했습니다. 재귀 렌더러 + 들여쓰기 UI, 댓글/답글 낙관적 등록(실패 시 롤백)을 적용했습니다.
- 삭제 정책을 정비해 자식 댓글이 있는 부모 댓글은 soft-delete 대신 placeholder(`[삭제된 댓글입니다.]`)로 보존하고, 해당 placeholder 댓글의 재수정을 차단했습니다.
- 보안 설정(`SecurityConfig`)에서 community/voc/comment/notification 접근 정책을 프로젝트 규칙에 맞춰 명시적으로 정리했습니다.

## Test plan
- [x] `backend`: `./gradlew compileJava`
- [x] `frontend`: `npx tsc --noEmit`
- [ ] 비로그인 상태에서 커뮤니티 목록/상세 접근 시 공개 동작 확인
- [ ] 비로그인 상태에서 댓글/좋아요/민원/알림 접근 시 로그인 필요 모달 노출 확인
- [ ] 로그인 상태에서 `My VOC` 진입 → 등록/내역 탭 전환 및 상세/수정/취소 동작 확인
- [ ] 댓글 트리 렌더링(들여쓰기/대댓글) 및 낙관적 등록(성공/실패 롤백) 확인
- [ ] 자식 있는 부모 댓글 삭제 시 placeholder 보존 + 재수정 차단 확인