### PR TITLE
[CS/feat] SSE 실시간 알림 채널 및 안정성 보강

### DIFF
--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/NotificationController.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/NotificationController.java
@@ -5,6 +5,7 @@ import com.coliving.common.notification.adapter.in.web.dto.res.NotificationListR
 import com.coliving.common.notification.adapter.in.web.dto.res.NotificationReadResponseDto;
 import com.coliving.common.notification.application.command.ListNotificationsCommand;
 import com.coliving.common.notification.application.command.MarkNotificationReadCommand;
+import com.coliving.common.notification.application.service.NotificationSseService;
 import com.coliving.common.notification.application.port.in.NotificationUseCase;
 import com.coliving.common.notification.application.result.MarkNotificationReadResult;
 import com.coliving.common.notification.application.result.NotificationItemResult;
@@ -12,6 +13,7 @@ import com.coliving.common.notification.application.result.NotificationListResul
 import com.coliving.global.dto.ApiResponse;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,14 +21,18 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 public class NotificationController {
 
     private final NotificationUseCase notificationUseCase;
+    private final NotificationSseService notificationSseService;
 
-    public NotificationController(NotificationUseCase notificationUseCase) {
+    public NotificationController(NotificationUseCase notificationUseCase,
+                                  NotificationSseService notificationSseService) {
         this.notificationUseCase = notificationUseCase;
+        this.notificationSseService = notificationSseService;
     }
 
     @GetMapping("/api/notifications")
@@ -78,6 +84,12 @@ public class NotificationController {
                 .build();
 
         return ApiResponse.ok(response);
+    }
+
+    @GetMapping(path = "/api/notifications/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamNotifications() {
+        Long userId = getAuthenticatedUserId();
+        return notificationSseService.connect(userId);
     }
 
     private NotificationItemResponseDto toItemDto(NotificationItemResult item) {

--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationSseEventResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationSseEventResponseDto.java
@@ -1,0 +1,20 @@
+package com.coliving.common.notification.adapter.in.web.dto.res;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+public class NotificationSseEventResponseDto {
+    private Long userId;
+    private Long notificationId;
+    private String type;
+    private String title;
+    private String message;
+    private String referenceType;
+    private Long referenceId;
+    private boolean isRead;
+    private OffsetDateTime createdAt;
+}

--- a/backend/src/main/java/com/coliving/common/notification/application/event/NotificationCreatedEvent.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/event/NotificationCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.coliving.common.notification.application.event;
+
+import com.coliving.common.notification.model.Notification;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class NotificationCreatedEvent {
+    private final Notification notification;
+}

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationCreatedEventListener.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationCreatedEventListener.java
@@ -1,0 +1,23 @@
+package com.coliving.common.notification.application.service;
+
+import com.coliving.common.notification.application.event.NotificationCreatedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class NotificationCreatedEventListener {
+    private final NotificationRealtimeFanoutService notificationRealtimeFanoutService;
+
+    public NotificationCreatedEventListener(NotificationRealtimeFanoutService notificationRealtimeFanoutService) {
+        this.notificationRealtimeFanoutService = notificationRealtimeFanoutService;
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onNotificationCreated(NotificationCreatedEvent event) {
+        if (event == null || event.getNotification() == null) {
+            return;
+        }
+        notificationRealtimeFanoutService.publish(event.getNotification());
+    }
+}

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationRealtimeFanoutService.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationRealtimeFanoutService.java
@@ -1,0 +1,57 @@
+package com.coliving.common.notification.application.service;
+
+import com.coliving.common.notification.adapter.in.web.dto.res.NotificationSseEventResponseDto;
+import com.coliving.common.notification.model.Notification;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationRealtimeFanoutService {
+    public static final String CHANNEL = "notification:sse:events";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final NotificationSseService notificationSseService;
+
+    public NotificationRealtimeFanoutService(StringRedisTemplate stringRedisTemplate,
+                                             ObjectMapper objectMapper,
+                                             NotificationSseService notificationSseService) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.objectMapper = objectMapper;
+        this.notificationSseService = notificationSseService;
+    }
+
+    public void publish(Notification notification) {
+        NotificationSseEventResponseDto payload = NotificationSseEventResponseDto.builder()
+                .userId(notification.getUserId())
+                .notificationId(notification.getNotificationId())
+                .type(notification.getType() != null ? notification.getType().name() : null)
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .referenceType(notification.getReferenceType() != null ? notification.getReferenceType().name() : null)
+                .referenceId(notification.getReferenceId())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+
+        try {
+            String raw = objectMapper.writeValueAsString(payload);
+            stringRedisTemplate.convertAndSend(CHANNEL, raw);
+        } catch (Exception e) {
+            // Redis/직렬화 장애 시에도 현재 인스턴스 연결로는 즉시 전달
+            notificationSseService.sendNotification(payload);
+        }
+    }
+
+    public void onMessage(String rawMessage) {
+        try {
+            NotificationSseEventResponseDto payload =
+                    objectMapper.readValue(rawMessage, NotificationSseEventResponseDto.class);
+            notificationSseService.sendNotification(payload);
+        } catch (JsonProcessingException ignored) {
+            // Malformed message is ignored to protect stream stability.
+        }
+    }
+}

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
@@ -3,6 +3,7 @@ package com.coliving.common.notification.application.service;
 import com.coliving.common.notification.application.command.CreateNotificationCommand;
 import com.coliving.common.notification.application.command.ListNotificationsCommand;
 import com.coliving.common.notification.application.command.MarkNotificationReadCommand;
+import com.coliving.common.notification.application.event.NotificationCreatedEvent;
 import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
 import com.coliving.common.notification.application.port.in.NotificationUseCase;
 import com.coliving.common.notification.application.port.out.NotificationRepositoryPort;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -29,9 +31,12 @@ public class NotificationService implements NotificationUseCase, CreateNotificat
     );
 
     private final NotificationRepositoryPort notificationRepositoryPort;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public NotificationService(NotificationRepositoryPort notificationRepositoryPort) {
+    public NotificationService(NotificationRepositoryPort notificationRepositoryPort,
+                               ApplicationEventPublisher eventPublisher) {
         this.notificationRepositoryPort = notificationRepositoryPort;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -89,6 +94,7 @@ public class NotificationService implements NotificationUseCase, CreateNotificat
                 command.getReferenceType(),
                 command.getReferenceId()
         );
+        eventPublisher.publishEvent(new NotificationCreatedEvent(saved));
 
         return CreateNotificationResult.builder()
                 .notificationId(saved.getNotificationId())

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationSseService.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationSseService.java
@@ -1,0 +1,106 @@
+package com.coliving.common.notification.application.service;
+
+import com.coliving.common.notification.adapter.in.web.dto.res.NotificationSseEventResponseDto;
+import com.coliving.common.notification.model.Notification;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class NotificationSseService {
+    private static final long SSE_TIMEOUT_MS = 30L * 60L * 1000L;
+    private static final String EVENT_CONNECTED = "connected";
+    private static final String EVENT_NOTIFICATION = "notification";
+
+    private final Map<Long, Map<String, SseEmitter>> emittersByUser = new ConcurrentHashMap<>();
+
+    public SseEmitter connect(Long userId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MS);
+        String emitterId = buildEmitterId(userId);
+
+        emittersByUser
+                .computeIfAbsent(userId, ignored -> new ConcurrentHashMap<>())
+                .put(emitterId, emitter);
+
+        emitter.onCompletion(() -> removeEmitter(userId, emitterId));
+        emitter.onTimeout(() -> removeEmitter(userId, emitterId));
+        emitter.onError(ignored -> removeEmitter(userId, emitterId));
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(EVENT_CONNECTED)
+                    .data(Map.of("status", "connected")));
+        } catch (Exception e) {
+            emitter.complete();
+            removeEmitter(userId, emitterId);
+        }
+
+        return emitter;
+    }
+
+    public void sendNotification(Notification notification) {
+        if (notification == null || notification.getUserId() == null) {
+            return;
+        }
+
+        NotificationSseEventResponseDto payload = NotificationSseEventResponseDto.builder()
+                .userId(notification.getUserId())
+                .notificationId(notification.getNotificationId())
+                .type(notification.getType() != null ? notification.getType().name() : null)
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .referenceType(notification.getReferenceType() != null ? notification.getReferenceType().name() : null)
+                .referenceId(notification.getReferenceId())
+                .isRead(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+        sendNotification(payload);
+    }
+
+    public void sendNotification(NotificationSseEventResponseDto payload) {
+        if (payload == null || payload.getNotificationId() == null || payload.getUserId() == null) {
+            return;
+        }
+        sendNotificationToUser(payload.getUserId(), payload);
+    }
+
+    public void sendNotificationToUser(Long userId, NotificationSseEventResponseDto payload) {
+        if (userId == null || payload == null) {
+            return;
+        }
+        Map<String, SseEmitter> userEmitters = emittersByUser.get(userId);
+        if (userEmitters == null || userEmitters.isEmpty()) {
+            return;
+        }
+
+        userEmitters.forEach((emitterId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .name(EVENT_NOTIFICATION)
+                        .id(String.valueOf(payload.getNotificationId()))
+                        .data(payload));
+            } catch (Exception e) {
+                emitter.complete();
+                removeEmitter(userId, emitterId);
+            }
+        });
+    }
+
+    private void removeEmitter(Long userId, String emitterId) {
+        Map<String, SseEmitter> userEmitters = emittersByUser.get(userId);
+        if (userEmitters == null) {
+            return;
+        }
+        userEmitters.remove(emitterId);
+        if (userEmitters.isEmpty()) {
+            emittersByUser.remove(userId);
+        }
+    }
+
+    private String buildEmitterId(Long userId) {
+        return userId + "_" + UUID.randomUUID();
+    }
+}

--- a/backend/src/main/java/com/coliving/common/notification/config/NotificationRedisSubscriberConfig.java
+++ b/backend/src/main/java/com/coliving/common/notification/config/NotificationRedisSubscriberConfig.java
@@ -1,0 +1,37 @@
+package com.coliving.common.notification.config;
+
+import com.coliving.common.notification.application.service.NotificationRealtimeFanoutService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class NotificationRedisSubscriberConfig {
+
+    @Bean
+    public MessageListenerAdapter notificationMessageListenerAdapter(
+            NotificationRealtimeFanoutService fanoutService
+    ) {
+        MessageListenerAdapter adapter = new MessageListenerAdapter(fanoutService, "onMessage");
+        adapter.setSerializer(StringRedisSerializer.UTF_8);
+        return adapter;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer notificationRedisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            MessageListenerAdapter notificationMessageListenerAdapter
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(
+                notificationMessageListenerAdapter,
+                new PatternTopic(NotificationRealtimeFanoutService.CHANNEL)
+        );
+        return container;
+    }
+}

--- a/frontend/src/app/api/notifications/stream/route.ts
+++ b/frontend/src/app/api/notifications/stream/route.ts
@@ -1,0 +1,57 @@
+import { cookies } from "next/headers";
+
+const BACKEND_URL = process.env.INTERNAL_BACKEND_URL || "http://localhost:8080";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value;
+
+  if (!accessToken) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        message: "인증이 필요합니다.",
+        errorCode: "UNAUTHORIZED",
+      }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  const upstream = await fetch(`${BACKEND_URL}/api/notifications/stream`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "text/event-stream",
+    },
+    cache: "no-store",
+  });
+
+  if (!upstream.ok || !upstream.body) {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        message: "실시간 알림 채널 연결에 실패했습니다.",
+        errorCode: "SSE_CONNECT_FAILED",
+      }),
+      {
+        status: upstream.status || 502,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/frontend/src/components/layout/AuthProvider.tsx
+++ b/frontend/src/components/layout/AuthProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { useAuthStore } from '@/store/useAuthStore';
+import NotificationSseClient from '@/components/layout/NotificationSseClient';
 
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
   const initializeAuth = useAuthStore((state) => state.initializeAuth);
@@ -13,5 +14,10 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
   // AuthProvider는 비동기 검증결과에 상관없이 children(화면)을 즉시 렌더링하도록 허용.
   // 실제 로그인 여부에 따른 UI 분기나 로딩은 개별 컴포넌트 단위에서 `isLoading`을 구독하여 처리.
-  return <>{children}</>;
+  return (
+    <>
+      {children}
+      <NotificationSseClient />
+    </>
+  );
 }

--- a/frontend/src/components/layout/NotificationSseClient.tsx
+++ b/frontend/src/components/layout/NotificationSseClient.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { Bell } from "lucide-react";
+import { useAuthStore } from "@/store/useAuthStore";
+
+type NotificationEventPayload = {
+  notificationId: number;
+  type: string | null;
+  title: string;
+  message: string;
+  referenceType: string | null;
+  referenceId: number | null;
+  isRead: boolean;
+  createdAt: string;
+};
+
+type NotificationToast = {
+  id: number;
+  title: string;
+  message: string;
+};
+
+type ApiResponse<T> = {
+  success: boolean;
+  data?: T;
+};
+
+type NotificationListData = {
+  totalElements: number;
+};
+
+export default function NotificationSseClient() {
+  const { isLoggedIn, isLoading } = useAuthStore();
+  const [toasts, setToasts] = useState<NotificationToast[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const hasUnread = unreadCount > 0;
+  const unreadLabel = useMemo(() => (unreadCount > 99 ? "99+" : String(unreadCount)), [unreadCount]);
+
+  useEffect(() => {
+    if (isLoading || !isLoggedIn) {
+      setToasts([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    let mounted = true;
+    const fetchUnreadCount = async () => {
+      try {
+        const res = await fetch("/api/notifications?is_read=false&p=0&s=1&sort=createdAt,desc", {
+          credentials: "include",
+        });
+        if (!res.ok) return;
+        const body = (await res.json()) as ApiResponse<NotificationListData>;
+        if (!mounted || !body.success || !body.data) return;
+        setUnreadCount(body.data.totalElements ?? 0);
+      } catch {
+        // Ignore: the realtime stream still works even if initial unread count fetch fails.
+      }
+    };
+
+    void fetchUnreadCount();
+    const unreadResyncTimer = window.setInterval(() => {
+      void fetchUnreadCount();
+    }, 60000);
+
+    const eventSource = new EventSource("/api/notifications/stream", { withCredentials: true });
+
+    const onNotification = (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(event.data) as NotificationEventPayload;
+        if (!mounted) return;
+
+        setUnreadCount((prev) => prev + (payload.isRead ? 0 : 1));
+        setToasts((prev) => {
+          const next = [{ id: payload.notificationId, title: payload.title, message: payload.message }, ...prev];
+          return next.slice(0, 3);
+        });
+
+        window.setTimeout(() => {
+          if (!mounted) return;
+          setToasts((prev) => prev.filter((t) => t.id !== payload.notificationId));
+        }, 4500);
+      } catch {
+        // Ignore malformed SSE payload.
+      }
+    };
+
+    const onConnected = () => {
+      void fetchUnreadCount();
+    };
+    eventSource.addEventListener("notification", onNotification as EventListener);
+    eventSource.addEventListener("connected", onConnected as EventListener);
+
+    return () => {
+      mounted = false;
+      window.clearInterval(unreadResyncTimer);
+      eventSource.removeEventListener("notification", onNotification as EventListener);
+      eventSource.removeEventListener("connected", onConnected as EventListener);
+      eventSource.close();
+    };
+  }, [isLoggedIn, isLoading]);
+
+  if (!isLoggedIn) return null;
+
+  return (
+    <>
+      <div className="pointer-events-none fixed top-20 right-4 z-[150] flex w-[22rem] max-w-[calc(100vw-2rem)] flex-col gap-2">
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className="pointer-events-auto rounded-xl border border-secondary/30 bg-background/95 px-4 py-3 shadow-lg backdrop-blur"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="text-xs font-black uppercase tracking-wider text-secondary">New Notification</p>
+            <p className="mt-1 text-sm font-semibold text-foreground">{toast.title}</p>
+            <p className="mt-1 line-clamp-2 text-xs text-foreground/80">{toast.message}</p>
+          </div>
+        ))}
+      </div>
+
+      <Link
+        href="/notifications"
+        className="fixed right-5 bottom-5 z-[140] inline-flex items-center gap-2 rounded-full border border-secondary/30 bg-background/95 px-4 py-2 text-sm font-black tracking-wide text-foreground shadow-md backdrop-blur hover:bg-background"
+      >
+        <span className="relative inline-flex">
+          <Bell className="size-4" />
+          {hasUnread ? (
+            <span className="absolute -top-2 -right-2 inline-flex min-w-5 items-center justify-center rounded-full bg-secondary px-1 text-[10px] leading-5 text-white">
+              {unreadLabel}
+            </span>
+          ) : null}
+        </span>
+        알림
+      </Link>
+    </>
+  );
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -31,6 +31,11 @@ const secretKey = new TextEncoder().encode(JWT_SECRET);
 
 export async function middleware(req: NextRequest) {
   if (req.nextUrl.pathname.startsWith('/api/')) {
+    // SSE 스트림은 app/api route handler에서 직접 처리 (장시간 연결 안정성 확보)
+    if (req.nextUrl.pathname === '/api/notifications/stream') {
+      return NextResponse.next();
+    }
+
     // [MOCK] /api/bff/admin/contracts 관련 모든 요청(목록, 승인, 반려)은 프록시하지 않고 통과시킵니다.
     if (req.nextUrl.pathname.includes('/admin/contracts')) {
       return NextResponse.next();
@@ -44,15 +49,16 @@ export async function middleware(req: NextRequest) {
       // Extract JWT from httpOnly cookie
       const accessToken = req.cookies.get('access_token')?.value;
 
-      let jwtPayload: any = null;
+      let jwtPayload: Record<string, unknown> | null = null;
 
       if (accessToken) {
         try {
           // Verify token format, signature, and expiration at the Edge
           const { payload } = await jwtVerify(accessToken, secretKey);
           jwtPayload = payload;
-        } catch (err: any) {
-          console.warn('[Middleware BFF] JWT Verification Failed:', err.code || err.message);
+        } catch (err: unknown) {
+          const errMsg = err instanceof Error ? err.message : String(err);
+          console.warn('[Middleware BFF] JWT Verification Failed:', errMsg);
           return NextResponse.json(
             {
               success: false,


### PR DESCRIPTION
## Summary
- 사용자별 SSE 구독 엔드포인트(`/api/notifications/stream`)와 emitter lifecycle(timeout/completion/error cleanup) 추가
- 알림 생성 시 커밋 이후(`AFTER_COMMIT`) 이벤트 발행 + Redis Pub/Sub fan-out으로 멀티 인스턴스 전달 보강
- 프론트 `EventSource` 구독 클라이언트/토스트/미읽음 배지 UI 추가, SSE 전용 route handler 분리 및 middleware 우회로 장시간 연결 안정화

## Test plan
- [x] backend: `./gradlew compileJava`
- [x] frontend: `npx eslint src/components/layout/NotificationSseClient.tsx src/middleware.ts src/app/api/notifications/stream/route.ts`
- [ ] 로그인 사용자로 `/api/notifications/stream` 연결 후 예약/민원 답변 알림 생성 시 토스트/배지 즉시 반영 확인
- [ ] Redis 장애 상황에서 현재 인스턴스 SSE 연결에 fallback 전송되는지 확인