### PR TITLE
[CS/fix] stop false login-required prompts in common domains

### DIFF
--- a/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentComposer.tsx
@@ -29,7 +29,7 @@ export function CommentComposer({ postId }: { postId: number }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/comment/_components/CommentItem.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentItem.tsx
@@ -74,7 +74,7 @@ export function CommentItem({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ content: text }),
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
           return;
         }
@@ -101,7 +101,7 @@ export function CommentItem({
           method: "DELETE",
           credentials: "include",
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
@@ -104,7 +104,7 @@ export function CommentThreadSection({
           body: JSON.stringify({ content: text, parentCommentId }),
         });
 
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
           setComments((prev) => prev.filter((c) => c.commentId !== tempId));
           return;

--- a/frontend/src/app/(common)/community/[postId]/page.tsx
+++ b/frontend/src/app/(common)/community/[postId]/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { ACCESS_DENIED_MESSAGE, LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "../_api/bff-server";
 import type { ApiResponse, PostDetail } from "../_types/community";
@@ -23,13 +23,24 @@ export default async function CommunityPostDetailPage({ params }: { params: Para
   const res = await bffGet(`posts/${id}`);
 
   if (res.status === 404) notFound();
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
     return (
       <CommunityShell>
         <MotionEnter>
           <div className="mx-auto max-w-3xl text-center">
             <LoginRequiredGate />
             <p className="font-medium text-destructive">{LOGIN_REQUIRED_MESSAGE}</p>
+          </div>
+        </MotionEnter>
+      </CommunityShell>
+    );
+  }
+  if (res.status === 403) {
+    return (
+      <CommunityShell>
+        <MotionEnter>
+          <div className="mx-auto max-w-3xl text-center">
+            <p className="font-medium text-destructive">{ACCESS_DENIED_MESSAGE}</p>
           </div>
         </MotionEnter>
       </CommunityShell>

--- a/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
+++ b/frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx
@@ -72,7 +72,7 @@ export function CommunityRichTextEditor({ value, onChange, placeholder, id }: Pr
             body: fd,
             credentials: "include",
           });
-          if (res.status === 401 || res.status === 403) {
+          if (res.status === 401) {
             setUploadError(LOGIN_REQUIRED_MESSAGE);
             setShowLoginModal(true);
             return;

--- a/frontend/src/app/(common)/community/_components/LikeToggle.tsx
+++ b/frontend/src/app/(common)/community/_components/LikeToggle.tsx
@@ -28,7 +28,7 @@ export function LikeToggle({ postId, initialLiked, initialCount }: Props) {
           credentials: "include",
           headers: { "Content-Type": "application/json" },
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setShowLoginModal(true);
           return;
         }

--- a/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
+++ b/frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx
@@ -124,7 +124,7 @@ export function PostEditDeleteActions({
         method: "DELETE",
         credentials: "include",
       });
-      if (res.status === 401 || res.status === 403) {
+      if (res.status === 401) {
         setSubmitError(LOGIN_REQUIRED_MESSAGE);
         setShowLoginModal(true);
         return;
@@ -189,7 +189,7 @@ export function PostEditDeleteActions({
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setSubmitError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
+++ b/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
@@ -96,7 +96,7 @@ export function NewPostForm() {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setSubmitError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/app/(common)/community/page.tsx
+++ b/frontend/src/app/(common)/community/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Search } from "lucide-react";
-import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { ACCESS_DENIED_MESSAGE, LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "./_api/bff-server";
 import type { ApiResponse, PostListData } from "./_types/community";
@@ -32,8 +32,10 @@ export default async function CommunityPage({ searchParams }: { searchParams: Se
   let list: PostListData | null = null;
   let error: string | null = null;
 
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
     error = LOGIN_REQUIRED_MESSAGE;
+  } else if (res.status === 403) {
+    error = ACCESS_DENIED_MESSAGE;
   } else if (!res.ok) {
     error = "목록을 불러오지 못했습니다.";
   } else {

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { Bell } from "lucide-react";
-import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { ACCESS_DENIED_MESSAGE, LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { Header } from "@/components/shared/Header";
 import { Footer } from "@/components/shared/Footer";
@@ -55,8 +55,10 @@ export default async function NotificationsPage({ searchParams }: { searchParams
   let list: NotificationListData | null = null;
   let error: string | null = null;
 
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
     error = LOGIN_REQUIRED_MESSAGE;
+  } else if (res.status === 403) {
+    error = ACCESS_DENIED_MESSAGE;
   } else if (!res.ok) {
     error = "알림을 불러오지 못했습니다.";
   } else {

--- a/frontend/src/app/(common)/profile/vocs/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { ClipboardList } from "lucide-react";
-import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
+import { ACCESS_DENIED_MESSAGE, LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { bffGet } from "@/app/(common)/vocs/_api/bff-server";
 import type { ApiResponse, VocListData } from "@/app/(common)/vocs/_types/vocs";
@@ -34,8 +34,10 @@ export default async function ProfileVocsPage({ searchParams }: { searchParams: 
 
   // 기본 탭(민원 등록) 진입에서도 즉시 로그인 필요 모달을 띄우기 위해 인증 체크를 항상 수행한다.
   const res = await bffGet(`vocs/my?${qs.toString()}`);
-  if (res.status === 401 || res.status === 403) {
+  if (res.status === 401) {
     authError = LOGIN_REQUIRED_MESSAGE;
+  } else if (res.status === 403) {
+    authError = ACCESS_DENIED_MESSAGE;
   } else if (showList && !res.ok) {
     listError = "목록을 불러오지 못했습니다.";
   } else if (showList) {
@@ -68,6 +70,14 @@ export default async function ProfileVocsPage({ searchParams }: { searchParams: 
           <MyVocTabLinks active={showList ? "list" : "register"} />
 
           {authError === LOGIN_REQUIRED_MESSAGE ? <LoginRequiredGate /> : null}
+          {authError && authError !== LOGIN_REQUIRED_MESSAGE ? (
+            <div
+              className="mb-6 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive"
+              role="alert"
+            >
+              {authError}
+            </div>
+          ) : null}
 
           {!showList ? (
             <div className="mx-auto max-w-4xl">

--- a/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
+++ b/frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx
@@ -72,7 +72,7 @@ export function VocRichTextEditor({ value, onChange, placeholder, id }: Props) {
             body: fd,
             credentials: "include",
           });
-          if (res.status === 401 || res.status === 403) {
+          if (res.status === 401) {
             setUploadError(LOGIN_REQUIRED_MESSAGE);
             setShowLoginModal(true);
             return;

--- a/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
+++ b/frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx
@@ -85,7 +85,7 @@ export function NewVocForm() {
           credentials: "include",
           body: formData,
         });
-        if (res.status === 401 || res.status === 403) {
+        if (res.status === 401) {
           setError(LOGIN_REQUIRED_MESSAGE);
           setShowLoginModal(true);
           return;

--- a/frontend/src/lib/auth-messages.ts
+++ b/frontend/src/lib/auth-messages.ts
@@ -1,6 +1,9 @@
 /** 인증이 필요할 때 UI·API 오류 메시지로 사용합니다. */
 export const LOGIN_REQUIRED_MESSAGE = "로그인이 필요합니다.";
 
+/** 로그인은 되었지만 접근 권한이 없을 때 안내 문구 */
+export const ACCESS_DENIED_MESSAGE = "접근 권한이 없습니다.";
+
 /** 로그인은 되었으나 본인 민원이 아닐 때(403) 안내 문구 */
 export const VOC_MY_VOC_FORBIDDEN_MESSAGE =
   "본인이 등록한 민원만 열람·수정할 수 있습니다.";


### PR DESCRIPTION
## Summary
- `comment`, `community`, `notifications`, `profile/vocs` 도메인에서 인증/권한 응답 처리를 분리했습니다.
- 기존에는 `401`/`403`을 모두 로그인 필요로 처리해, 로그인된 사용자도 “로그인이 필요합니다” 메시지가 반복 노출되는 문제가 있었습니다.
- 이제 `401`은 로그인 필요, `403`은 권한 없음으로 분기해 UI 안내가 정확히 동작합니다.
- 공통 메시지 `ACCESS_DENIED_MESSAGE`를 추가하고, SSR 페이지/클라이언트 액션/에디터 업로드 경로에 일관 적용했습니다.

## What changed
- 공통 메시지 추가
  - `frontend/src/lib/auth-messages.ts`
- 페이지(SSR) 분기 수정
  - `frontend/src/app/(common)/community/page.tsx`
  - `frontend/src/app/(common)/community/[postId]/page.tsx`
  - `frontend/src/app/(common)/notifications/page.tsx`
  - `frontend/src/app/(common)/profile/vocs/page.tsx`
- 클라이언트 액션/폼/API 호출 분기 수정 (`401`만 로그인 모달)
  - `frontend/src/app/(common)/comment/_components/CommentComposer.tsx`
  - `frontend/src/app/(common)/comment/_components/CommentItem.tsx`
  - `frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx`
  - `frontend/src/app/(common)/community/_components/LikeToggle.tsx`
  - `frontend/src/app/(common)/community/_components/PostEditDeleteActions.tsx`
  - `frontend/src/app/(common)/community/new/_components/NewPostForm.tsx`
  - `frontend/src/app/(common)/vocs/new/_components/NewVocForm.tsx`
  - `frontend/src/app/(common)/community/_components/CommunityRichTextEditor.tsx`
  - `frontend/src/app/(common)/vocs/_components/VocRichTextEditor.tsx`

## Test plan
- [x] 비로그인 상태에서 보호 페이지/액션 접근 시 로그인 필요 안내 노출 확인 (`401`)
- [x] 로그인 상태에서 권한 없는 리소스 접근 시 로그인 필요 대신 권한 없음 안내 확인 (`403`)
- [x] 다음 경로/기능 확인
  - `/community`, `/community/[postId]`, `/community/new`
  - 댓글 작성/수정/삭제, 좋아요 토글
  - `/notifications`
  - `/profile/vocs`, VOC 등록/수정, 리치텍스트 이미지 업로드
- [x] 변경 파일 linter diagnostics 확인 (에러 없음)