### PR TITLE
Feat/59

### DIFF
--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
@@ -149,7 +149,7 @@ public class AdminSpaceService implements AdminSpaceUseCase {
         String savedFileName = fileStoragePort.storeFile(spaceId, file);
 
         // 프론트엔드가 자체 프록시(/api/bff/...)를 통해 컨트롤러 엔드포인트를 타도록 경로 합성
-        String imageUrl = "/api/bff/admin/spaces/" + spaceId + "/images/serve/" + savedFileName;
+        String imageUrl = "/api/admin/spaces/" + spaceId + "/images/serve/" + savedFileName;
 
         AdminSpace.SpaceImage newImage = AdminSpace.SpaceImage.builder()
                 .imageUrl(imageUrl)

--- a/frontend/src/app/(public)/rooms/_components/RoomCard.tsx
+++ b/frontend/src/app/(public)/rooms/_components/RoomCard.tsx
@@ -83,7 +83,7 @@ export function RoomCard({ room, index }: RoomCardProps) {
             <p className="text-sm font-black tracking-[0.3em] text-secondary uppercase">
               {room.roomTypeName || '—'}
             </p>
-            {room.monthlyRent !== undefined && (
+            {room.monthlyRent != null && (
               <p className="text-lg font-black text-foreground">
                 ₩{room.monthlyRent.toLocaleString()}
                 <span className="ml-1 text-xs opacity-30">/월</span>

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -44,7 +44,15 @@ export interface SpaceDTO {
 }
 
 export const fetchSpaces = async () => {
-  return await apiFetch<any>('/admin/spaces');
+  const res = await apiFetch<any>('/admin/spaces');
+  if (res.data?.content) {
+    res.data.content = res.data.content.map((s: any) => ({
+      ...s,
+      ...(s.privateDetail || {}),
+      ...(s.commonDetail || {})
+    }));
+  }
+  return res;
 };
 
 export const createSpace = async (data: SpaceDTO) => {
@@ -70,7 +78,15 @@ export const uploadSpaceImage = async (spaceId: number, file: File, isThumbnail:
 };
 
 export const fetchSpace = async (spaceId: number) => {
-  return await apiFetch<SpaceDTO>(`/admin/spaces/${spaceId}`);
+  const res = await apiFetch<any>(`/admin/spaces/${spaceId}`);
+  if (res.data) {
+    res.data = {
+      ...res.data,
+      ...(res.data.privateDetail || {}),
+      ...(res.data.commonDetail || {})
+    };
+  }
+  return res as ApiResponse<SpaceDTO>;
 };
 
 export const updateSpace = async (spaceId: number, data: Partial<SpaceDTO>) => {

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -55,10 +55,15 @@ export const fetchSpaces = async () => {
   return res;
 };
 
-export const createSpace = async (data: SpaceDTO) => {
+export const createSpace = async (data: SpaceDTO & Record<string, any>) => {
+  const { 
+    spaceId, roomTypeName, images, 
+    privateDetail, commonDetail, positionX, positionY, 
+    ...payload 
+  } = data;
   return await apiFetch<any>('/admin/spaces', {
     method: 'POST',
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
 };
 
@@ -89,10 +94,15 @@ export const fetchSpace = async (spaceId: number) => {
   return res as ApiResponse<SpaceDTO>;
 };
 
-export const updateSpace = async (spaceId: number, data: Partial<SpaceDTO>) => {
+export const updateSpace = async (spaceId: number, data: Partial<SpaceDTO> & Record<string, any>) => {
+  const { 
+    spaceId: _id, type, roomTypeName, images, 
+    privateDetail, commonDetail, positionX, positionY, 
+    ...payload 
+  } = data;
   return await apiFetch<any>(`/admin/spaces/${spaceId}`, {
     method: 'PUT',
-    body: JSON.stringify(data),
+    body: JSON.stringify(payload),
   });
 };
 

--- a/frontend/src/app/admin/spaces/page.tsx
+++ b/frontend/src/app/admin/spaces/page.tsx
@@ -29,10 +29,19 @@ export default function SpacesPage() {
     loadSpaces();
   }, []);
 
-  const statusLabel: Record<string, { text: string; color: string }> = {
-    AVAILABLE: { text: '이용 가능', color: 'bg-green-500' },
-    OCCUPIED: { text: '사용 중', color: 'bg-red-500' },
-    MAINTENANCE: { text: '점검 중', color: 'bg-yellow-500' },
+  const getStatusDisplay = (space: SpaceDTO) => {
+    if (space.type === 'PRIVATE') {
+      return {
+        AVAILABLE: { text: '계약 가능', color: 'bg-green-500' },
+        OCCUPIED: { text: '입주 중', color: 'bg-blue-500' },
+        MAINTENANCE: { text: '점검 중', color: 'bg-yellow-500' },
+      }[space.status] || { text: space.status, color: 'bg-gray-500' };
+    }
+    return {
+      AVAILABLE: { text: '이용 가능', color: 'bg-green-500' },
+      OCCUPIED: { text: '사용 중', color: 'bg-blue-500' },
+      MAINTENANCE: { text: '점검 중', color: 'bg-yellow-500' },
+    }[space.status] || { text: space.status, color: 'bg-gray-500' };
   };
 
   const tabs: { key: Tab; label: string; icon: React.ReactNode }[] = [
@@ -86,7 +95,8 @@ export default function SpacesPage() {
       {activeTab === 'spaces' && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {spaces.map((space: SpaceDTO, idx: number) => {
-            const status = statusLabel[space.status] || { text: space.status, color: 'bg-gray-500' };
+            const status = getStatusDisplay(space);
+            const thumbnailUrl = space.images?.find(img => img.isThumbnail)?.imageUrl || space.images?.[0]?.imageUrl;
             return (
               <motion.div 
                 key={space.spaceId}
@@ -124,10 +134,10 @@ export default function SpacesPage() {
                   <p className="mt-1 text-xs font-bold text-[var(--color-accent)]">{space.roomTypeName}</p>
                 )}
 
-                {space.images && space.images.length > 0 ? (
+                {thumbnailUrl ? (
                   <div className="mt-4 w-full h-32 rounded-2xl overflow-hidden bg-black/10">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={space.images[0].imageUrl} alt={space.name} className="w-full h-full object-cover" />
+                    <img src={thumbnailUrl} alt={space.name} className="w-full h-full object-cover" />
                   </div>
                 ) : (
                   <div className="mt-4 w-full h-32 rounded-2xl bg-black/10 flex items-center justify-center font-bold tracking-tighter text-black/30">


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자 페이지에서 공간(Space) 정보 조회 및 수정 시 발생하는 500 Internal Server Error 발생 및 유저 뷰 렌더링 결함을 해결해야 했습니다.
- 백엔드 데이터를 프론트엔드 규격에 맞춰 안전하게 통신하도록 정제하고, 대표 이미지 및 상태명 텍스트 등 UI/UX 측면의 데이터를 기획 명세에 부합하도록 수정했습니다.
- 백엔드 Space 도메인의 Soft delete 정책을 데이터베이스 동작 레벨로 올바르게 적용하였습니다.

## 🔑 주요 변경 사항 (What)
**[Backend]**
- [Space](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java:66:4-72:5) 도메인 엔티티에 `@SQLDelete` 속성을 적용하여 안전한 Soft delete 보장
- 공간 상세 응답 데이터를 평탄화(Flatten)하여 프론트엔드 [SpaceDTO](cci:2://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts:10:0-43:1) 구조와 일치시키도록 규격화
- 레거시 잔재된 이미지 URL의 `/api/bff/` Prefix 생성 관련 예외 처리 로직 완전 제거

**[Frontend]**
- **Payload 정제 로직**: 관리자 뷰 로직에서 공간 관련 등록(POST) 및 수정(PUT) 시 서버가 모르는 잉여 객체 프로퍼티(`images`, `roomTypeName`, `privateDetail` 등)를 클라이언트 단에서 걸러내어(Sanitize) `UnrecognizedPropertyException` 500 에러 사전 방지
- **UI 상태 텍스트 분기**: 공간 유형(PRIVATE/COMMON)에 맞춰 상태 배지 텍스트를 "계약 가능/입주 중" / "이용 가능/사용 중"으로 별도 분리 렌더링
- **명세서 정합성 보완**: `OCCUPIED`(입주 중/사용 중) 상태의 배지 색상을 파란색(`bg-blue-500`)으로 통일 
- **사용자 뷰 렌더링 에러 해결**: 유저 방 목록 조회 시 `monthlyRent`가 비어있을 때(`.toLocaleString()` 에러) 빈 카드 뷰가 Crash(`Cannot read properties of null`) 되지 않고 하얀 카드로 매끄럽게 렌더링 되도록 Null 안전 로직 보강
- **썸네일 렌더링**: 무조건 첫 번째 이미지를 렌더링하지 않고 검색해 `isThumbnail`이 `true`인 대표 이미지를 노출하도록 노출 로직 개선

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #59

## 💻 테스트 방법 (How to Test)
1. 브랜치 Fetch & Checkout 이후 로컬 환경에서 도커 앱을 재빌드합니다.
   `docker compose up -d --build frontend backend`
2. **관리자 페이지 테스트**
   - 관리자용 스페이스 관리 페이지 접속 후, 뷰 내 `PRIVATE` 와 `COMMON` 공간의 배지 이름과 파란색/초록색 구분이 잘 되는지 확인합니다.
   - 공간 세부 내용을 수정한 뒤 "저장"을 눌렀을 때, 500 에러 없이 즉석 노출 리스트에 정상 반영되는 것을 확인합니다.
3. **사용자 페이지 테스트**
   - 사용자 방 목록 뷰(`/rooms`) 접근 시 데이터 파편화로 인해 월세 정보가 누락된 공간 카드가 있어도 화면이 뻗지 않고 깔끔하게 표출되는지 검증합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- *(기존 대비 개선된 상태명 리스트 텍스트, 파란색 점령 배지 통일 부분 등 스크린샷 1장 첨부 요망)*

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 프론트-백엔드 간 DTO 파편화로 인해 PUT 요청 시 잉여 데이터가 넘어가던 문제를 프론트의 [spaceAdminApi.ts](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts:0:0-0:0) 구조 분해 할당을 통해 쳐내어 해결했습니다. 추후 API 통신 시에도 동일 사례를 피하기 위해 이 부분을 눈여겨봐 주시면 좋겠습니다!
- 관련된 팀원 멘션: @username 

Closes #59
