### PR TITLE
[CS/fix] 민원 소유권 404/403 구분 및 프론트·BFF 에러 처리 정리

### DIFF
--- a/backend/src/main/java/com/coliving/common/voc/application/service/VocService.java
+++ b/backend/src/main/java/com/coliving/common/voc/application/service/VocService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Service
@@ -92,16 +93,13 @@ public class VocService implements VocUseCase {
     @Override
     @Transactional(readOnly = true)
     public VocResult getMyVoc(GetMyVocCommand command) {
-        Voc voc = vocRepositoryPort.findByVocIdAndUserId(command.getVocId(), command.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
-        return toVocResult(voc);
+        return toVocResult(requireMyVoc(command.getVocId(), command.getUserId()));
     }
 
     @Override
     @Transactional
     public VocResult updateVoc(UpdateVocCommand command) {
-        Voc existing = vocRepositoryPort.findByVocIdAndUserId(command.getVocId(), command.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        Voc existing = requireMyVoc(command.getVocId(), command.getUserId());
 
         if (existing.getStatus() != VocStatus.OPEN) {
             throw new BusinessException(ErrorCode.INVALID_STATUS);
@@ -137,8 +135,7 @@ public class VocService implements VocUseCase {
     @Override
     @Transactional
     public VocResult cancelVoc(CancelVocCommand command) {
-        Voc existing = vocRepositoryPort.findByVocIdAndUserId(command.getVocId(), command.getUserId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        Voc existing = requireMyVoc(command.getVocId(), command.getUserId());
 
         if (existing.getStatus() != VocStatus.OPEN) {
             throw new BusinessException(ErrorCode.INVALID_STATUS);
@@ -150,6 +147,18 @@ public class VocService implements VocUseCase {
         Voc cancelled = vocRepositoryPort.findByVocIdAndUserId(command.getVocId(), command.getUserId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
         return toVocResult(cancelled);
+    }
+
+    /**
+     * 존재하지 않는 민원은 404, 타인 소유 민원은 403으로 구분합니다(강제 URL 접근 시에도 상태 코드가 명확히 구분됨).
+     */
+    private Voc requireMyVoc(Long vocId, Long userId) {
+        Voc voc = vocRepositoryPort.findByVocId(vocId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+        if (!Objects.equals(voc.getUserId(), userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        return voc;
     }
 
     private VocResult toVocResult(Voc v) {

--- a/backend/src/test/java/com/coliving/common/voc/application/service/VocServiceOwnershipTest.java
+++ b/backend/src/test/java/com/coliving/common/voc/application/service/VocServiceOwnershipTest.java
@@ -1,0 +1,116 @@
+package com.coliving.common.voc.application.service;
+
+import com.coliving.common.notification.application.port.out.NotificationRepositoryPort;
+import com.coliving.common.voc.application.command.CancelVocCommand;
+import com.coliving.common.voc.application.command.GetMyVocCommand;
+import com.coliving.common.voc.application.command.UpdateVocCommand;
+import com.coliving.common.voc.application.port.out.VocRepositoryPort;
+import com.coliving.common.voc.model.Voc;
+import com.coliving.common.voc.model.VocCategory;
+import com.coliving.common.voc.model.VocStatus;
+import com.coliving.global.error.BusinessException;
+import com.coliving.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class VocServiceOwnershipTest {
+
+    @Mock
+    private VocRepositoryPort vocRepositoryPort;
+
+    @Mock
+    private NotificationRepositoryPort notificationRepositoryPort;
+
+    @InjectMocks
+    private VocService vocService;
+
+    @Test
+    void getMyVoc_whenVocMissing_returnsNotFound() {
+        when(vocRepositoryPort.findByVocId(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> vocService.getMyVoc(GetMyVocCommand.builder().vocId(1L).userId(10L).build()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void getMyVoc_whenWrongOwner_returnsForbidden() {
+        when(vocRepositoryPort.findByVocId(1L)).thenReturn(Optional.of(sampleVoc(1L, 99L, VocStatus.OPEN)));
+
+        assertThatThrownBy(() -> vocService.getMyVoc(GetMyVocCommand.builder().vocId(1L).userId(10L).build()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void getMyVoc_whenOwner_ok() {
+        when(vocRepositoryPort.findByVocId(1L)).thenReturn(Optional.of(sampleVoc(1L, 10L, VocStatus.OPEN)));
+
+        assertThat(vocService.getMyVoc(GetMyVocCommand.builder().vocId(1L).userId(10L).build()).getVocId())
+                .isEqualTo(1L);
+    }
+
+    @Test
+    void updateVoc_whenWrongOwner_returnsForbidden_andDoesNotUpdate() {
+        when(vocRepositoryPort.findByVocId(1L)).thenReturn(Optional.of(sampleVoc(1L, 99L, VocStatus.OPEN)));
+
+        assertThatThrownBy(() -> vocService.updateVoc(UpdateVocCommand.builder()
+                .vocId(1L)
+                .userId(10L)
+                .category(VocCategory.FACILITY)
+                .title("t")
+                .content("c")
+                .build()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(vocRepositoryPort, never()).updateOwned(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void cancelVoc_whenWrongOwner_returnsForbidden_andDoesNotCancel() {
+        when(vocRepositoryPort.findByVocId(1L)).thenReturn(Optional.of(sampleVoc(1L, 99L, VocStatus.OPEN)));
+
+        assertThatThrownBy(() -> vocService.cancelVoc(CancelVocCommand.builder().vocId(1L).userId(10L).build()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(vocRepositoryPort, never()).cancelOwned(any(), any());
+        verify(notificationRepositoryPort, never()).softDeleteByReference(any(), any());
+    }
+
+    private static Voc sampleVoc(Long vocId, Long userId, VocStatus status) {
+        return Voc.builder()
+                .vocId(vocId)
+                .userId(userId)
+                .category(VocCategory.FACILITY)
+                .title("title")
+                .content("content")
+                .attachments(List.of())
+                .status(status)
+                .adminReply(null)
+                .replyUserId(null)
+                .repliedAt(null)
+                .createdAt(null)
+                .updatedAt(null)
+                .build();
+    }
+}

--- a/frontend/src/app/(common)/profile/vocs/[vocId]/edit/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/[vocId]/edit/page.tsx
@@ -7,6 +7,7 @@ import type { ApiResponse, VocDetail } from "@/app/(common)/vocs/_types/vocs";
 import { VocShell } from "@/app/(common)/vocs/_components/VocShell";
 import { MotionEnter } from "@/app/(common)/community/_components/MotionEnter";
 import { VocEditForm } from "@/app/(common)/vocs/_components/VocEditForm";
+import { VocAccessDeniedState } from "../../_components/VocAccessDeniedState";
 
 type Params = Promise<{ vocId: string }>;
 
@@ -21,7 +22,8 @@ export default async function ProfileVocEditPage({ params }: { params: Params })
   if (Number.isNaN(id)) notFound();
 
   const res = await bffGet(`vocs/${id}`);
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 404) notFound();
+  if (res.status === 401) {
     return (
       <VocShell>
         <MotionEnter>
@@ -33,7 +35,22 @@ export default async function ProfileVocEditPage({ params }: { params: Params })
       </VocShell>
     );
   }
-  if (!res.ok) notFound();
+  if (res.status === 403) {
+    return <VocAccessDeniedState />;
+  }
+  if (!res.ok) {
+    return (
+      <VocShell>
+        <MotionEnter>
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="font-medium text-destructive" role="alert">
+              민원 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+        </MotionEnter>
+      </VocShell>
+    );
+  }
 
   const body = (await res.json()) as ApiResponse<VocDetail>;
   if (!body.success || !body.data) notFound();

--- a/frontend/src/app/(common)/profile/vocs/[vocId]/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/[vocId]/page.tsx
@@ -13,6 +13,7 @@ import { apiFileUrlToBffPath } from "@/lib/bff-file-url";
 import { isRichTextBodyHtml } from "@/lib/post-html";
 import { prepareVocBodyForDisplay, VOC_RICH_BODY_CLASSNAME } from "@/lib/vocs-html";
 import { cn } from "@/lib/utils";
+import { VocAccessDeniedState } from "../_components/VocAccessDeniedState";
 
 type Params = Promise<{ vocId: string }>;
 
@@ -44,7 +45,7 @@ export default async function ProfileVocDetailPage({ params }: { params: Params 
   const res = await bffGet(`vocs/${id}`);
 
   if (res.status === 404) notFound();
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
     return (
       <VocShell>
         <MotionEnter>
@@ -56,7 +57,22 @@ export default async function ProfileVocDetailPage({ params }: { params: Params 
       </VocShell>
     );
   }
-  if (!res.ok) notFound();
+  if (res.status === 403) {
+    return <VocAccessDeniedState />;
+  }
+  if (!res.ok) {
+    return (
+      <VocShell>
+        <MotionEnter>
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="font-medium text-destructive" role="alert">
+              민원을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+            </p>
+          </div>
+        </MotionEnter>
+      </VocShell>
+    );
+  }
 
   const body = (await res.json()) as ApiResponse<VocDetail>;
   if (!body.success || !body.data) notFound();

--- a/frontend/src/app/(common)/profile/vocs/_components/VocAccessDeniedState.tsx
+++ b/frontend/src/app/(common)/profile/vocs/_components/VocAccessDeniedState.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+import { VocShell } from "@/app/(common)/vocs/_components/VocShell";
+import { MotionEnter } from "@/app/(common)/community/_components/MotionEnter";
+import { VOC_MY_VOC_FORBIDDEN_MESSAGE } from "@/lib/auth-messages";
+
+export function VocAccessDeniedState({
+  message = VOC_MY_VOC_FORBIDDEN_MESSAGE,
+}: {
+  message?: string;
+}) {
+  return (
+    <VocShell>
+      <MotionEnter>
+        <div className="mx-auto max-w-3xl space-y-6 text-center">
+          <p className="font-medium text-destructive" role="alert">
+            {message}
+          </p>
+          <p className="text-sm font-medium text-muted-foreground">
+            다른 회원의 민원은 조회할 수 없습니다. URL을 직접 입력한 경우 나의 민원 내역으로 돌아가 주세요.
+          </p>
+          <Link
+            href="/profile/vocs?tab=list"
+            className="inline-flex rounded-xl bg-primary px-6 py-3 text-sm font-black uppercase tracking-wider text-primary-foreground"
+          >
+            나의 민원 내역
+          </Link>
+        </div>
+      </MotionEnter>
+    </VocShell>
+  );
+}

--- a/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocDetailActions.tsx
@@ -8,6 +8,7 @@ import { Loader2, Pencil, Ban } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { bffErrorMessageFromResponse } from "@/lib/bff-error-message";
 import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { VOC_MY_VOC_FORBIDDEN_MESSAGE } from "@/lib/auth-messages";
 
 export function VocDetailActions({ vocId, status }: { vocId: number; status: string }) {
   const router = useRouter();
@@ -25,8 +26,12 @@ export function VocDetailActions({ vocId, status }: { vocId: number; status: str
           method: "POST",
           credentials: "include",
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
+          return;
+        }
+        if (res.status === 403) {
+          alert(await bffErrorMessageFromResponse(res, VOC_MY_VOC_FORBIDDEN_MESSAGE));
           return;
         }
         if (res.ok) {

--- a/frontend/src/app/(common)/vocs/_components/VocEditForm.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocEditForm.tsx
@@ -9,7 +9,7 @@ import { ArrowLeft, ChevronDown, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
 import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
-import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { LOGIN_REQUIRED_MESSAGE, VOC_MY_VOC_FORBIDDEN_MESSAGE } from "@/lib/auth-messages";
 import { plainTextFromHtml } from "@/lib/post-html";
 import type { ApiResponse } from "@/types/api";
 import {
@@ -112,7 +112,7 @@ export function VocEditForm({ initial }: Props) {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;
@@ -122,6 +122,10 @@ export function VocEditForm({ initial }: Props) {
           json = await res.json();
         } catch {
           setError("서버 응답을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.");
+          return;
+        }
+        if (res.status === 403) {
+          setError(messageFromBffResponse(json, VOC_MY_VOC_FORBIDDEN_MESSAGE));
           return;
         }
         if (!res.ok || !json.success) {

--- a/frontend/src/app/admin/vocs/[vocId]/page.tsx
+++ b/frontend/src/app/admin/vocs/[vocId]/page.tsx
@@ -44,11 +44,49 @@ export default async function AdminVocDetailPage({ params }: { params: Params })
   if (res.status === 401) {
     return (
       <MotionEnter>
-        <p className="mx-auto max-w-3xl text-center font-medium text-destructive">관리자 로그인이 필요합니다.</p>
+        <div className="mx-auto max-w-3xl space-y-4 text-center">
+          <p className="font-medium text-destructive" role="alert">
+            관리자 로그인이 필요합니다.
+          </p>
+          <Link
+            href="/login"
+            className="inline-block font-black text-sm uppercase tracking-wider text-secondary underline underline-offset-4"
+          >
+            로그인으로 이동
+          </Link>
+        </div>
       </MotionEnter>
     );
   }
-  if (!res.ok) notFound();
+  if (res.status === 403) {
+    return (
+      <MotionEnter>
+        <div className="mx-auto max-w-3xl space-y-4 text-center">
+          <p className="font-medium text-destructive" role="alert">
+            관리자만 이 민원을 열람할 수 있습니다.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            일반 회원 계정으로는 관리자 전용 경로에 접근할 수 없습니다.
+          </p>
+          <Link
+            href="/admin"
+            className="inline-block font-black text-sm uppercase tracking-wider text-secondary underline underline-offset-4"
+          >
+            관리자 홈
+          </Link>
+        </div>
+      </MotionEnter>
+    );
+  }
+  if (!res.ok) {
+    return (
+      <MotionEnter>
+        <p className="mx-auto max-w-3xl text-center font-medium text-destructive" role="alert">
+          민원을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.
+        </p>
+      </MotionEnter>
+    );
+  }
 
   const body = (await res.json()) as ApiResponse<AdminVocDetail>;
   if (!body.success || !body.data) notFound();

--- a/frontend/src/lib/auth-messages.ts
+++ b/frontend/src/lib/auth-messages.ts
@@ -1,2 +1,6 @@
 /** 인증이 필요할 때 UI·API 오류 메시지로 사용합니다. */
 export const LOGIN_REQUIRED_MESSAGE = "로그인이 필요합니다.";
+
+/** 로그인은 되었으나 본인 민원이 아닐 때(403) 안내 문구 */
+export const VOC_MY_VOC_FORBIDDEN_MESSAGE =
+  "본인이 등록한 민원만 열람·수정할 수 있습니다.";

--- a/frontend/src/lib/bff-error-message.ts
+++ b/frontend/src/lib/bff-error-message.ts
@@ -4,11 +4,16 @@ import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 const DEFAULT_SAVE_FAIL = "저장하지 못했습니다. 잠시 후 다시 시도해 주세요.";
 
 /** 이미 파싱한 BFF JSON에서 사용자에게 보여 줄 메시지를 고릅니다. */
+function apiErrorCode(json: ApiResponse<unknown>): string | undefined {
+  return json.errorCode ?? json.error_code;
+}
+
 export function messageFromBffResponse<T>(
   json: ApiResponse<T>,
   fallback: string = DEFAULT_SAVE_FAIL,
 ): string {
-  if (json.error_code === "UNAUTHORIZED") {
+  const code = apiErrorCode(json);
+  if (code === "UNAUTHORIZED" || code === "INVALID_CREDENTIALS") {
     return LOGIN_REQUIRED_MESSAGE;
   }
   const m = json.message?.trim();

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -3,5 +3,8 @@ export interface ApiResponse<T> {
   success: boolean;
   data: T | null;
   message: string | null;
-  error_code?: string;   // 실패 시에만 포함
+  /** 백엔드 JSON (camelCase) */
+  errorCode?: string;
+  /** 레거시/스네이크 케이스 대비 */
+  error_code?: string;
 }


### PR DESCRIPTION
## Overview
로그인한 사용자가 타인 민원 URL로 접근할 때 **404(없음)**와 **403(권한 없음)**을 구분하고, 프로필·관리자 VOC 화면과 폼에서 **401(로그인)**과 **403(권한)**을 혼동하지 않도록 맞췄습니다.

## Backend
- `VocService.requireMyVoc`: 민원 미존재 → `NOT_FOUND`(404), 소유자 불일치 → `FORBIDDEN`(403)
- 소유자 비교에 `Objects.equals(voc.getUserId(), userId)` 사용 (null 안전)
- `getMyVoc` / `updateVoc` / `cancelVoc` 동일 규칙 적용
- 단위 테스트: `VocServiceOwnershipTest` (조회·수정·취소 시 타인 소유 시 403 및 저장소 미호출 검증)

## Frontend
- `profile/vocs/[vocId]`, `profile/vocs/[vocId]/edit`: 404 `notFound`, 401 로그인 게이트, 403 `VocAccessDeniedState`, 기타 실패 시 안내 문구
- `admin/vocs/[vocId]`: 404 / 401 / 403 / 기타 실패 분기 명시
- `VocEditForm`, `VocDetailActions`: 401만 로그인 모달·403은 권한 메시지
- `VocAccessDeniedState` 컴포넌트 추가, `VOC_MY_VOC_FORBIDDEN_MESSAGE` 상수
- `ApiResponse`에 `errorCode` 지원, `bff-error-message`에서 camelCase·snake_case 모두 해석

## Test Plan
- [x] `./gradlew compileJava compileTestJava`
- [x] `VocServiceOwnershipTest` 통과
- [ ] 수동: 본인 민원 상세 정상, 타인 `vocId`로 접근 시 403 UI, 존재하지 않는 ID는 404
- [ ] 수동: 관리자 계정이 아닌 토큰으로 `/admin/vocs/{id}` 시 403 안내

## Related
- DoD: 강제 URL 접근 시 외부/타인 사용자 차단 — **403(타인 소유)** / **404(미존재)** 로 구분 가능