### PR TITLE
Feat/121

### DIFF
--- a/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/req/ReservationCreateRequestDto.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/in/web/dto/req/ReservationCreateRequestDto.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 
 /**
  * 예약 신청 요청 DTO
@@ -43,5 +44,11 @@ public class ReservationCreateRequestDto {
     public boolean isValidTimeRange() {
         if (startTime == null || endTime == null) return false;
         return endTime.isAfter(startTime);
+    }
+
+    public boolean isWithinMaxUsageMinutes(long maxMinutes) {
+        if (startTime == null || endTime == null) return false;
+        long durationMinutes = ChronoUnit.MINUTES.between(startTime, endTime);
+        return durationMinutes > 0 && durationMinutes <= maxMinutes;
     }
 }

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationEntity.java
@@ -63,7 +63,7 @@ public class ReservationEntity extends BaseEntity {
     @Column(name = "end_time", nullable = false)
     private LocalTime endTime;
 
-    // 승인자 (관리자) 참조 — nullable (PENDING 상태에서는 null)
+    // 승인자 (관리자) 참조 — 직접 승인 정책에서는 null일 수 있음
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "approved_by")
     private UserEntity approvedBy;
@@ -76,7 +76,7 @@ public class ReservationEntity extends BaseEntity {
         this.reservationDate = reservationDate;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.status = ReservationStatus.PENDING;
+        this.status = ReservationStatus.APPROVED;
     }
 
     /** 예약자 ID 편의 getter */

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
@@ -61,7 +61,7 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     /**
      * 예약 시간대 중복 체크 (비즈니스 규칙 #10)
      *
-     * 동일 시설, 동일 날짜에 APPROVED 상태인 예약 중 시간이 겹치는 건이 있는지 확인한다.
+     * 동일 시설, 동일 날짜에 PENDING 또는 APPROVED 상태인 예약 중 시간이 겹치는 건이 있는지 확인한다.
      * 중복 판정 조건: 새 예약의 시작 < 기존 종료 AND 새 예약의 종료 > 기존 시작
      *
      * @param spaceId   시설 ID
@@ -73,7 +73,10 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     @Query("SELECT COUNT(r) > 0 FROM ReservationEntity r " +
            "WHERE r.space.spaceId = :spaceId " +
            "AND r.reservationDate = :date " +
-           "AND r.status = com.coliving.reservation.model.ReservationStatus.APPROVED " +
+           "AND r.status IN (" +
+           "com.coliving.reservation.model.ReservationStatus.PENDING, " +
+           "com.coliving.reservation.model.ReservationStatus.APPROVED" +
+           ") " +
            "AND r.startTime < :endTime " +
            "AND r.endTime > :startTime")
     boolean existsOverlappingReservation(

--- a/backend/src/main/java/com/coliving/reservation/application/service/FacilityQueryService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/FacilityQueryService.java
@@ -155,7 +155,7 @@ public class FacilityQueryService implements FacilityQueryUseCase {
             return "MY_RESERVATION";
         }
 
-        if (reservation.status() == ReservationStatus.APPROVED) {
+        if (reservation.status() == ReservationStatus.PENDING || reservation.status() == ReservationStatus.APPROVED) {
             return "OCCUPIED";
         }
 

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -35,6 +35,8 @@ import java.util.Objects;
 @SuppressWarnings("null")
 public class ReservationCommandService implements ReservationCommandUseCase {
 
+    private static final long MAX_RESERVATION_MINUTES = 120;
+
     private final ReservationJpaRepository reservationRepository;
     private final UserJpaRepository userRepository;
     private final SpaceJpaRepository spaceRepository;
@@ -46,8 +48,9 @@ public class ReservationCommandService implements ReservationCommandUseCase {
      * 1. 시간 범위 유효성 검사 (종료 > 시작)
      * 2. 사용자 조회
      * 3. 시설 조회
-     * 4. 동시성 체크 — 동일 시설/날짜/시간대에 APPROVED 예약 존재 시 ReservationOverlapException
-     * 5. 엔티티 생성(PENDING) 및 저장
+     * 4. 최대 이용 시간(2시간) 검증
+     * 5. 동시성 체크 — 동일 시설/날짜/시간대에 APPROVED 예약 존재 시 ReservationOverlapException
+     * 6. 엔티티 생성(APPROVED) 및 저장
      */
     @Override
     @Transactional
@@ -55,6 +58,10 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         // 1. 시간 범위 유효성 검사
         if (!request.isValidTimeRange()) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR, "종료 시간은 시작 시간보다 이후여야 합니다.");
+        }
+
+        if (!request.isWithinMaxUsageMinutes(MAX_RESERVATION_MINUTES)) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "공용시설 예약은 최대 2시간까지만 가능합니다.");
         }
 
         // 2. 요청 사용자 조회
@@ -83,7 +90,7 @@ public class ReservationCommandService implements ReservationCommandUseCase {
             throw new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다.");
         }
 
-        // 5. 예약 엔티티 생성 (초기 상태: PENDING) 및 저장
+        // 5. 예약 엔티티 생성 (초기 상태: APPROVED) 및 저장
         @SuppressWarnings("null")
         ReservationEntity savedReservation = reservationRepository.save(
                 ReservationEntity.builder()

--- a/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
@@ -19,6 +19,8 @@ const DAYS_KO = ["월", "화", "수", "목", "금", "토", "일"];
 const SLOT_MINUTES = 30; // 30분 단위
 const DAY_START = 6;     // 06:00
 const DAY_END = 23;      // 23:00
+const MAX_RESERVATION_MINUTES = 120;
+const MAX_SLOT_COUNT = MAX_RESERVATION_MINUTES / SLOT_MINUTES;
 
 interface SlotData {
   status: "AVAILABLE" | "MY_RESERVATION" | "OCCUPIED";
@@ -113,7 +115,7 @@ function SlotCell({ slotData, isSelected, isPast, onPointerDown, onPointerEnter 
     : status === "MY_RESERVATION"
     ? "border-accent/60 bg-accent/20 cursor-not-allowed"
     : status === "OCCUPIED"
-    ? "border-muted bg-muted/40 cursor-not-allowed opacity-70"
+    ? "border-red-400/70 bg-red-500/20 cursor-not-allowed"
     : "border-border/50 bg-surface hover:border-primary/40 hover:bg-primary/10";
 
   return (
@@ -126,7 +128,7 @@ function SlotCell({ slotData, isSelected, isPast, onPointerDown, onPointerEnter 
       title={
         isPast ? "지난 시간" :
         status === "MY_RESERVATION" ? "내 예약" :
-        status === "OCCUPIED" ? "예약 불가" :
+        status === "OCCUPIED" ? "이미 예약된 시간" :
         isSelected ? "선택 취소" : "클릭하여 선택"
       }
     />
@@ -239,7 +241,9 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
 
       const startValue = Math.min(getTimeValue(currentDrag.anchorTime), getTimeValue(targetTime));
       const endValue = Math.max(getTimeValue(currentDrag.anchorTime), getTimeValue(targetTime));
+      const direction = getTimeValue(targetTime) >= getTimeValue(currentDrag.anchorTime) ? 1 : -1;
       const nextSelection: { date: string; time: string }[] = [];
+      let exceededMaxDuration = false;
 
       for (const time of TIME_SLOTS) {
         const timeValue = getTimeValue(time);
@@ -259,7 +263,43 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
         nextSelection.push({ date, time });
       }
 
-      setSelectedSlots(nextSelection);
+      const anchorIndex = TIME_SLOTS.indexOf(currentDrag.anchorTime);
+      const targetIndex = TIME_SLOTS.indexOf(targetTime);
+      const requestedSlotCount = Math.abs(targetIndex - anchorIndex) + 1;
+
+      if (requestedSlotCount > MAX_SLOT_COUNT) {
+        exceededMaxDuration = true;
+        const limitedSelection: { date: string; time: string }[] = [];
+        for (let step = 0; step < MAX_SLOT_COUNT; step += 1) {
+          const slotIndex = anchorIndex + step * direction;
+          const time = TIME_SLOTS[slotIndex];
+          if (!time) break;
+
+          const slotData = timetable[date]?.[time];
+          const isPastSlot = date < today || (date === today && time < nowTime);
+
+          if (!isSelectableSlot(slotData, isPastSlot)) {
+            setFeedback({
+              type: "error",
+              msg: "예약 불가 영역은 드래그해서 선택할 수 없습니다.",
+            });
+            return currentDrag;
+          }
+
+          limitedSelection.push({ date, time });
+        }
+        setSelectedSlots(direction === -1 ? limitedSelection.reverse() : limitedSelection);
+      } else {
+        setSelectedSlots(nextSelection);
+      }
+
+      if (exceededMaxDuration) {
+        setFeedback({
+          type: "error",
+          msg: "최대 2시간까지만 선택할 수 있습니다.",
+        });
+      }
+
       return currentDrag;
     });
   }, [nowTime, timetable, today]);
@@ -364,7 +404,7 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
         {[
           { color: "bg-primary", label: "선택됨" },
           { color: "bg-accent/30 border border-accent/60", label: "내 예약" },
-          { color: "bg-muted/40 border border-muted", label: "예약 불가" },
+          { color: "bg-red-500/20 border border-red-400/70", label: "이미 예약됨" },
           { color: "bg-surface border border-border/50", label: "예약 가능" },
         ].map(({ color, label }) => (
           <div key={label} className="flex items-center gap-1.5">
@@ -486,7 +526,7 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
                 {selectedDate} &nbsp;{selectedStart} – {selectedEnd}
               </p>
               <p className="text-xs text-muted-foreground">
-                {facility.name} · {selectedSlots.length * SLOT_MINUTES}분
+                {facility.name} · {selectedSlots.length * SLOT_MINUTES}분 / 최대 {MAX_RESERVATION_MINUTES}분
               </p>
               {reservationWindow ? (
                 <p className="text-[11px] font-medium text-muted-foreground/80">

--- a/frontend/src/app/(user)/my-history/reservation/_api/index.ts
+++ b/frontend/src/app/(user)/my-history/reservation/_api/index.ts
@@ -1,0 +1,12 @@
+import { apiFetch } from "@/lib/api";
+import type { MyReservationItem } from "../_types";
+
+export async function fetchMyReservations() {
+  return apiFetch<MyReservationItem[]>("/reservations/my");
+}
+
+export async function cancelReservation(reservationId: number) {
+  return apiFetch<void>(`/reservations/${reservationId}/cancel`, {
+    method: "POST",
+  });
+}

--- a/frontend/src/app/(user)/my-history/reservation/_components/ReservationHistoryCard.tsx
+++ b/frontend/src/app/(user)/my-history/reservation/_components/ReservationHistoryCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { CalendarRange, Clock3, MapPin } from "lucide-react";
+import { ReservationStatusBadge } from "./ReservationStatusBadge";
+import type { MyReservationItem } from "../_types";
+
+function formatReservationDate(date: string) {
+  const parsed = new Date(`${date}T00:00:00`);
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  }).format(parsed);
+}
+
+function formatTimeRange(startTime: string, endTime: string) {
+  return `${startTime.slice(0, 5)} - ${endTime.slice(0, 5)}`;
+}
+
+function buildLocalIso(date: string, time: string) {
+  return `${date}T${time.length === 5 ? `${time}:00` : time}`;
+}
+
+export function ReservationHistoryCard({
+  reservation,
+  index,
+  onCancel,
+  isCancelling = false,
+}: {
+  reservation: MyReservationItem;
+  index: number;
+  onCancel?: (reservationId: number) => void;
+  isCancelling?: boolean;
+}) {
+  const canCancel = reservation.status === "PENDING" || reservation.status === "APPROVED";
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 18 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.38, delay: index * 0.04 }}
+      whileHover={{ y: -4, scale: 1.01 }}
+      className="rounded-[2rem] border border-primary/10 bg-primary/5 p-6 md:p-8"
+    >
+      <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <p className="text-[10px] font-black tracking-[0.32em] text-accent uppercase">
+              Reservation #{String(reservation.id).padStart(4, "0")}
+            </p>
+            <h2 className="text-2xl font-black tracking-tighter text-primary md:text-3xl">
+              {reservation.spaceName}
+            </h2>
+          </div>
+
+          <div className="grid gap-3 text-sm text-muted md:grid-cols-2">
+            <div className="flex items-start gap-3 rounded-2xl border border-primary/8 bg-background/60 p-4">
+              <CalendarRange className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+              <div>
+                <p className="text-[10px] font-black tracking-[0.28em] uppercase text-primary/45">
+                  예약 일시
+                </p>
+                <p className="mt-1 font-semibold text-primary">
+                  {formatReservationDate(reservation.reservationDate)}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 rounded-2xl border border-primary/8 bg-background/60 p-4">
+              <Clock3 className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+              <div>
+                <p className="text-[10px] font-black tracking-[0.28em] uppercase text-primary/45">
+                  이용 시간
+                </p>
+                <p className="mt-1 font-semibold text-primary">
+                  {formatTimeRange(reservation.startTime, reservation.endTime)}
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-3 rounded-2xl border border-primary/8 bg-background/60 p-4 md:col-span-2">
+              <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-accent" />
+              <div className="min-w-0">
+                <p className="text-[10px] font-black tracking-[0.28em] uppercase text-primary/45">
+                  로컬 ISO
+                </p>
+                <p className="mt-1 break-all font-mono text-xs text-primary/70">
+                  {buildLocalIso(reservation.reservationDate, reservation.startTime)}
+                </p>
+                <p className="mt-1 break-all font-mono text-xs text-primary/70">
+                  {buildLocalIso(reservation.reservationDate, reservation.endTime)}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-col items-start gap-3 md:items-end">
+          <ReservationStatusBadge status={reservation.status} />
+          <p className="text-[10px] font-black tracking-[0.28em] text-primary/40 uppercase">
+            Space ID {reservation.spaceId}
+          </p>
+          {canCancel ? (
+            <button
+              type="button"
+              onClick={() => onCancel?.(reservation.id)}
+              disabled={isCancelling}
+              className="rounded-full border border-primary/15 bg-background px-4 py-2 text-[11px] font-black tracking-[0.2em] text-primary uppercase transition hover:bg-primary hover:text-background disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isCancelling ? "취소 중" : "예약 취소"}
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </motion.article>
+  );
+}

--- a/frontend/src/app/(user)/my-history/reservation/_components/ReservationStatusBadge.tsx
+++ b/frontend/src/app/(user)/my-history/reservation/_components/ReservationStatusBadge.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import type { MyReservationItem } from "../_types";
+
+const statusMeta: Record<
+  MyReservationItem["status"],
+  { label: string; className: string }
+> = {
+  PENDING: {
+    label: "승인 대기",
+    className: "border-accent/30 bg-accent/10 text-accent",
+  },
+  APPROVED: {
+    label: "예약 확정",
+    className: "border-primary/15 bg-primary text-background",
+  },
+  CANCELLED: {
+    label: "취소됨",
+    className: "border-secondary/40 bg-secondary/15 text-muted",
+  },
+  COMPLETED: {
+    label: "이용 완료",
+    className: "border-primary/10 bg-primary/10 text-primary",
+  },
+};
+
+export function ReservationStatusBadge({
+  status,
+}: {
+  status: MyReservationItem["status"];
+}) {
+  const meta = statusMeta[status];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-3 py-1 text-[10px] font-black tracking-[0.24em] uppercase",
+        meta.className,
+      )}
+    >
+      {meta.label}
+    </span>
+  );
+}

--- a/frontend/src/app/(user)/my-history/reservation/_types/index.ts
+++ b/frontend/src/app/(user)/my-history/reservation/_types/index.ts
@@ -1,0 +1,9 @@
+export interface MyReservationItem {
+  id: number;
+  spaceId: number;
+  spaceName: string;
+  status: "PENDING" | "APPROVED" | "CANCELLED" | "COMPLETED";
+  reservationDate: string;
+  startTime: string;
+  endTime: string;
+}

--- a/frontend/src/app/(user)/my-history/reservation/page.tsx
+++ b/frontend/src/app/(user)/my-history/reservation/page.tsx
@@ -1,8 +1,237 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import { AlertCircle, CalendarClock, ChevronRight, Loader2, SearchX } from "lucide-react";
+import { cancelReservation, fetchMyReservations } from "./_api";
+import { ReservationHistoryCard } from "./_components/ReservationHistoryCard";
+import { ReservationStatusBadge } from "./_components/ReservationStatusBadge";
+import type { MyReservationItem } from "./_types";
+
+const statusOrder: MyReservationItem["status"][] = [
+  "PENDING",
+  "APPROVED",
+  "COMPLETED",
+  "CANCELLED",
+];
+
 export default function ReservationHistoryPage() {
+  const [reservations, setReservations] = useState<MyReservationItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [cancellingReservationId, setCancellingReservationId] = useState<number | null>(null);
+  const [actionMessage, setActionMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+  const [activeStatusFilter, setActiveStatusFilter] = useState<MyReservationItem["status"] | "ALL">("ALL");
+
+  useEffect(() => {
+    const loadReservations = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const response = await fetchMyReservations();
+        setReservations(response.data ?? []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "예약 내역을 불러오지 못했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void loadReservations();
+  }, []);
+
+  const statusCounts = useMemo(() => {
+    return statusOrder.map((status) => ({
+      status,
+      count: reservations.filter((reservation) => reservation.status === status).length,
+    }));
+  }, [reservations]);
+
+  const filteredReservations = useMemo(() => {
+    if (activeStatusFilter === "ALL") {
+      return reservations;
+    }
+
+    return reservations.filter((reservation) => reservation.status === activeStatusFilter);
+  }, [activeStatusFilter, reservations]);
+
+  const handleCancelReservation = async (reservationId: number) => {
+    setCancellingReservationId(reservationId);
+    setActionMessage(null);
+    try {
+      await cancelReservation(reservationId);
+      setReservations((current) =>
+        current.map((reservation) =>
+          reservation.id === reservationId
+            ? { ...reservation, status: "CANCELLED" }
+            : reservation,
+        ),
+      );
+      setActionMessage({ type: "success", text: "예약이 취소되었습니다." });
+    } catch (err) {
+      setActionMessage({
+        type: "error",
+        text: err instanceof Error ? err.message : "예약 취소에 실패했습니다.",
+      });
+    } finally {
+      setCancellingReservationId(null);
+    }
+  };
+
   return (
-    <div>
-      <h1 className="text-3xl font-bold">예약 이력</h1>
-      <p className="mt-2 text-muted-foreground">공용시설 예약 이력을 확인하세요.</p>
-    </div>
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.45 }}
+      className="mx-auto max-w-[1200px] px-6 py-10 text-primary md:px-12 md:py-16 lg:px-24"
+    >
+      <section className="border-b border-primary/12 pb-10 md:pb-14">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-4">
+            <span className="text-[10px] font-black tracking-[0.4em] text-accent uppercase">
+              My History / Reservation
+            </span>
+            <h1 className="text-[14vw] font-black leading-[0.85] tracking-tighter uppercase md:text-[10vw] lg:text-[6vw]">
+              MY
+              <br />
+              RESERVATIONS
+            </h1>
+            <p className="max-w-2xl border-l-2 border-accent pl-6 text-base font-medium tracking-tight text-muted md:text-lg">
+              공용시설 예약 내역을 시간순으로 확인하고, 현재 상태를 빠르게 파악할 수 있는 이용자 전용 보드입니다.
+            </p>
+          </div>
+
+          <div className="rounded-[2rem] border border-primary/10 bg-primary/5 p-6 md:min-w-[280px]">
+            <p className="text-[10px] font-black tracking-[0.28em] text-primary/45 uppercase">
+              Total Reservations
+            </p>
+            <p className="mt-3 text-5xl font-black tracking-tighter">
+              {String(reservations.length).padStart(2, "0")}
+            </p>
+            <p className="mt-3 flex items-center gap-2 text-sm font-semibold text-muted">
+              <ChevronRight className="h-4 w-4 text-accent" />
+              최신 예약부터 순서대로 표시됩니다
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 py-10 md:grid-cols-2 xl:grid-cols-4">
+        {statusCounts.map(({ status, count }, index) => (
+          <motion.div
+            key={status}
+            initial={{ opacity: 0, y: 18 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.35, delay: index * 0.05 }}
+            whileHover={{ y: -4, scale: 1.01 }}
+            className={`rounded-[2rem] border p-5 transition ${
+              activeStatusFilter === status
+                ? "border-primary bg-primary/10 shadow-sm shadow-primary/10"
+                : "border-primary/10 bg-background/70"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() =>
+                setActiveStatusFilter((current) => (current === status ? "ALL" : status))
+              }
+              className="w-full text-left"
+            >
+              <ReservationStatusBadge status={status} />
+              <p className="mt-5 text-4xl font-black tracking-tighter text-primary">
+                {String(count).padStart(2, "0")}
+              </p>
+              <p className="mt-2 text-sm font-medium tracking-tight text-muted">
+                클릭하면 해당 상태 예약만 필터링됩니다.
+              </p>
+            </button>
+          </motion.div>
+        ))}
+      </section>
+
+      <section className="space-y-6">
+        {!isLoading && !error ? (
+          <div className="flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={() => setActiveStatusFilter("ALL")}
+              className={`rounded-full border px-4 py-2 text-[11px] font-black tracking-[0.2em] uppercase transition ${
+                activeStatusFilter === "ALL"
+                  ? "border-primary bg-primary text-background"
+                  : "border-primary/15 bg-background text-primary"
+              }`}
+            >
+              전체 보기
+            </button>
+            {activeStatusFilter !== "ALL" ? (
+              <p className="text-sm font-semibold tracking-tight text-muted">
+                현재 <span className="text-primary">{activeStatusFilter}</span> 상태 예약만 보고 있습니다.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {actionMessage ? (
+          <div
+            className={`rounded-2xl border px-5 py-4 text-sm font-semibold ${
+              actionMessage.type === "success"
+                ? "border-green-200 bg-green-50 text-green-700"
+                : "border-red-200 bg-red-50 text-red-600"
+            }`}
+          >
+            {actionMessage.text}
+          </div>
+        ) : null}
+
+        {isLoading ? (
+          <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-[2rem] border border-primary/10 bg-primary/5 p-10 text-center">
+            <Loader2 className="h-10 w-10 animate-spin text-accent" />
+            <p className="text-[10px] font-black tracking-[0.26em] text-primary/45 uppercase">
+              Loading reservation timeline
+            </p>
+          </div>
+        ) : error ? (
+          <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-[2rem] border border-red-200 bg-red-50/70 p-10 text-center">
+            <AlertCircle className="h-10 w-10 text-red-500" />
+            <h2 className="text-2xl font-black tracking-tighter text-primary">
+              예약 내역을 불러오지 못했습니다
+            </h2>
+            <p className="max-w-md text-sm font-medium tracking-tight text-muted">
+              {error}
+            </p>
+          </div>
+        ) : filteredReservations.length === 0 ? (
+          <div className="flex min-h-[280px] flex-col items-center justify-center gap-4 rounded-[2rem] border border-primary/10 bg-primary/5 p-10 text-center">
+            <SearchX className="h-10 w-10 text-accent" />
+            <h2 className="text-2xl font-black tracking-tighter text-primary">
+              {activeStatusFilter === "ALL" ? "아직 예약 내역이 없습니다" : "선택한 상태의 예약이 없습니다"}
+            </h2>
+            <p className="max-w-md text-sm font-medium tracking-tight text-muted">
+              {activeStatusFilter === "ALL"
+                ? "새로운 예약을 신청하면 이 화면에서 일정과 상태를 바로 확인할 수 있습니다."
+                : "다른 상태 카드를 누르거나 전체 보기로 돌아가서 다른 예약을 확인해보세요."}
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-3">
+              <CalendarClock className="h-5 w-5 text-accent" />
+              <p className="text-[10px] font-black tracking-[0.26em] text-primary/45 uppercase">
+                Reservation Timeline
+              </p>
+            </div>
+            {filteredReservations.map((reservation, index) => (
+              <ReservationHistoryCard
+                key={reservation.id}
+                reservation={reservation}
+                index={index}
+                onCancel={handleCancelReservation}
+                isCancelling={cancellingReservationId === reservation.id}
+              />
+            ))}
+          </>
+        )}
+      </section>
+    </motion.div>
   );
 }

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -34,6 +34,7 @@ const navItems: NavItem[] = [
     children: [
       { name: "Notification", path: "/notifications" },
       { name: "Profile", path: "/profile" },
+      { name: "My Reservations", path: "/my-history/reservation" },
       { name: "My VOC", path: "/profile/vocs" },
       { name: "My Contracts", path: "/my-contracts" },
       { name: "Logout", path: "/login" },


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 이용자가 예약한 공용시설 내역을 직접 확인할 수 있는 전용 화면이 필요했습니다.
- 기존에는 예약 신청과 타임테이블 선택 UX는 있었지만, 예약 완료 후 상태를 조회하거나 취소할 수 있는 사용자 동선이 부족했습니다.
- 이번 PR에서는 이용자용 예약 내역 페이지를 추가하고, 시설 예약 플로우를 실제 사용 흐름에 맞게 보완했습니다.

## 🔑 주요 변경 사항 (What)
- 이용자용 내 예약 조회 페이지 추가
- `My` 드롭다운 메뉴에서 예약 내역 페이지로 진입 가능하도록 연결
- `/api/reservations/my` 연동 및 예약 상태별 카드/목록 UI 구현
- 예약 상태 카드 클릭 시 해당 상태만 필터링되도록 개선
- 예약 내역 페이지에서 예약 취소 기능 추가
- 시설 예약 신청 시 관리자 승인 없이 즉시 확정되도록 예약 상태 정책 변경
- 이미 예약된 시간대는 중복 예약되지 않도록 백엔드 중복 체크 강화
- 타임테이블에서 이미 예약된 슬롯을 빨간색 블록으로 표시
- 슬롯 선택 시 최대 이용 시간을 2시간으로 제한하고, 프런트/백엔드 양쪽에서 검증
- 선택 시간의 로컬 ISO 기준 표시 유지 및 드래그 선택 UX 개선

## 💻 테스트 방법 (How to Test)
1. 인프라 실행
   - `docker compose up -d db redis mock-iot`
2. 백엔드 실행
   - `backend` 디렉토리에서 로컬 환경변수를 설정한 뒤 `./gradlew bootRun`
3. 프런트 실행
   - `frontend` 디렉토리에서 `npm run dev`
4. 로그인
   - 이용자 계정으로 로그인합니다.
5. 시설 예약 페이지 확인
   - `/facilities` 진입 후 타임테이블이 정상적으로 표시되는지 확인합니다.
6. 중복 예약 블록 확인
   - 이미 예약된 시간대가 빨간색 블록으로 표시되는지 확인합니다.
7. 최대 2시간 제한 확인
   - 슬롯을 드래그해 2시간을 초과하려고 할 때 선택이 제한되고 안내 메시지가 뜨는지 확인합니다.
8. 예약 신청 확인
   - 비어 있는 시간대를 선택해 예약 신청 시 바로 예약 확정 상태로 생성되는지 확인합니다.
9. 내 예약 페이지 확인
   - 헤더 `My > My Reservations`로 이동합니다.
10. 상태 필터 확인
   - `승인대기`, `예약확정`, `이용완료`, `취소됨` 카드 클릭 시 해당 상태 예약만 필터링되는지 확인합니다.
11. 예약 취소 확인
   - `APPROVED` 또는 `PENDING` 예약에서 `예약 취소` 버튼 클릭 시 상태가 `CANCELLED`로 바뀌는지 확인합니다.

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 예약 내역 페이지는 프론트 아키텍처 규칙에 맞춰 `/(user)/my-history/reservation` 아래 `_api`, `_components`, `_types`로 분리했습니다.
- 예약 상태 정책을 즉시 확정 방식으로 변경했기 때문에, `PENDING` 상태를 앞으로 계속 유지할지 도메인 차원에서 한 번 더 정리해보면 좋겠습니다.
- 중복 예약 방지는 백엔드 쿼리와 타임테이블 점유 표시를 함께 수정했습니다. 슬롯 점유 기준과 상태 해석을 중점적으로 봐주시면 좋겠습니다.

Closes #121
