### PR TITLE
[CS/feat] Redis 조회수 캐싱 + 좋아요 동시성 가드로 핫스팟 완화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ JWT_SECRET=production-secret-key-change-me-minimum-32-chars!!
 MOCK_IOT_URL=MOCK_IOT_URL
 APP_UPLOAD_DIR=/var/lib/cokkiri/uploads
 APP_DEMO_DATA_ENABLED=false
+REDIS_HOST=redis
+REDIS_PORT=6379

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     // Spring Boot Starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/backend/src/main/java/com/coliving/CoLivingApplication.java
+++ b/backend/src/main/java/com/coliving/CoLivingApplication.java
@@ -2,10 +2,12 @@ package com.coliving;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
+@EnableScheduling
 public class CoLivingApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityLikeActionGuard.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityLikeActionGuard.java
@@ -1,0 +1,76 @@
+package com.coliving.common.community.adapter.out.cache;
+
+import com.coliving.global.error.BusinessException;
+import com.coliving.global.error.ErrorCode;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
+
+@Component
+public class CommunityLikeActionGuard {
+    private static final DefaultRedisScript<Long> COMPARE_AND_DELETE_SCRIPT = new DefaultRedisScript<>(
+            "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end",
+            Long.class
+    );
+
+    private final StringRedisTemplate redis;
+    private final Map<String, ReentrantLock> localLocks = new ConcurrentHashMap<>();
+
+    public CommunityLikeActionGuard(ObjectProvider<StringRedisTemplate> redisProvider) {
+        this.redis = redisProvider.getIfAvailable();
+    }
+
+    public LockHandle acquire(Long postId, Long userId) {
+        String key = "community:like:lock:" + postId + ":" + userId;
+
+        if (redis != null) {
+            try {
+                String token = UUID.randomUUID().toString();
+                Boolean ok = redis.opsForValue().setIfAbsent(key, token, Duration.ofSeconds(3));
+                if (!Boolean.TRUE.equals(ok)) {
+                    throw new BusinessException(ErrorCode.CONCURRENCY_ERROR);
+                }
+                return () -> {
+                    try {
+                        redis.execute(
+                                COMPARE_AND_DELETE_SCRIPT,
+                                Collections.singletonList(key),
+                                token
+                        );
+                    } catch (RuntimeException ignored) {
+                    }
+                };
+            } catch (BusinessException e) {
+                throw e;
+            } catch (RuntimeException ignored) {
+                // Redis 장애 시 로컬 락 폴백
+            }
+        }
+
+        ReentrantLock lock = localLocks.computeIfAbsent(key, k -> new ReentrantLock());
+        boolean ok = lock.tryLock();
+        if (!ok) {
+            throw new BusinessException(ErrorCode.CONCURRENCY_ERROR);
+        }
+        return () -> {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        };
+    }
+
+    @FunctionalInterface
+    public interface LockHandle extends AutoCloseable {
+        @Override
+        void close();
+    }
+}
+

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityViewCountCache.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityViewCountCache.java
@@ -1,0 +1,112 @@
+package com.coliving.common.community.adapter.out.cache;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class CommunityViewCountCache {
+    private static final String HASH_KEY = "community:view:delta";
+    private static final String DRAIN_KEY = "community:view:delta:drain";
+
+    private final StringRedisTemplate redis;
+    private final Map<Long, Long> localDelta = new ConcurrentHashMap<>();
+
+    public CommunityViewCountCache(ObjectProvider<StringRedisTemplate> redisProvider) {
+        this.redis = redisProvider.getIfAvailable();
+    }
+
+    public long incrementAndGetDelta(Long postId) {
+        if (postId == null) {
+            return 0L;
+        }
+
+        if (redis != null) {
+            try {
+                Long value = redis.opsForHash().increment(HASH_KEY, String.valueOf(postId), 1L);
+                return value == null ? 1L : value;
+            } catch (RuntimeException ignored) {
+                // Redis 장애 시 로컬 메모리 폴백
+            }
+        }
+
+        return localDelta.merge(postId, 1L, Long::sum);
+    }
+
+    public long getDelta(Long postId) {
+        if (postId == null) {
+            return 0L;
+        }
+
+        if (redis != null) {
+            try {
+                Object value = redis.opsForHash().get(HASH_KEY, String.valueOf(postId));
+                if (value == null) return 0L;
+                return Long.parseLong(String.valueOf(value));
+            } catch (RuntimeException ignored) {
+                // Redis 장애 시 로컬 메모리 폴백
+            }
+        }
+        return localDelta.getOrDefault(postId, 0L);
+    }
+
+    public Map<Long, Long> drainAll() {
+        if (redis != null) {
+            try {
+                Map<Long, Long> merged = new LinkedHashMap<>();
+
+                // 이전 flush 도중 실패한 잔여 데이터 복구
+                Map<Object, Object> pendingRaw = redis.opsForHash().entries(DRAIN_KEY);
+                merge(merged, toLongMap(pendingRaw));
+                if (!pendingRaw.isEmpty()) {
+                    redis.delete(DRAIN_KEY);
+                }
+
+                // 현재 누적분 snapshot
+                Boolean exists = redis.hasKey(HASH_KEY);
+                if (Boolean.TRUE.equals(exists)) {
+                    redis.rename(HASH_KEY, DRAIN_KEY);
+                    Map<Object, Object> raw = redis.opsForHash().entries(DRAIN_KEY);
+                    merge(merged, toLongMap(raw));
+                    redis.delete(DRAIN_KEY);
+                }
+                return merged;
+            } catch (RuntimeException ignored) {
+                // Redis 장애 시 로컬 메모리 폴백
+            }
+        }
+
+        synchronized (localDelta) {
+            if (localDelta.isEmpty()) return Map.of();
+            Map<Long, Long> snap = new LinkedHashMap<>(localDelta);
+            localDelta.clear();
+            return snap;
+        }
+    }
+
+    private Map<Long, Long> toLongMap(Map<Object, Object> raw) {
+        if (raw == null || raw.isEmpty()) return Map.of();
+        Map<Long, Long> out = new LinkedHashMap<>();
+        for (Map.Entry<Object, Object> e : raw.entrySet()) {
+            try {
+                Long postId = Long.parseLong(String.valueOf(e.getKey()));
+                Long delta = Long.parseLong(String.valueOf(e.getValue()));
+                if (delta > 0L) out.put(postId, delta);
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return out;
+    }
+
+    private void merge(Map<Long, Long> target, Map<Long, Long> from) {
+        if (from == null || from.isEmpty()) return;
+        for (Map.Entry<Long, Long> e : from.entrySet()) {
+            target.merge(e.getKey(), e.getValue(), Long::sum);
+        }
+    }
+}
+

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityViewCountSyncScheduler.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/cache/CommunityViewCountSyncScheduler.java
@@ -1,0 +1,35 @@
+package com.coliving.common.community.adapter.out.cache;
+
+import com.coliving.common.community.adapter.out.jpa.PostJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommunityViewCountSyncScheduler {
+    private final CommunityViewCountCache viewCountCache;
+    private final PostJpaRepository postJpaRepository;
+
+    @Scheduled(fixedDelayString = "${app.community.view-sync-ms:10000}")
+    @Transactional
+    public void flushViewCountDeltas() {
+        Map<Long, Long> deltas = viewCountCache.drainAll();
+        if (deltas.isEmpty()) return;
+
+        long touched = 0L;
+        for (Map.Entry<Long, Long> e : deltas.entrySet()) {
+            long delta = e.getValue() == null ? 0L : e.getValue();
+            if (delta <= 0L) continue;
+            int updated = postJpaRepository.addViewCount(e.getKey(), delta);
+            if (updated > 0) touched++;
+        }
+        log.debug("community viewCount sync completed. touchedPosts={}", touched);
+    }
+}
+

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/jpa/PostJpaRepository.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/jpa/PostJpaRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostJpaRepository extends JpaRepository<PostEntity, Long>, JpaSpecificationExecutor<PostEntity> {
 
@@ -23,5 +25,17 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, Long>, JpaS
             countQuery = "SELECT COUNT(p) FROM PostEntity p"
     )
     Page<PostEntity> findAllNoticeFirst(Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE PostEntity p SET p.viewCount = p.viewCount + :delta WHERE p.postId = :postId")
+    int addViewCount(@Param("postId") Long postId, @Param("delta") long delta);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE PostEntity p SET p.likeCount = p.likeCount + 1 WHERE p.postId = :postId")
+    int increaseLikeCount(@Param("postId") Long postId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE PostEntity p SET p.likeCount = CASE WHEN p.likeCount <= 0 THEN 0 ELSE p.likeCount - 1 END WHERE p.postId = :postId")
+    int decreaseLikeCount(@Param("postId") Long postId);
 }
 

--- a/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/community/adapter/out/persistence/CommunityPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.coliving.common.community.adapter.out.persistence;
 
+import com.coliving.common.community.adapter.out.cache.CommunityViewCountCache;
 import com.coliving.common.community.adapter.out.jpa.PostEntity;
 import com.coliving.common.community.adapter.out.jpa.PostJpaRepository;
 import com.coliving.common.community.adapter.out.jpa.PostLikeEntity;
@@ -31,15 +32,18 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
     private final PostLikeJpaRepository postLikeJpaRepository;
     private final CommentRepositoryPort commentRepositoryPort;
     private final ObjectMapper objectMapper;
+    private final CommunityViewCountCache viewCountCache;
 
     public CommunityPersistenceAdapter(PostJpaRepository postJpaRepository,
                                        PostLikeJpaRepository postLikeJpaRepository,
                                        CommentRepositoryPort commentRepositoryPort,
-                                       ObjectMapper objectMapper) {
+                                       ObjectMapper objectMapper,
+                                       CommunityViewCountCache viewCountCache) {
         this.postJpaRepository = postJpaRepository;
         this.postLikeJpaRepository = postLikeJpaRepository;
         this.commentRepositoryPort = commentRepositoryPort;
         this.objectMapper = objectMapper;
+        this.viewCountCache = viewCountCache;
     }
 
     @Override
@@ -76,20 +80,17 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
             PostLikeEntity likeEntity = existingLike.get();
             likeEntity.softDelete();
             postLikeJpaRepository.save(likeEntity);
-
-            postEntity.decreaseLikeCount();
-            postJpaRepository.save(postEntity);
+            postJpaRepository.decreaseLikeCount(postId);
         } else {
             PostLikeEntity likeEntity = new PostLikeEntity();
             likeEntity.setPost(postEntity);
             likeEntity.setUserId(userId);
             postLikeJpaRepository.save(likeEntity);
-
-            postEntity.increaseLikeCount();
-            postJpaRepository.save(postEntity);
+            postJpaRepository.increaseLikeCount(postId);
         }
-
-        return mapPostEntityToModel(postEntity);
+        PostEntity refreshed = postJpaRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        return mapPostEntityToModel(refreshed);
     }
 
     @Override
@@ -148,10 +149,23 @@ public class CommunityPersistenceAdapter implements CommunityRepositoryPort {
     public Post incrementViewCount(Long postId) {
         PostEntity entity = postJpaRepository.findById(postId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
-
-        entity.incrementViewCount();
-        entity = postJpaRepository.save(entity);
-        return mapPostEntityToModel(entity);
+        long delta = viewCountCache.incrementAndGetDelta(postId);
+        Post base = mapPostEntityToModel(entity);
+        int mergedViewCount = (base.getViewCount() == null ? 0 : base.getViewCount()) + (int) Math.max(0L, delta);
+        return Post.builder()
+                .postId(base.getPostId())
+                .userId(base.getUserId())
+                .category(base.getCategory())
+                .title(base.getTitle())
+                .content(base.getContent())
+                .attachments(base.getAttachments())
+                .links(base.getLinks())
+                .viewCount(mergedViewCount)
+                .likeCount(base.getLikeCount())
+                .commentCount(base.getCommentCount())
+                .createdAt(base.getCreatedAt())
+                .updatedAt(base.getUpdatedAt())
+                .build();
     }
 
     @Override

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -1,5 +1,6 @@
 package com.coliving.common.community.application.service;
 
+import com.coliving.common.community.adapter.out.cache.CommunityLikeActionGuard;
 import com.coliving.common.community.application.command.*;
 import com.coliving.common.community.application.port.in.CommunityUseCase;
 import com.coliving.common.community.application.port.out.CommunityRepositoryPort;
@@ -33,9 +34,12 @@ public class CommunityService implements CommunityUseCase {
     );
 
     private final CommunityRepositoryPort repositoryPort;
+    private final CommunityLikeActionGuard likeActionGuard;
 
-    public CommunityService(CommunityRepositoryPort repositoryPort) {
+    public CommunityService(CommunityRepositoryPort repositoryPort,
+                            CommunityLikeActionGuard likeActionGuard) {
         this.repositoryPort = repositoryPort;
+        this.likeActionGuard = likeActionGuard;
     }
 
     @Override
@@ -194,14 +198,17 @@ public class CommunityService implements CommunityUseCase {
     @Override
     @Transactional
     public ToggleLikeResult toggleLike(TogglePostLikeCommand command) {
-        Post after = repositoryPort.toggleLike(command.getPostId(), command.getActorId());
-        boolean likedByMe = repositoryPort.isLikedByMe(command.getPostId(), command.getActorId());
+        try (CommunityLikeActionGuard.LockHandle ignored =
+                     likeActionGuard.acquire(command.getPostId(), command.getActorId())) {
+            Post after = repositoryPort.toggleLike(command.getPostId(), command.getActorId());
+            boolean likedByMe = repositoryPort.isLikedByMe(command.getPostId(), command.getActorId());
 
-        return ToggleLikeResult.builder()
-                .postId(after.getPostId())
-                .liked(likedByMe)
-                .likeCount(after.getLikeCount())
-                .build();
+            return ToggleLikeResult.builder()
+                    .postId(after.getPostId())
+                    .liked(likedByMe)
+                    .likeCount(after.getLikeCount())
+                    .build();
+        }
     }
 
     @Override

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -7,6 +7,10 @@ spring:
     url: ${DB_URL:jdbc:postgresql://db:5432/coliving}
     username: ${DB_USERNAME:coliving}
     password: ${DB_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
   jpa:
     show-sql: false
     hibernate:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -21,6 +21,10 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 jwt:
   secret: dev-secret-key-minimum-32-characters-long!!

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -9,6 +9,10 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  data:
+    redis:
+      host: ${REDIS_HOST:redis}
+      port: ${REDIS_PORT:6379}
   jpa.show-sql: false
   sql.init.mode: never
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -4,9 +4,16 @@ app:
   upload:
     # 업로드 파일 루트 경로 (community/voc 하위 폴더는 코드에서 추가)
     dir: data/uploads
+  community:
+    view-sync-ms: 10000
 
 spring:
   profiles.active: dev
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      timeout: 1500ms
   jpa:
     # 마이그레이션 도구(Flyway 등) 미사용 → JPA Entity가 스키마를 직접 관리
     # update: 엔티티 변경 시 컬럼/테이블 자동 추가 (삭제는 안 함)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - DB_URL=${DB_URL:-jdbc:postgresql://db:5432/coliving}
       - DB_USERNAME=${DB_USERNAME:-coliving}
       - DB_PASSWORD=${DB_PASSWORD}
+      - REDIS_HOST=${REDIS_HOST:-redis}
+      - REDIS_PORT=${REDIS_PORT:-6379}
       - JWT_SECRET=${JWT_SECRET}
       - MOCK_IOT_URL=${MOCK_IOT_URL:-http://mock-iot:8000}
       - APP_UPLOAD_DIR=${APP_UPLOAD_DIR:-/var/lib/cokkiri/uploads}
@@ -31,6 +33,7 @@ services:
       - uploads-data:/var/lib/cokkiri/uploads
     depends_on:
       db: { condition: service_healthy }
+      redis: { condition: service_healthy }
 
   db:
     container_name: team1-cokkiri-db
@@ -57,6 +60,19 @@ services:
       - "8000"
     volumes:
       - ./mock-iot/mappings:/home/wiremock/mappings
+
+  redis:
+    container_name: team1-cokkiri-redis
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: [ "redis-server", "--appendonly", "yes" ]
+    expose:
+      - "6379"
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   postgres-data:


### PR DESCRIPTION
## Overview
커뮤니티 상세 조회/좋아요 집중 트래픽에서 DB 병목을 줄이기 위해, 조회수는 Redis delta 캐싱 후 주기적 배치 싱크로 전환하고 좋아요 토글에는 동시성 가드를 추가했습니다.

## What Changed
- 조회수 캐싱
  - `CommunityViewCountCache` 추가: `community:view:delta` 해시에 조회수 delta 누적
  - `CommunityViewCountSyncScheduler` 추가: `app.community.view-sync-ms` 주기로 DB `view_count` 배치 반영
  - Redis 장애 시 로컬 메모리 폴백 및 drain 복구 로직 보강
- 좋아요 동시성 방어
  - `CommunityLikeActionGuard` 추가: `postId+userId` 단위 락(SETNX+TTL)
  - 락 해제는 토큰 compare-and-delete(Lua)로 레이스 방지
  - 충돌 시 `CONCURRENCY_ERROR(409)` 반환
- 카운트 정합성/경합 대응
  - `PostJpaRepository`에 원자적 증감 쿼리 추가
    - `addViewCount`, `increaseLikeCount`, `decreaseLikeCount`
  - `CommunityPersistenceAdapter`의 like/view 갱신 경로를 원자 update 기반으로 변경
- 인프라/설정
  - `spring-boot-starter-data-redis` 의존성 추가
  - `application*.yml`에 Redis 설정 추가
  - `docker-compose.yml`에 `redis` 서비스/healthcheck/depends_on 추가
  - `.env.example`에 `REDIS_HOST`, `REDIS_PORT` 추가
  - `@EnableScheduling` 활성화

## Scope Note
- 본 최적화는 현재 카운터 핫스팟이 있는 `community` 도메인에 적용했습니다.
- `comment/notification/voc`는 현 시점에 조회수/좋아요 카운터 로직이 없어 동일 패턴 적용 대상이 아닙니다.

## Test Plan
- [ ] 로컬 docker-compose 기동 후 커뮤니티 상세 다중 조회 시 DB write 빈도 감소 확인
- [ ] 동일 사용자 좋아요 연타/중복 요청 시 409 충돌 처리 및 like_count 정합성 확인
- [ ] 배치 주기(`app.community.view-sync-ms`) 조정 시 조회수 반영 지연/부하 균형 확인