### PR TITLE
[CS/style] align list visuals with my-contracts tone

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1461,7 +1461,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1534,7 +1533,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2047,7 +2045,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3052,7 +3049,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3226,7 +3222,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5467,7 +5462,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5649,7 +5643,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5659,7 +5652,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5679,7 +5671,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5753,8 +5744,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6460,7 +6450,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6610,7 +6599,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/app/(common)/community/_components/CategoryFilter.tsx
+++ b/frontend/src/app/(common)/community/_components/CategoryFilter.tsx
@@ -8,17 +8,17 @@ type Props = {
 
 export function CategoryFilter({ active }: Props) {
   const base =
-    "shrink-0 rounded-full border px-5 py-2.5 text-[10px] font-black uppercase tracking-[0.24em] transition-colors";
+    "shrink-0 text-[10px] font-black uppercase tracking-[0.3em] transition-all whitespace-nowrap";
 
   return (
-    <div className="flex gap-3 overflow-x-auto pb-2 md:flex-wrap md:overflow-visible">
+    <div className="flex items-center gap-10 overflow-x-auto pb-2 md:pb-0">
       <Link
         href="/community"
         className={cn(
           base,
           !active
-            ? "border-primary bg-primary text-primary-foreground shadow-sm"
-            : "border-border bg-background text-foreground/75 hover:border-secondary/60 hover:text-foreground",
+            ? "text-accent underline underline-offset-8"
+            : "opacity-40 hover:opacity-100",
         )}
       >
         전체
@@ -30,8 +30,8 @@ export function CategoryFilter({ active }: Props) {
           className={cn(
             base,
             active === c.value
-              ? "border-primary bg-primary text-primary-foreground shadow-sm"
-              : "border-border bg-background text-foreground/75 hover:border-secondary/60 hover:text-foreground",
+              ? "text-accent underline underline-offset-8"
+              : "opacity-40 hover:opacity-100",
           )}
         >
           {c.label}

--- a/frontend/src/app/(common)/community/_components/PostCard.tsx
+++ b/frontend/src/app/(common)/community/_components/PostCard.tsx
@@ -17,7 +17,7 @@ export function PostCard({ post }: { post: PostListItem }) {
       <motion.div
         whileHover={{ y: -8, scale: 1.01 }}
         transition={{ type: "spring", stiffness: 420, damping: 26 }}
-        className="rounded-[2.25rem] border border-primary/10 bg-background p-7 shadow-2xl shadow-primary/5 md:p-9"
+        className="rounded-[2.5rem] border border-primary/5 bg-white p-8 shadow-2xl shadow-primary/5 md:p-10"
       >
         <div className="flex flex-wrap items-center gap-3">
           <span className="rounded-full bg-secondary/15 px-3 py-1 font-black text-[10px] uppercase tracking-[0.24em] text-secondary">
@@ -27,10 +27,10 @@ export function PostCard({ post }: { post: PostListItem }) {
             {formatDateTimeKo(post.createdAt)}
           </span>
         </div>
-        <h2 className="mt-4 line-clamp-2 text-xl font-black uppercase leading-tight tracking-tighter text-foreground md:text-2xl">
+        <h2 className="mt-5 line-clamp-2 text-[clamp(1.5rem,3vw,2.35rem)] font-black leading-[0.95] tracking-tighter text-foreground transition-colors group-hover:text-accent">
           {post.title}
         </h2>
-        <div className="mt-7 flex flex-wrap gap-3 text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+        <div className="mt-8 flex flex-wrap gap-3 text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
           <span className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5">
             <Eye className="size-4 shrink-0 opacity-80" aria-hidden />
             {post.viewCount}

--- a/frontend/src/app/(common)/community/page.tsx
+++ b/frontend/src/app/(common)/community/page.tsx
@@ -58,7 +58,7 @@ export default async function CommunityPage({ searchParams }: { searchParams: Se
                   니티
                 </span>
               </h1>
-              <p className="max-w-xl font-medium tracking-tight text-balance text-foreground/85 md:text-lg">
+              <p className="mt-8 max-w-xl border-l-2 border-accent pl-6 text-lg font-medium tracking-tight text-balance text-foreground/75">
                 공지·질문·모임 — 입주자들이 모이는{" "}
                 <span className="text-secondary">함께</span>의 공간입니다.
               </p>


### PR DESCRIPTION
## Summary
- `(common)/community` 프론트 UI를 `(user)/my-contracts` 페이지 톤에 맞춰 재정렬했습니다.
- 커뮤니티 목록 카드의 배경/비율/패딩/타이틀 스케일을 조정해 페이지 간 일관성을 높였습니다.
- 카테고리 필터를 텍스트+언더라인 활성형으로 변경해 my-contracts 필터 리듬과 맞췄습니다.
- 커뮤니티 상단 설명 영역에 에디토리얼 보더/간격을 적용해 헤더 구성도 통일했습니다.

## Changed files
- `frontend/src/app/(common)/community/page.tsx`
- `frontend/src/app/(common)/community/_components/PostCard.tsx`
- `frontend/src/app/(common)/community/_components/CategoryFilter.tsx`
- `frontend/package-lock.json` (로컬 의존성 동기화 과정 반영)

## Test plan
- [x] `/community` 진입 시 카드 배경/타이틀 크기/간격이 my-contracts 톤과 유사한지 확인
- [x] 카테고리 필터 활성 상태(언더라인/강조) 및 탭 전환 동작 확인
- [x] 헤더 설명 블록(좌측 보더/간격) 시각적 정렬 확인
- [x] 변경 파일 lint diagnostics 확인 (에러 없음)