### PR TITLE
[CS/feat] 미처리 우선 목록 및 답변 시 처리완료

### DIFF
--- a/backend/src/main/java/com/coliving/admin/voc/adapter/in/web/AdminVocController.java
+++ b/backend/src/main/java/com/coliving/admin/voc/adapter/in/web/AdminVocController.java
@@ -41,14 +41,17 @@ public class AdminVocController {
     @GetMapping("/api/admin/vocs")
     public ApiResponse<AdminVocListResponseDto> listVocs(
             @RequestParam(required = false) String status,
+            @RequestParam(required = false) Boolean pending,
             @RequestParam(value = "p", defaultValue = "0") int page,
             @RequestParam(value = "s", defaultValue = "20") int size,
             @RequestParam(required = false, defaultValue = "createdAt,desc") String sort
     ) {
-        VocStatus statusFilter = parseStatusOrNull(status);
+        boolean pendingOnly = Boolean.TRUE.equals(pending);
+        VocStatus statusFilter = pendingOnly ? null : parseStatusOrNull(status);
 
         ListAdminVocsCommand command = ListAdminVocsCommand.builder()
                 .status(statusFilter)
+                .pendingOnly(pendingOnly)
                 .page(page)
                 .size(size)
                 .sort(sort)

--- a/backend/src/main/java/com/coliving/admin/voc/application/command/ListAdminVocsCommand.java
+++ b/backend/src/main/java/com/coliving/admin/voc/application/command/ListAdminVocsCommand.java
@@ -8,6 +8,8 @@ import lombok.Getter;
 @Builder
 public class ListAdminVocsCommand {
     private final VocStatus status;
+    /** true면 OPEN·IN_PROGRESS만(미처리 큐), status 필터는 무시 */
+    private final boolean pendingOnly;
     private final int page;
     private final int size;
     private final String sort;

--- a/backend/src/main/java/com/coliving/admin/voc/application/service/AdminVocService.java
+++ b/backend/src/main/java/com/coliving/admin/voc/application/service/AdminVocService.java
@@ -48,10 +48,11 @@ public class AdminVocService implements AdminVocUseCase {
     public AdminVocListResult listVocs(ListAdminVocsCommand command) {
         int safePage = Math.max(0, command.getPage());
         int safeSize = normalizeSize(command.getSize());
-        Sort sort = parseSort(command.getSort());
-        PageRequest pageRequest = PageRequest.of(safePage, safeSize, sort);
+        PageRequest pageRequest = command.isPendingOnly()
+                ? PageRequest.of(safePage, safeSize)
+                : PageRequest.of(safePage, safeSize, parseSort(command.getSort()));
 
-        Page<Voc> page = vocRepositoryPort.findPageForAdmin(command.getStatus(), pageRequest);
+        Page<Voc> page = vocRepositoryPort.findPageForAdmin(command.getStatus(), command.isPendingOnly(), pageRequest);
 
         List<AdminVocListItemResult> content = page.getContent().stream()
                 .map(v -> AdminVocListItemResult.builder()

--- a/backend/src/main/java/com/coliving/common/voc/adapter/out/jpa/VocJpaRepository.java
+++ b/backend/src/main/java/com/coliving/common/voc/adapter/out/jpa/VocJpaRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface VocJpaRepository extends JpaRepository<VocEntity, Long> {
@@ -20,4 +21,19 @@ public interface VocJpaRepository extends JpaRepository<VocEntity, Long> {
             WHERE (:status IS NULL OR v.status = :status)
             """)
     Page<VocEntity> findPageByOptionalStatus(@Param("status") VocStatus status, Pageable pageable);
+
+    /** 미처리(접수·처리 중): OPEN을 먼저, 그다음 IN_PROGRESS(문자열 정렬과 무관하게 고정) */
+    @Query(
+            value = """
+                    SELECT v FROM VocEntity v
+                    WHERE v.status IN :statuses
+                    ORDER BY CASE WHEN v.status = com.coliving.common.voc.model.VocStatus.OPEN THEN 0 ELSE 1 END,
+                             v.createdAt DESC
+                    """,
+            countQuery = """
+                    SELECT COUNT(v) FROM VocEntity v
+                    WHERE v.status IN :statuses
+                    """
+    )
+    Page<VocEntity> findPageByStatusInPendingOrder(@Param("statuses") List<VocStatus> statuses, Pageable pageable);
 }

--- a/backend/src/main/java/com/coliving/common/voc/adapter/out/persistence/VocPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/voc/adapter/out/persistence/VocPersistenceAdapter.java
@@ -60,7 +60,12 @@ public class VocPersistenceAdapter implements VocRepositoryPort {
     }
 
     @Override
-    public Page<Voc> findPageForAdmin(VocStatus status, Pageable pageable) {
+    public Page<Voc> findPageForAdmin(VocStatus status, boolean pendingOnly, Pageable pageable) {
+        if (pendingOnly) {
+            return vocJpaRepository
+                    .findPageByStatusInPendingOrder(List.of(VocStatus.OPEN, VocStatus.IN_PROGRESS), pageable)
+                    .map(this::toModel);
+        }
         return vocJpaRepository.findPageByOptionalStatus(status, pageable).map(this::toModel);
     }
 
@@ -99,9 +104,7 @@ public class VocPersistenceAdapter implements VocRepositoryPort {
         entity.setAdminReply(reply);
         entity.setReplyUserId(adminUserId);
         entity.setRepliedAt(OffsetDateTime.now());
-        if (entity.getStatus() == VocStatus.OPEN) {
-            entity.setStatus(VocStatus.IN_PROGRESS);
-        }
+        entity.setStatus(VocStatus.RESOLVED);
 
         entity = vocJpaRepository.save(entity);
         return toModel(entity);

--- a/backend/src/main/java/com/coliving/common/voc/application/port/out/VocRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/common/voc/application/port/out/VocRepositoryPort.java
@@ -20,7 +20,10 @@ public interface VocRepositoryPort {
 
     Page<Voc> findByUserId(Long userId, Pageable pageable);
 
-    Page<Voc> findPageForAdmin(VocStatus status, Pageable pageable);
+    /**
+     * @param pendingOnly true이면 OPEN·IN_PROGRESS만 조회(미처리 큐). status는 무시됩니다.
+     */
+    Page<Voc> findPageForAdmin(VocStatus status, boolean pendingOnly, Pageable pageable);
 
     Voc updateOwned(Long vocId, Long userId, VocCategory category, String title, String content,
                     List<VocAttachment> attachments);

--- a/frontend/src/app/admin/vocs/[vocId]/_components/AdminVocActions.tsx
+++ b/frontend/src/app/admin/vocs/[vocId]/_components/AdminVocActions.tsx
@@ -103,7 +103,7 @@ export function AdminVocActions({ vocId, status }: Props) {
               className={fieldClass}
             />
             <p className="mt-2 text-sm font-medium tracking-tight text-muted-foreground">
-              등록 시 입주민에게 알림이 발송됩니다. (OPEN → 처리 중으로 전환될 수 있습니다.)
+              등록 시 입주민에게 알림이 발송되며, 해당 민원은 처리 완료(RESOLVED)로 반영됩니다.
             </p>
           </div>
           {error ? (

--- a/frontend/src/app/admin/vocs/_components/AdminVocStatusFilter.tsx
+++ b/frontend/src/app/admin/vocs/_components/AdminVocStatusFilter.tsx
@@ -1,24 +1,56 @@
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { ADMIN_VOC_STATUS_FILTERS } from "../_types/admin-vocs";
 
 type Props = {
-  activeStatus: string;
+  /** 미처리 큐(OPEN·IN_PROGRESS) */
+  pending: boolean;
+  /** 전체 목록 */
+  all: boolean;
+  /** 단일 상태 필터 */
+  status: string;
 };
 
-export function AdminVocStatusFilter({ activeStatus }: Props) {
-  const base = "shrink-0 rounded-xl border px-4 py-2.5 text-xs font-black uppercase tracking-wider transition-transform duration-200 hover:scale-[1.02]";
+const base =
+  "shrink-0 rounded-xl border px-4 py-2.5 text-xs font-black uppercase tracking-wider transition-transform duration-200 hover:scale-[1.02]";
 
+const STATUS_TABS: { value: string; label: string }[] = [
+  { value: "OPEN", label: "접수" },
+  { value: "IN_PROGRESS", label: "처리 중" },
+  { value: "RESOLVED", label: "처리 완료" },
+  { value: "CANCELLED", label: "취소" },
+];
+
+export function AdminVocStatusFilter({ pending, all, status }: Props) {
   return (
     <div className="flex gap-3 overflow-x-auto pb-2 md:flex-wrap md:overflow-visible md:gap-3">
-      {ADMIN_VOC_STATUS_FILTERS.map((f) => {
-        const isAll = f.value === "";
-        const href = isAll ? "/admin/vocs" : `/admin/vocs?status=${encodeURIComponent(f.value)}`;
-        const active = isAll ? activeStatus === "" : activeStatus === f.value;
+      <Link
+        href="/admin/vocs?pending=true"
+        className={cn(
+          base,
+          pending
+            ? "border-secondary bg-primary text-primary-foreground shadow-sm"
+            : "border-border bg-background text-foreground hover:border-secondary/60",
+        )}
+      >
+        미처리
+      </Link>
+      <Link
+        href="/admin/vocs?all=1"
+        className={cn(
+          base,
+          all
+            ? "border-secondary bg-primary text-primary-foreground shadow-sm"
+            : "border-border bg-background text-foreground hover:border-secondary/60",
+        )}
+      >
+        전체
+      </Link>
+      {STATUS_TABS.map((t) => {
+        const active = !pending && !all && status === t.value;
         return (
           <Link
-            key={f.value || "all"}
-            href={href}
+            key={t.value}
+            href={`/admin/vocs?status=${encodeURIComponent(t.value)}`}
             className={cn(
               base,
               active
@@ -26,7 +58,7 @@ export function AdminVocStatusFilter({ activeStatus }: Props) {
                 : "border-border bg-background text-foreground hover:border-secondary/60",
             )}
           >
-            {f.label}
+            {t.label}
           </Link>
         );
       })}

--- a/frontend/src/app/admin/vocs/_lib/admin-voc-list-query.ts
+++ b/frontend/src/app/admin/vocs/_lib/admin-voc-list-query.ts
@@ -1,0 +1,70 @@
+/** `searchParams` await 결과 등 단일 문자열 값 위주 */
+export type SearchParamsLike = Record<string, string | string[] | undefined>;
+
+function param(sp: SearchParamsLike, key: string): string {
+  const v = sp[key];
+  if (v == null) return "";
+  return Array.isArray(v) ? (v[0] ?? "") : v;
+}
+
+/** 목록 API·페이지네이션용 쿼리스트링 (필터 1개만 적용) */
+export function buildAdminVocListApiQuery(sp: SearchParamsLike): string {
+  const status = param(sp, "status").trim();
+  const all = param(sp, "all") === "1" || param(sp, "all") === "true";
+  const pending = param(sp, "pending") === "true" || param(sp, "pending") === "1";
+
+  const qs = new URLSearchParams();
+  if (pending) qs.set("pending", "true");
+  else if (all) {
+    /* 전체: status·pending 생략 (백엔드 기본 목록) */
+  } else if (status) qs.set("status", status);
+  else qs.set("pending", "true");
+
+  const page = Math.max(0, parseInt(param(sp, "p") || "0", 10) || 0);
+  const size = Math.min(50, Math.max(1, parseInt(param(sp, "s") || "20", 10) || 20));
+  qs.set("p", String(page));
+  qs.set("s", String(size));
+  qs.set("sort", "createdAt,desc");
+  return qs.toString();
+}
+
+/** 페이지네이션 링크에 붙일 필터 부분 (p, s 제외) */
+export function buildAdminVocListBaseQuery(sp: SearchParamsLike): string {
+  const status = param(sp, "status").trim();
+  const all = param(sp, "all") === "1" || param(sp, "all") === "true";
+  const pending = param(sp, "pending") === "true" || param(sp, "pending") === "1";
+
+  if (pending) return "pending=true";
+  if (all) return "all=1";
+  if (status) return `status=${encodeURIComponent(status)}`;
+  return "pending=true";
+}
+
+export function parseAdminVocListScope(sp: SearchParamsLike): {
+  pending: boolean;
+  all: boolean;
+  status: string;
+} {
+  const status = param(sp, "status").trim();
+  const all = param(sp, "all") === "1" || param(sp, "all") === "true";
+  const pending = param(sp, "pending") === "true" || param(sp, "pending") === "1";
+  return { pending, all, status };
+}
+
+export function adminVocListNeedsDefaultRedirect(sp: SearchParamsLike): boolean {
+  const status = param(sp, "status").trim();
+  const all = param(sp, "all") === "1" || param(sp, "all") === "true";
+  const pending = param(sp, "pending") === "true" || param(sp, "pending") === "1";
+  return !pending && !all && !status;
+}
+
+/** `/admin/vocs` 단독 진입 시 미처리 큐로 보냄(p·s 유지) */
+export function redirectToDefaultAdminVocList(sp: SearchParamsLike): string {
+  const qs = new URLSearchParams();
+  qs.set("pending", "true");
+  const p = param(sp, "p");
+  const s = param(sp, "s");
+  if (p) qs.set("p", p);
+  if (s) qs.set("s", s);
+  return `/admin/vocs?${qs.toString()}`;
+}

--- a/frontend/src/app/admin/vocs/_types/admin-vocs.ts
+++ b/frontend/src/app/admin/vocs/_types/admin-vocs.ts
@@ -43,15 +43,6 @@ export type ApiResponse<T> = {
   errorCode?: string | null;
 };
 
-/** 백엔드 VocStatus */
-export const ADMIN_VOC_STATUS_FILTERS: { value: string; label: string }[] = [
-  { value: "", label: "전체" },
-  { value: "OPEN", label: "접수" },
-  { value: "IN_PROGRESS", label: "처리 중" },
-  { value: "RESOLVED", label: "처리 완료" },
-  { value: "CANCELLED", label: "취소" },
-];
-
 export function adminVocCategoryLabel(code: string): string {
   switch (code) {
     case "FACILITY":

--- a/frontend/src/app/admin/vocs/page.tsx
+++ b/frontend/src/app/admin/vocs/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { LayoutList } from "lucide-react";
 import { adminBffGet } from "./_api/admin-bff-server";
 import type { AdminVocListData, ApiResponse } from "./_types/admin-vocs";
@@ -6,8 +7,15 @@ import { MotionEnter } from "./_components/MotionEnter";
 import { AdminVocStatusFilter } from "./_components/AdminVocStatusFilter";
 import { AdminVocListCard } from "./_components/AdminVocListCard";
 import { AdminVocPaginationBar } from "./_components/AdminVocPaginationBar";
+import {
+  adminVocListNeedsDefaultRedirect,
+  buildAdminVocListApiQuery,
+  buildAdminVocListBaseQuery,
+  parseAdminVocListScope,
+  redirectToDefaultAdminVocList,
+} from "./_lib/admin-voc-list-query";
 
-type SearchParams = Promise<{ status?: string; p?: string; s?: string }>;
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
 export const metadata = {
   title: "민원 관리 | Admin",
@@ -15,17 +23,14 @@ export const metadata = {
 
 export default async function AdminVocListPage({ searchParams }: { searchParams: SearchParams }) {
   const sp = await searchParams;
-  const status = sp.status?.trim() ?? "";
-  const page = Math.max(0, parseInt(sp.p ?? "0", 10) || 0);
-  const size = Math.min(50, Math.max(1, parseInt(sp.s ?? "20", 10) || 20));
 
-  const qs = new URLSearchParams();
-  if (status) qs.set("status", status);
-  qs.set("p", String(page));
-  qs.set("s", String(size));
-  qs.set("sort", "createdAt,desc");
+  if (adminVocListNeedsDefaultRedirect(sp)) {
+    redirect(redirectToDefaultAdminVocList(sp));
+  }
 
-  const res = await adminBffGet(`admin/vocs?${qs.toString()}`);
+  const { pending, all, status } = parseAdminVocListScope(sp);
+
+  const res = await adminBffGet(`admin/vocs?${buildAdminVocListApiQuery(sp)}`);
   let list: AdminVocListData | null = null;
   let error: string | null = null;
 
@@ -39,7 +44,7 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
     else error = body.message ?? "목록을 불러오지 못했습니다.";
   }
 
-  const baseQuery = status ? `status=${encodeURIComponent(status)}` : "";
+  const baseQuery = buildAdminVocListBaseQuery(sp);
 
   return (
     <MotionEnter>
@@ -52,7 +57,7 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
               <span className="underline decoration-secondary decoration-2 underline-offset-[0.18em]">관리</span>
             </h1>
             <p className="max-w-xl font-medium tracking-tight text-balance text-foreground/85 md:text-lg">
-              전체 입주민 민원을 조회합니다. 답변 등록과 처리 완료는 각 건 상세에서 진행합니다.
+              기본 화면은 미처리(접수·처리 중) 안건입니다. 답변 등록 시 해당 건은 처리 완료로 반영됩니다.
             </p>
           </div>
           <Link
@@ -64,8 +69,7 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
         </header>
 
         <section className="mt-12 space-y-4">
-          <p className="font-black text-[10px] uppercase tracking-[0.3em] text-muted-foreground"></p>
-          <AdminVocStatusFilter activeStatus={status} />
+          <AdminVocStatusFilter pending={pending} all={all} status={status} />
         </section>
 
         {error && (
@@ -99,7 +103,7 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
               page={list.page}
               totalPages={list.totalPages}
               baseQuery={baseQuery}
-              pageSize={size}
+              pageSize={list.size}
             />
           </>
         )}


### PR DESCRIPTION
## 변경 사항

### 백엔드
- `GET /api/admin/vocs`에 `pending` 쿼리 파라미터 추가
- `pending=true`일 때 OPEN(미처리) 민원을 먼저 보여주고, 동일 그룹 내에서는 `createdAt DESC` 정렬
- 관리자 답변 등록(`applyAdminReply`) 시 민원 상태를 즉시 `RESOLVED`로 변경

### 프론트엔드
- `/admin/vocs` 기본 진입 시 미처리 큐(`pending=true`)로 리다이렉트
- "전체" 보기는 URL에 `all=1`만 두고 API에서는 `pending`/상태 필터 생략
- 목록 쿼리·페이지네이션·필터 연동을 `admin-voc-list-query.ts`로 정리

## 참고
- 브랜치: `feat/100`