### PR TITLE
Feat/59 공간 CRUD 버그 수정 및 갤러리 UI 추가

### DIFF
--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminSpaceController.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminSpaceController.java
@@ -74,8 +74,10 @@ public class AdminSpaceController {
     @Operation(summary = "공간 목록 조회 (페이징)")
     @GetMapping
     public ApiResponse<Page<AdminSpaceResponseDto>> getSpaces(
+            @RequestParam(required = false) com.coliving.admin.space.model.SpaceType type,
+            @RequestParam(required = false) com.coliving.admin.space.model.SpaceStatus status,
             @PageableDefault(size = 20) Pageable pageable) {
-        Page<AdminSpaceResponseDto> result = adminSpaceUseCase.getSpaces(pageable)
+        Page<AdminSpaceResponseDto> result = adminSpaceUseCase.getSpaces(type, status, pageable)
                 .map(AdminSpaceResponseDto::from);
         return ApiResponse.ok(result);
     }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminSpaceController.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminSpaceController.java
@@ -155,4 +155,13 @@ public class AdminSpaceController {
             return ResponseEntity.notFound().build();
         }
     }
+
+    @Operation(summary = "공간 이미지 삭제")
+    @DeleteMapping("/{spaceId}/images/{imageId}")
+    public ApiResponse<Void> deleteSpaceImage(
+            @PathVariable Long spaceId,
+            @PathVariable Long imageId) {
+        adminSpaceUseCase.deleteImage(spaceId, imageId);
+        return ApiResponse.ok(null);
+    }
 }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
@@ -53,5 +53,13 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
             Pageable pageable);
 
     List<SpaceEntity> findByFloor(Integer floor);
+
+    @Query(value = "SELECT DISTINCT s FROM SpaceEntity s " +
+                    "LEFT JOIN FETCH s.commonDetail " +
+                    "LEFT JOIN FETCH s.images " +
+                    "WHERE s.type = :type AND s.status <> :excludeStatus " +
+                    "ORDER BY s.name")
+    List<SpaceEntity> findByTypeAndStatusNot(@Param("type") SpaceType type,
+                                             @Param("excludeStatus") SpaceStatus excludeStatus);
 }
 

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
@@ -20,6 +20,16 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
     Optional<SpaceEntity> findByName(String name);
 
     @Query(value = "SELECT s FROM SpaceEntity s " +
+                   "WHERE (:type IS NULL OR s.type = :type) " +
+                   "AND (:status IS NULL OR s.status = :status)",
+           countQuery = "SELECT COUNT(s) FROM SpaceEntity s " +
+                        "WHERE (:type IS NULL OR s.type = :type) " +
+                        "AND (:status IS NULL OR s.status = :status)")
+    Page<SpaceEntity> findSpacesWithFilter(@Param("type") SpaceType type,
+                                           @Param("status") SpaceStatus status,
+                                           Pageable pageable);
+
+    @Query(value = "SELECT s FROM SpaceEntity s " +
                     "LEFT JOIN FETCH s.privateDetail " +
                     "WHERE s.type = :type AND s.status = :status",
             countQuery = "SELECT COUNT(s) FROM SpaceEntity s " +

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminSpacePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminSpacePersistenceAdapter.java
@@ -257,4 +257,9 @@ public class AdminSpacePersistenceAdapter implements AdminSpaceRepositoryPort {
 
         spaceImageJpaRepository.save(imageEntity);
     }
+
+    @Override
+    public void deleteImage(Long imageId) {
+        spaceImageJpaRepository.deleteById(imageId);
+    }
 }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminSpacePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminSpacePersistenceAdapter.java
@@ -76,8 +76,13 @@ public class AdminSpacePersistenceAdapter implements AdminSpaceRepositoryPort {
     }
 
     @Override
-    public Page<AdminSpace> findAll(Pageable pageable) {
-        return spaceJpaRepository.findAll(pageable).map(this::toAdminSpace);
+    public boolean existsById(Long spaceId) {
+        return spaceJpaRepository.existsById(spaceId);
+    }
+
+    @Override
+    public Page<AdminSpace> findSpaces(com.coliving.admin.space.model.SpaceType type, com.coliving.admin.space.model.SpaceStatus status, Pageable pageable) {
+        return spaceJpaRepository.findSpacesWithFilter(type, status, pageable).map(this::toAdminSpace);
     }
 
     @Override

--- a/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminSpaceUseCase.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminSpaceUseCase.java
@@ -13,7 +13,7 @@ public interface AdminSpaceUseCase {
 
     AdminSpaceResult getSpace(Long spaceId);
 
-    Page<AdminSpaceResult> getSpaces(Pageable pageable);
+    Page<AdminSpaceResult> getSpaces(com.coliving.admin.space.model.SpaceType type, com.coliving.admin.space.model.SpaceStatus status, Pageable pageable);
 
     AdminSpaceResult updateSpace(UpdateSpaceCommand command);
 

--- a/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminSpaceUseCase.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminSpaceUseCase.java
@@ -22,4 +22,6 @@ public interface AdminSpaceUseCase {
     void uploadImage(Long spaceId, org.springframework.web.multipart.MultipartFile file, com.coliving.admin.space.model.ImageType imageType, Boolean isThumbnail);
 
     java.nio.file.Path loadImage(Long spaceId, String fileName);
+
+    void deleteImage(Long spaceId, Long imageId);
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminSpaceRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminSpaceRepositoryPort.java
@@ -17,7 +17,9 @@ public interface AdminSpaceRepositoryPort {
 
     Optional<AdminSpace> findById(Long spaceId);
 
-    Page<AdminSpace> findAll(Pageable pageable);
+    boolean existsById(Long spaceId);
+
+    Page<AdminSpace> findSpaces(com.coliving.admin.space.model.SpaceType type, com.coliving.admin.space.model.SpaceStatus status, Pageable pageable);
 
     boolean existsByName(String name);
 

--- a/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminSpaceRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminSpaceRepositoryPort.java
@@ -28,4 +28,6 @@ public interface AdminSpaceRepositoryPort {
     void updatePositions(List<AdminSpace> spaces);
 
     void saveImage(Long spaceId, AdminSpace.SpaceImage image);
+
+    void deleteImage(Long imageId);
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
@@ -74,8 +74,8 @@ public class AdminSpaceService implements AdminSpaceUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<AdminSpaceResult> getSpaces(Pageable pageable) {
-        return adminSpaceRepositoryPort.findAll(pageable)
+    public Page<AdminSpaceResult> getSpaces(SpaceType type, SpaceStatus status, Pageable pageable) {
+        return adminSpaceRepositoryPort.findSpaces(type, status, pageable)
                 .map(AdminSpaceResult::from);
     }
 
@@ -170,9 +170,11 @@ public class AdminSpaceService implements AdminSpaceUseCase {
 
     @Override
     public void deleteImage(Long spaceId, Long imageId) {
-        // 공간 존재 검증
-        adminSpaceRepositoryPort.findById(spaceId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SPACE_NOT_FOUND));
+        // 공간 존재 검증 시 엔티티 전체를 로드하면 JPA 양방향 연관관계(Cascade) 때문에 
+        // soft-delete 된 이미지가 트랜잭션 플러시 시점에 다시 살아남 (findById 대신 existsById 사용)
+        if (!adminSpaceRepositoryPort.existsById(spaceId)) {
+            throw new BusinessException(ErrorCode.SPACE_NOT_FOUND);
+        }
 
         adminSpaceRepositoryPort.deleteImage(imageId);
     }

--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
@@ -167,4 +167,13 @@ public class AdminSpaceService implements AdminSpaceUseCase {
         // 이미지가 실제로 존재하는지 여부 검증 (DB) 등 추가 가능
         return fileStoragePort.loadFile(spaceId, fileName);
     }
+
+    @Override
+    public void deleteImage(Long spaceId, Long imageId) {
+        // 공간 존재 검증
+        adminSpaceRepositoryPort.findById(spaceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SPACE_NOT_FOUND));
+
+        adminSpaceRepositoryPort.deleteImage(imageId);
+    }
 }

--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -50,6 +50,7 @@ public class SecurityConfig {
 
                         // --- 공개: 공간·룸 조회 ---
                         .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/experience/**").permitAll() // EXPERIENCE 공용시설 소개 🔓 Public
 
                         // --- 커뮤니티: 목록·상세만 비로그인 조회 (Controller에서 Optional Actor 처리) ---
                         .requestMatchers(HttpMethod.GET, "/api/posts", "/api/posts/*").permitAll()

--- a/backend/src/main/java/com/coliving/user/experience/adapter/in/web/ExperienceController.java
+++ b/backend/src/main/java/com/coliving/user/experience/adapter/in/web/ExperienceController.java
@@ -1,0 +1,35 @@
+package com.coliving.user.experience.adapter.in.web;
+
+import com.coliving.global.dto.ApiResponse;
+import com.coliving.user.experience.adapter.in.web.dto.CommonSpaceResponseDto;
+import com.coliving.user.experience.application.port.in.ExperienceUseCase;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Experience", description = "공용시설 소개 API (Public)")
+@RestController
+@RequestMapping("/api/experience")
+@RequiredArgsConstructor
+public class ExperienceController {
+
+    private final ExperienceUseCase experienceUseCase;
+
+    @Operation(summary = "전체 공용시설 목록 조회 (EXPERIENCE 소개 페이지용)",
+               description = "예약 가능 여부와 무관하게 모든 공용시설을 조회합니다. 비로그인 사용자도 접근 가능합니다.")
+    @GetMapping
+    public ApiResponse<List<CommonSpaceResponseDto>> getAllCommonSpaces() {
+        List<CommonSpaceResponseDto> result = experienceUseCase.getAllCommonSpaces()
+                .stream()
+                .map(CommonSpaceResponseDto::from)
+                .toList();
+
+        return ApiResponse.ok(result);
+    }
+}

--- a/backend/src/main/java/com/coliving/user/experience/adapter/in/web/ExperienceController.java
+++ b/backend/src/main/java/com/coliving/user/experience/adapter/in/web/ExperienceController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +31,14 @@ public class ExperienceController {
                 .map(CommonSpaceResponseDto::from)
                 .toList();
 
+        return ApiResponse.ok(result);
+    }
+
+    @Operation(summary = "특정 공용시설 상세 조회 (EXPERIENCE 상세 페이지용)",
+               description = "단일 공용시설의 상세 정보를 조회합니다.")
+    @GetMapping("/{spaceId}")
+    public ApiResponse<CommonSpaceResponseDto> getCommonSpace(@PathVariable Long spaceId) {
+        CommonSpaceResponseDto result = CommonSpaceResponseDto.from(experienceUseCase.getCommonSpace(spaceId));
         return ApiResponse.ok(result);
     }
 }

--- a/backend/src/main/java/com/coliving/user/experience/adapter/in/web/dto/CommonSpaceResponseDto.java
+++ b/backend/src/main/java/com/coliving/user/experience/adapter/in/web/dto/CommonSpaceResponseDto.java
@@ -1,0 +1,68 @@
+package com.coliving.user.experience.adapter.in.web.dto;
+
+import com.coliving.user.experience.model.CommonSpace;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+public class CommonSpaceResponseDto {
+
+    private Long spaceId;
+    private String name;
+    private String status;
+    private Integer floor;
+    private BigDecimal area;
+    private String description;
+    private List<String> amenities;
+
+    // Common 상세
+    private Integer maxCapacity;
+    private String operatingHours;
+    private Boolean isReservable;
+    private BigDecimal usageFee;
+
+    // 이미지
+    private String thumbnailUrl;
+    private List<SpaceImageDto> images;
+
+    @Getter
+    @Builder
+    public static class SpaceImageDto {
+        private Long spaceImageId;
+        private String imageUrl;
+        private String imageType;
+        private Integer sortOrder;
+        private Boolean isThumbnail;
+    }
+
+    public static CommonSpaceResponseDto from(CommonSpace cs) {
+        return CommonSpaceResponseDto.builder()
+                .spaceId(cs.getSpaceId())
+                .name(cs.getName())
+                .status(cs.getStatus() != null ? cs.getStatus().name() : null)
+                .floor(cs.getFloor())
+                .area(cs.getArea())
+                .description(cs.getDescription())
+                .amenities(cs.getAmenities())
+                .maxCapacity(cs.getMaxCapacity())
+                .operatingHours(cs.getOperatingHours())
+                .isReservable(cs.getIsReservable())
+                .usageFee(cs.getUsageFee())
+                .thumbnailUrl(cs.getThumbnailUrl())
+                .images(cs.getImages() != null ? cs.getImages().stream()
+                        .map(img -> SpaceImageDto.builder()
+                                .spaceImageId(img.getSpaceImageId())
+                                .imageUrl(img.getImageUrl())
+                                .imageType(img.getImageType() != null ? img.getImageType().name() : null)
+                                .sortOrder(img.getSortOrder())
+                                .isThumbnail(img.getIsThumbnail())
+                                .build())
+                        .toList() : null)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/user/experience/adapter/out/persistence/ExperiencePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/experience/adapter/out/persistence/ExperiencePersistenceAdapter.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -30,6 +31,13 @@ public class ExperiencePersistenceAdapter implements ExperienceRepositoryPort {
         return entities.stream()
                 .map(this::toCommonSpace)
                 .toList();
+    }
+
+    @Override
+    public Optional<CommonSpace> findCommonSpaceById(Long spaceId) {
+        return spaceJpaRepository.findById(spaceId)
+                .filter(entity -> entity.getType() == SpaceType.COMMON && entity.getStatus() != SpaceStatus.MAINTENANCE)
+                .map(this::toCommonSpace);
     }
 
     private CommonSpace toCommonSpace(SpaceEntity entity) {

--- a/backend/src/main/java/com/coliving/user/experience/adapter/out/persistence/ExperiencePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/experience/adapter/out/persistence/ExperiencePersistenceAdapter.java
@@ -1,0 +1,87 @@
+package com.coliving.user.experience.adapter.out.persistence;
+
+import com.coliving.admin.space.adapter.out.jpa.CommonSpaceDetailEntity;
+import com.coliving.admin.space.adapter.out.jpa.SpaceEntity;
+import com.coliving.admin.space.adapter.out.jpa.SpaceImageEntity;
+import com.coliving.admin.space.adapter.out.jpa.SpaceJpaRepository;
+import com.coliving.admin.space.model.SpaceStatus;
+import com.coliving.admin.space.model.SpaceType;
+import com.coliving.user.experience.application.port.out.ExperienceRepositoryPort;
+import com.coliving.user.experience.model.CommonSpace;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ExperiencePersistenceAdapter implements ExperienceRepositoryPort {
+
+    private final SpaceJpaRepository spaceJpaRepository;
+
+    @Override
+    public List<CommonSpace> findAllCommonSpaces() {
+        List<SpaceEntity> entities = spaceJpaRepository.findByTypeAndStatusNot(
+                SpaceType.COMMON, SpaceStatus.MAINTENANCE);
+
+        return entities.stream()
+                .map(this::toCommonSpace)
+                .toList();
+    }
+
+    private CommonSpace toCommonSpace(SpaceEntity entity) {
+        String thumbnailUrl = entity.getImages().stream()
+                .filter(img -> Boolean.TRUE.equals(img.getIsThumbnail()))
+                .map(SpaceImageEntity::getImageUrl)
+                .findFirst()
+                .orElse(null);
+
+        List<CommonSpace.SpaceImage> images = entity.getImages().stream()
+                .map(img -> CommonSpace.SpaceImage.builder()
+                        .spaceImageId(img.getSpaceImageId())
+                        .imageUrl(img.getImageUrl())
+                        .imageType(img.getImageType())
+                        .sortOrder(img.getSortOrder())
+                        .isThumbnail(img.getIsThumbnail())
+                        .build())
+                .toList();
+
+        CommonSpaceDetailEntity detail = entity.getCommonDetail();
+
+        return CommonSpace.builder()
+                .spaceId(entity.getSpaceId())
+                .name(entity.getName())
+                .status(entity.getStatus())
+                .floor(entity.getFloor())
+                .area(entity.getArea())
+                .description(entity.getDescription())
+                .amenities(parseAmenities(entity.getAmenities()))
+                .maxCapacity(detail != null ? detail.getMaxCapacity() : null)
+                .operatingHours(detail != null ? detail.getOperatingHours() : null)
+                .isReservable(detail != null ? detail.getIsReservable() : null)
+                .usageFee(detail != null ? detail.getUsageFee() : null)
+                .thumbnailUrl(thumbnailUrl)
+                .images(images)
+                .build();
+    }
+
+    private List<String> parseAmenities(String amenitiesJson) {
+        if (amenitiesJson == null || amenitiesJson.isBlank()) {
+            return Collections.emptyList();
+        }
+        String trimmed = amenitiesJson.trim();
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            trimmed = trimmed.substring(1, trimmed.length() - 1);
+        }
+        if (trimmed.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(trimmed.split(","))
+                .map(s -> s.trim().replaceAll("^\"|\"$", ""))
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/coliving/user/experience/application/port/in/ExperienceUseCase.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/port/in/ExperienceUseCase.java
@@ -15,4 +15,9 @@ public interface ExperienceUseCase {
      * 전체 공용시설 목록 조회 (점검 중 제외)
      */
     List<CommonSpace> getAllCommonSpaces();
+
+    /**
+     * 특정 공용시설 상세 조회
+     */
+    CommonSpace getCommonSpace(Long spaceId);
 }

--- a/backend/src/main/java/com/coliving/user/experience/application/port/in/ExperienceUseCase.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/port/in/ExperienceUseCase.java
@@ -1,0 +1,18 @@
+package com.coliving.user.experience.application.port.in;
+
+import com.coliving.user.experience.model.CommonSpace;
+
+import java.util.List;
+
+/**
+ * 공용시설 소개 조회 유스케이스 (EXPERIENCE 페이지용)
+ *
+ * 예약 가능 여부와 무관하게 모든 COMMON 공간을 조회한다.
+ */
+public interface ExperienceUseCase {
+
+    /**
+     * 전체 공용시설 목록 조회 (점검 중 제외)
+     */
+    List<CommonSpace> getAllCommonSpaces();
+}

--- a/backend/src/main/java/com/coliving/user/experience/application/port/out/ExperienceRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/port/out/ExperienceRepositoryPort.java
@@ -1,0 +1,16 @@
+package com.coliving.user.experience.application.port.out;
+
+import com.coliving.user.experience.model.CommonSpace;
+
+import java.util.List;
+
+/**
+ * 공용시설 조회용 Repository Port (EXPERIENCE 페이지)
+ */
+public interface ExperienceRepositoryPort {
+
+    /**
+     * 전체 공용시설 목록 조회 (점검 중 제외, is_reservable 무관)
+     */
+    List<CommonSpace> findAllCommonSpaces();
+}

--- a/backend/src/main/java/com/coliving/user/experience/application/port/out/ExperienceRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/port/out/ExperienceRepositoryPort.java
@@ -3,6 +3,7 @@ package com.coliving.user.experience.application.port.out;
 import com.coliving.user.experience.model.CommonSpace;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 공용시설 조회용 Repository Port (EXPERIENCE 페이지)
@@ -13,4 +14,9 @@ public interface ExperienceRepositoryPort {
      * 전체 공용시설 목록 조회 (점검 중 제외, is_reservable 무관)
      */
     List<CommonSpace> findAllCommonSpaces();
+
+    /**
+     * 특정 공용시설 상세 조회
+     */
+    Optional<CommonSpace> findCommonSpaceById(Long spaceId);
 }

--- a/backend/src/main/java/com/coliving/user/experience/application/service/ExperienceService.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/service/ExperienceService.java
@@ -1,0 +1,31 @@
+package com.coliving.user.experience.application.service;
+
+import com.coliving.user.experience.application.port.in.ExperienceUseCase;
+import com.coliving.user.experience.application.port.out.ExperienceRepositoryPort;
+import com.coliving.user.experience.model.CommonSpace;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ExperienceService implements ExperienceUseCase {
+
+    private final ExperienceRepositoryPort experienceRepositoryPort;
+
+    @Override
+    public List<CommonSpace> getAllCommonSpaces() {
+        log.info("[EXPERIENCE] 전체 공용시설 목록 조회 요청");
+
+        List<CommonSpace> spaces = experienceRepositoryPort.findAllCommonSpaces();
+
+        log.info("[EXPERIENCE] 조회된 전체 공용시설 수: {}", spaces.size());
+        return spaces;
+    }
+}

--- a/backend/src/main/java/com/coliving/user/experience/application/service/ExperienceService.java
+++ b/backend/src/main/java/com/coliving/user/experience/application/service/ExperienceService.java
@@ -4,6 +4,9 @@ import com.coliving.user.experience.application.port.in.ExperienceUseCase;
 import com.coliving.user.experience.application.port.out.ExperienceRepositoryPort;
 import com.coliving.user.experience.model.CommonSpace;
 
+import com.coliving.global.error.BusinessException;
+import com.coliving.global.error.ErrorCode;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,5 +30,16 @@ public class ExperienceService implements ExperienceUseCase {
 
         log.info("[EXPERIENCE] 조회된 전체 공용시설 수: {}", spaces.size());
         return spaces;
+    }
+
+    @Override
+    public CommonSpace getCommonSpace(Long spaceId) {
+        log.info("[EXPERIENCE] 공용시설 상세 조회 요청: spaceId={}", spaceId);
+
+        return experienceRepositoryPort.findCommonSpaceById(spaceId)
+                .orElseThrow(() -> {
+                    log.warn("[EXPERIENCE] 공용시설을 찾을 수 없음: spaceId={}", spaceId);
+                    return new BusinessException(ErrorCode.NOT_FOUND);
+                });
     }
 }

--- a/backend/src/main/java/com/coliving/user/experience/model/CommonSpace.java
+++ b/backend/src/main/java/com/coliving/user/experience/model/CommonSpace.java
@@ -1,0 +1,47 @@
+package com.coliving.user.experience.model;
+
+import com.coliving.admin.space.model.ImageType;
+import com.coliving.admin.space.model.SpaceStatus;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 유저가 보는 공용시설 정보 (COMMON 유형 공간 조회용 도메인 모델)
+ * EXPERIENCE 소개 페이지에서 사용한다.
+ */
+@Getter
+@Builder
+public class CommonSpace {
+
+    private Long spaceId;
+    private String name;
+    private SpaceStatus status;
+    private Integer floor;
+    private BigDecimal area;
+    private String description;
+    private List<String> amenities;
+
+    // Common 상세
+    private Integer maxCapacity;
+    private String operatingHours;
+    private Boolean isReservable;
+    private BigDecimal usageFee;
+
+    // 이미지
+    private String thumbnailUrl;
+    private List<SpaceImage> images;
+
+    @Getter
+    @Builder
+    public static class SpaceImage {
+        private Long spaceImageId;
+        private String imageUrl;
+        private ImageType imageType;
+        private Integer sortOrder;
+        private Boolean isThumbnail;
+    }
+}

--- a/frontend/src/app/(public)/experience/[id]/_components/FacilityGallery.tsx
+++ b/frontend/src/app/(public)/experience/[id]/_components/FacilityGallery.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { CommonSpaceImage } from '../../_api';
+
+interface FacilityGalleryProps {
+  images: CommonSpaceImage[];
+}
+
+export function FacilityGallery({ images }: FacilityGalleryProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (!images || images.length === 0) return null;
+
+  const handleNext = () => setCurrentIndex((prev) => (prev + 1) % images.length);
+  const handlePrev = () => setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-sm md:text-base font-black tracking-[0.3em] uppercase opacity-30">
+        Gallery
+      </h3>
+      
+      <div className="p-4 md:p-6 rounded-2xl bg-foreground/[0.02] border border-foreground/[0.05]">
+        <div className="relative overflow-hidden rounded-[2rem] bg-foreground/5 aspect-[16/9] group mb-6">
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={currentIndex}
+              src={images[currentIndex].imageUrl}
+              alt={`Gallery ${currentIndex + 1}`}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.3 }}
+              className="w-full h-full object-cover"
+            />
+          </AnimatePresence>
+
+          {images.length > 1 && (
+            <>
+              <button
+                onClick={handlePrev}
+                className="absolute left-4 md:left-8 top-1/2 -translate-y-1/2 p-3 rounded-full bg-background/80 text-foreground backdrop-blur-md opacity-0 group-hover:opacity-100 transition-opacity hover:scale-110"
+              >
+                <ChevronLeft size={24} />
+              </button>
+              <button
+                onClick={handleNext}
+                className="absolute right-4 md:right-8 top-1/2 -translate-y-1/2 p-3 rounded-full bg-background/80 text-foreground backdrop-blur-md opacity-0 group-hover:opacity-100 transition-opacity hover:scale-110"
+              >
+                <ChevronRight size={24} />
+              </button>
+
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-black/50 backdrop-blur-md text-white text-xs font-bold tracking-widest">
+                {currentIndex + 1} / {images.length}
+              </div>
+            </>
+          )}
+        </div>
+
+        {images.length > 1 && (
+          <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory flex-nowrap hide-scrollbar pb-2">
+            {images.map((img, idx) => (
+              <button
+                key={img.spaceImageId || idx}
+                onClick={() => setCurrentIndex(idx)}
+                className={`relative shrink-0 w-20 h-20 md:w-28 md:h-28 rounded-2xl overflow-hidden snap-center transition-all duration-300 ${
+                  currentIndex === idx ? 'ring-2 ring-[var(--color-accent)] ring-offset-2 scale-95 opacity-100' : 'opacity-40 hover:opacity-100'
+                }`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={img.imageUrl} alt="Thumbnail" className="w-full h-full object-cover" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/experience/[id]/_components/FacilityHero.tsx
+++ b/frontend/src/app/(public)/experience/[id]/_components/FacilityHero.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Sparkles, ArrowLeft } from 'lucide-react';
+import Link from 'next/link';
+import type { CommonSpaceImage } from '../../_api';
+
+interface FacilityHeroProps {
+  images?: CommonSpaceImage[];
+  spaceName: string;
+  selectedImage: number;
+  onSelectImage: (index: number) => void;
+}
+
+export function FacilityHero({ images, spaceName, selectedImage, onSelectImage }: FacilityHeroProps) {
+  const hasImages = images && images.length > 0;
+  const currentSrc = hasImages ? images[selectedImage]?.imageUrl : null;
+
+  if (!hasImages) {
+    return (
+      <section className="relative h-[80vh] w-full overflow-hidden bg-foreground/5 flex items-center justify-center">
+        <Sparkles size={64} className="opacity-10" />
+        {/* Back button */}
+        <div className="absolute right-0 bottom-0 left-0 p-6 md:p-12 lg:p-24">
+          <div className="mx-auto max-w-[1400px]">
+            <Link
+              href="/experience"
+              className="group mb-8 inline-flex items-center gap-2 text-foreground/60 transition-all hover:text-foreground"
+            >
+              <ArrowLeft className="h-6 w-6 transition-transform group-hover:-translate-x-1" />
+              <span className="text-sm font-medium tracking-[0.1em] uppercase">
+                Return to Experience
+              </span>
+            </Link>
+            <h1 className="text-4xl sm:text-5xl md:text-7xl lg:text-8xl xl:text-9xl font-black text-foreground tracking-tighter mb-4 leading-[0.85] max-w-[95%] md:max-w-[80%]">
+              {spaceName}
+            </h1>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="relative h-[80vh] w-full overflow-hidden bg-black">
+      {/* Main image */}
+      <motion.div
+        className="absolute inset-0"
+        key={selectedImage}
+        initial={{ scale: 1.1, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        transition={{ duration: 1.5, ease: [0.22, 1, 0.36, 1] }}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={currentSrc!}
+          alt={spaceName}
+          className="h-full w-full object-cover opacity-80"
+        />
+      </motion.div>
+
+      {/* Gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+
+      {/* Title overlay */}
+      <div className="absolute right-0 bottom-0 left-0 p-6 md:p-12 lg:p-24">
+        <div className="mx-auto max-w-[1400px]">
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.5, duration: 1 }}
+          >
+            <Link
+              href="/experience"
+              className="group mb-8 inline-flex items-center gap-2 text-white/90 drop-shadow-lg transition-all hover:text-white"
+            >
+              <ArrowLeft className="h-6 w-6 transition-transform group-hover:-translate-x-1" />
+              <span className="text-sm font-medium tracking-[0.1em] uppercase">
+                Return to Experience
+              </span>
+            </Link>
+            <h1 className="text-4xl sm:text-5xl md:text-7xl lg:text-8xl xl:text-9xl font-black text-white tracking-tighter mb-4 leading-[0.85] max-w-[95%] md:max-w-[80%]">
+              {spaceName}
+            </h1>
+          </motion.div>
+        </div>
+      </div>
+
+      {/* Desktop Image Navigation — right side thumbnails */}
+      {images.length > 1 && (
+        <div className="hidden md:flex absolute right-6 bottom-12 flex-col gap-4">
+          {images.map((img, i) => (
+            <button
+              key={img.spaceImageId}
+              onClick={() => onSelectImage(i)}
+              className={`h-16 w-16 overflow-hidden rounded-lg border-2 transition-all cursor-pointer ${
+                selectedImage === i
+                  ? 'scale-110 border-white'
+                  : 'border-transparent opacity-50 hover:opacity-100'
+              }`}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={img.imageUrl} alt="" className="h-full w-full object-cover" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Mobile Image Navigation */}
+      {images.length > 1 && (
+        <div className="flex md:hidden absolute bottom-4 left-1/2 -translate-x-1/2 items-center gap-2 bg-black/40 backdrop-blur-sm rounded-full px-4 py-2">
+          {images.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => onSelectImage(i)}
+              className={`w-2 h-2 rounded-full transition-all duration-300 cursor-pointer ${
+                i === selectedImage
+                  ? 'bg-white w-4'
+                  : 'bg-white/50'
+              }`}
+              aria-label={`이미지 ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/app/(public)/experience/[id]/_components/FacilitySpec.tsx
+++ b/frontend/src/app/(public)/experience/[id]/_components/FacilitySpec.tsx
@@ -1,0 +1,44 @@
+import type { CommonSpaceDto } from '../../_api';
+
+interface FacilitySpecProps {
+  space: CommonSpaceDto;
+}
+
+export function FacilitySpec({ space }: FacilitySpecProps) {
+  const specs = [
+    { label: '시설명', value: space.name, wide: true },
+    { label: '층수', value: space.floor ? (space.floor > 0 ? `${space.floor}층` : `지하 ${Math.abs(space.floor)}층`) : '-' },
+    { label: '면적', value: space.area ? `${space.area}㎡` : '-' },
+    { label: '수용 인원', value: space.maxCapacity ? `최대 ${space.maxCapacity}명` : '제한 없음' },
+    { label: '운영 시간', value: space.operatingHours || '24시간' },
+    {
+      label: '이용 방식',
+      value: space.isReservable ? '예약제' : '자유 이용',
+    },
+  ];
+
+  return (
+    <div className="space-y-12">
+      <h3 className="text-sm md:text-base font-black tracking-[0.3em] uppercase opacity-30">
+        Facility Information
+      </h3>
+      <div className="grid grid-cols-2 gap-3 md:gap-4 lg:grid-cols-3">
+        {specs.map((item) => (
+          <div
+            key={item.label}
+            className={`p-4 md:p-6 rounded-2xl bg-foreground/[0.02] border border-foreground/[0.05] space-y-1 md:space-y-2 ${
+              item.wide ? 'col-span-2 lg:col-span-1' : 'col-span-1'
+            }`}
+          >
+            <span className="text-[10px] md:text-xs font-black tracking-[0.2em] uppercase opacity-20 block">
+              {item.label}
+            </span>
+            <span className="text-sm md:text-base font-bold text-foreground block leading-tight break-keep">
+              {item.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/experience/[id]/page.tsx
+++ b/frontend/src/app/(public)/experience/[id]/page.tsx
@@ -8,6 +8,7 @@ import { ArrowRight } from 'lucide-react';
 import { fetchCommonSpace, CommonSpaceDto } from '../_api';
 import { FacilityHero } from './_components/FacilityHero';
 import { FacilitySpec } from './_components/FacilitySpec';
+import { FacilityGallery } from './_components/FacilityGallery';
 import { AmenityBadges } from '../../rooms/[id]/_components/AmenityBadges';
 
 const formatKRW = (value?: number) => {
@@ -83,11 +84,10 @@ export default function ExperienceDetailPage() {
                 viewport={{ once: true }}
               >
                 <span
-                  className={`inline-block px-6 py-2.5 text-xs md:text-sm font-black tracking-[0.2em] uppercase rounded-full border ${
-                    space.isReservable 
-                      ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)] border-[var(--color-accent)]/20' 
+                  className={`inline-block px-6 py-2.5 text-xs md:text-sm font-black tracking-[0.2em] uppercase rounded-full border ${space.isReservable
+                      ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)] border-[var(--color-accent)]/20'
                       : 'bg-black/5 text-foreground border-foreground/10'
-                  }`}
+                    }`}
                 >
                   {space.isReservable ? '예약제 공간' : '자유 이용 공간'}
                 </span>
@@ -147,6 +147,14 @@ export default function ExperienceDetailPage() {
               {/* Amenities */}
               <AmenityBadges amenities={space.amenities} />
             </div>
+
+            {/* Separator */}
+            <div className="h-px bg-foreground/10" />
+
+            {/* Image Gallery (내 도메인 전용 카드) */}
+            {space.images && space.images.length > 0 && (
+              <FacilityGallery images={space.images} />
+            )}
           </div>
 
           {/* Reserve CTA — Editorial dark card */}

--- a/frontend/src/app/(public)/experience/[id]/page.tsx
+++ b/frontend/src/app/(public)/experience/[id]/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { fetchCommonSpace, CommonSpaceDto } from '../_api';
+import { FacilityHero } from './_components/FacilityHero';
+import { FacilitySpec } from './_components/FacilitySpec';
+import { AmenityBadges } from '../../rooms/[id]/_components/AmenityBadges';
+
+const formatKRW = (value?: number) => {
+  if (value === undefined || value === null || value === 0) return '무료';
+  if (value >= 10000) {
+    const man = Math.floor(value / 10000);
+    const remainder = value % 10000;
+    return remainder > 0
+      ? `₩${man.toLocaleString()}만 ${remainder.toLocaleString()}원`
+      : `₩${man.toLocaleString()}만원`;
+  }
+  return `₩${value.toLocaleString()}`;
+};
+
+export default function ExperienceDetailPage() {
+  const params = useParams<{ id: string }>();
+  const [space, setSpace] = useState<CommonSpaceDto | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedImage, setSelectedImage] = useState(0);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetchCommonSpace(Number(params.id));
+        setSpace(res);
+      } catch (e) {
+        console.error(e);
+        setError('시설 정보를 불러올 수 없습니다');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [params.id]);
+
+  if (loading) return <DetailSkeleton />;
+
+  if (error || !space) {
+    return (
+      <div className="min-h-screen bg-background text-foreground flex flex-col items-center justify-center p-8">
+        <p className="text-lg font-bold opacity-50 mb-6">{error || '시설을 찾을 수 없습니다'}</p>
+        <Link href="/experience" className="text-sm font-bold text-[var(--color-accent)] underline underline-offset-4">
+          ← 목록으로 돌아가기
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground selection:bg-primary selection:text-primary-foreground">
+      {/* Hero Image */}
+      <FacilityHero
+        images={space.images}
+        spaceName={space.name}
+        selectedImage={selectedImage}
+        onSelectImage={setSelectedImage}
+      />
+
+      {/* Content Section */}
+      <section className="px-6 py-16 md:px-12 lg:px-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] space-y-32">
+          <div className="space-y-20">
+            {/* Status Badge + Intro */}
+            <div className="space-y-8">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+              >
+                <span
+                  className={`inline-block px-6 py-2.5 text-xs md:text-sm font-black tracking-[0.2em] uppercase rounded-full border ${
+                    space.isReservable 
+                      ? 'bg-[var(--color-accent)]/10 text-[var(--color-accent)] border-[var(--color-accent)]/20' 
+                      : 'bg-black/5 text-foreground border-foreground/10'
+                  }`}
+                >
+                  {space.isReservable ? '예약제 공간' : '자유 이용 공간'}
+                </span>
+                {space.status === 'MAINTENANCE' && (
+                  <span className="ml-3 inline-block px-6 py-2.5 text-xs md:text-sm font-black tracking-[0.2em] uppercase rounded-full border bg-destructive/10 text-destructive border-destructive/20">
+                    점검 중
+                  </span>
+                )}
+              </motion.div>
+
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                className="max-w-4xl"
+              >
+                <h2 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl xl:text-7xl font-black tracking-tight text-foreground mb-6 md:mb-10 leading-[1.1] break-keep">
+                  공유와 소통, 진정한 코리빙의 경험.
+                </h2>
+                {space.description && (
+                  <p className="text-base sm:text-lg md:text-xl lg:text-2xl leading-relaxed font-medium text-foreground/70 text-balance italic">
+                    &ldquo;{space.description}&rdquo;
+                  </p>
+                )}
+              </motion.div>
+            </div>
+
+            {/* Separator */}
+            <div className="h-px bg-foreground/10" />
+
+            {/* Room Details Grid */}
+            <FacilitySpec space={space} />
+
+            {/* Separator */}
+            <div className="h-px bg-foreground/10" />
+
+            {/* Pricing + Amenities — 2-column */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-16 lg:gap-24">
+              {/* Pricing Details */}
+              <div className="space-y-12">
+                <h3 className="text-sm md:text-base font-black tracking-[0.3em] uppercase opacity-30">
+                  Usage Fee
+                </h3>
+                <div className="space-y-6">
+                  <div className="flex justify-between items-baseline group">
+                    <span className="text-base md:text-lg lg:text-xl font-bold tracking-tight text-foreground/50">
+                      시간당 이용료
+                    </span>
+                    <div className="flex-1 mx-4 border-b border-dotted border-foreground/20" />
+                    <span className="text-lg md:text-xl lg:text-3xl font-black text-foreground">
+                      {formatKRW(space.usageFee)}
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Amenities */}
+              <AmenityBadges amenities={space.amenities} />
+            </div>
+          </div>
+
+          {/* Reserve CTA — Editorial dark card */}
+          <motion.div
+            className="relative overflow-hidden rounded-[32px] md:rounded-[40px] bg-primary p-6 md:p-16 text-primary-foreground"
+            initial={{ opacity: 0, y: 40 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+          >
+            <div className="relative z-10 flex flex-col gap-8 md:flex-row md:items-center md:justify-between">
+              <div className="space-y-6">
+                <div>
+                  <h3 className="text-sm md:text-base font-black tracking-[0.4em] uppercase opacity-50 mb-4">
+                    Experience Together
+                  </h3>
+                  <p className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-black tracking-tighter leading-tight">
+                    {space.isReservable ? '입주하고 편리하게 예약하세요.' : '입주자라면 누구나, 언제든지.'}
+                  </p>
+                </div>
+              </div>
+
+              {space.isReservable ? (
+                <Link
+                  href={`/facilities?spaceId=${space.spaceId}`}
+                  className="group inline-flex items-center justify-center h-16 md:h-22 px-12 rounded-full bg-background text-primary hover:bg-secondary hover:text-white transition-all duration-500 font-black tracking-widest text-sm md:text-base shrink-0"
+                >
+                  Reserve Facility
+                  <ArrowRight className="ml-3 h-5 w-5 transition-transform group-hover:translate-x-1" />
+                </Link>
+              ) : (
+                <div className="inline-flex items-center justify-center h-16 md:h-22 px-12 rounded-full bg-white/10 text-white/90 border border-white/20 font-black tracking-widest text-sm md:text-base shrink-0">
+                  자유 이용 시설
+                </div>
+              )}
+            </div>
+
+            {/* Decorative gradient */}
+            <div className="absolute top-0 right-0 w-1/2 h-full bg-gradient-to-l from-white/5 to-transparent pointer-events-none" />
+          </motion.div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+/** 인라인 Skeleton — 클라이언트 내부 로딩 시 사용 */
+function DetailSkeleton() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      {/* Hero Skeleton */}
+      <div className="relative h-[80vh] w-full bg-foreground/5 animate-pulse" />
+
+      {/* Content Skeleton */}
+      <div className="px-6 py-16 md:px-12 lg:px-24 md:py-32">
+        <div className="mx-auto max-w-[1200px] animate-pulse space-y-20">
+          <div className="h-8 w-32 bg-foreground/5 rounded-full" />
+          <div className="h-16 w-3/4 bg-foreground/5 rounded-2xl" />
+          <div className="h-6 w-full bg-foreground/5 rounded-xl" />
+          <div className="h-px bg-foreground/10" />
+          <div className="grid grid-cols-2 gap-4 lg:grid-cols-3">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-20 bg-foreground/[0.02] border border-foreground/5 rounded-2xl" />
+            ))}
+          </div>
+          <div className="h-px bg-foreground/10" />
+          <div className="h-48 bg-foreground/5 rounded-[32px]" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/experience/_api/index.ts
+++ b/frontend/src/app/(public)/experience/_api/index.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from '@/lib/api';
+
+export interface CommonSpaceImage {
+  spaceImageId: number;
+  imageUrl: string;
+  imageType: string;
+  sortOrder: number;
+  isThumbnail: boolean;
+}
+
+export interface CommonSpaceDto {
+  spaceId: number;
+  name: string;
+  status: string;
+  floor: number;
+  area: number;
+  description: string;
+  amenities: string[];
+  maxCapacity: number;
+  operatingHours: string;
+  isReservable: boolean;
+  usageFee: number;
+  thumbnailUrl: string | null;
+  images: CommonSpaceImage[];
+}
+
+export async function fetchCommonSpaces(): Promise<CommonSpaceDto[]> {
+  const res = await apiFetch<CommonSpaceDto[]>('/experience');
+  return res.data ?? [];
+}

--- a/frontend/src/app/(public)/experience/_api/index.ts
+++ b/frontend/src/app/(public)/experience/_api/index.ts
@@ -28,3 +28,9 @@ export async function fetchCommonSpaces(): Promise<CommonSpaceDto[]> {
   const res = await apiFetch<CommonSpaceDto[]>('/experience');
   return res.data ?? [];
 }
+
+export async function fetchCommonSpace(spaceId: number): Promise<CommonSpaceDto> {
+  const res = await apiFetch<CommonSpaceDto>(`/experience/${spaceId}`);
+  if (!res.data) throw new Error('Facility not found');
+  return res.data;
+}

--- a/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
+++ b/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Clock, Users, CalendarCheck, Sparkles } from 'lucide-react';
+import { CommonSpaceDto } from '../_api';
+
+export function FacilityCard({ space, index }: { space: CommonSpaceDto; index: number }) {
+  const fallbackImage = `https://picsum.photos/seed/space${space.spaceId}/800/600`;
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 40 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, delay: index * 0.08, ease: [0.22, 1, 0.36, 1] }}
+      className="group relative overflow-hidden rounded-[2rem] bg-[var(--color-muted)]/30 border border-foreground/5 transition-all duration-500 hover:shadow-xl hover:border-foreground/10"
+    >
+      {/* 이미지 */}
+      <div className="relative aspect-[16/10] overflow-hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={space.thumbnailUrl || fallbackImage}
+          alt={space.name}
+          className="h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+        />
+        {/* 오버레이 배지 */}
+        <div className="absolute top-4 left-4 flex gap-2">
+          <span className={`px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest backdrop-blur-md ${
+            space.isReservable
+              ? 'bg-[var(--color-accent)]/90 text-white'
+              : 'bg-white/90 text-foreground'
+          }`}>
+            {space.isReservable ? '예약제' : '자유 이용'}
+          </span>
+        </div>
+        {space.floor && (
+          <span className="absolute top-4 right-4 px-3 py-1.5 rounded-full text-[10px] font-black uppercase tracking-widest bg-foreground/80 text-background backdrop-blur-md">
+            {space.floor > 0 ? `${space.floor}F` : `B${Math.abs(space.floor)}`}
+          </span>
+        )}
+      </div>
+
+      {/* 콘텐츠 */}
+      <div className="p-6 space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <h3 className="text-xl font-black tracking-tighter leading-tight">
+            {space.name}
+          </h3>
+          {space.usageFee > 0 && (
+            <span className="shrink-0 text-sm font-black text-[var(--color-accent)]">
+              ₩{space.usageFee?.toLocaleString()}<span className="text-[10px] opacity-60">/시간</span>
+            </span>
+          )}
+        </div>
+
+        {space.description && (
+          <p className="text-sm font-medium leading-relaxed opacity-60 line-clamp-2">
+            {space.description}
+          </p>
+        )}
+
+        {/* 메타 정보 */}
+        <div className="flex flex-wrap gap-3 pt-2 border-t border-foreground/5">
+          {space.operatingHours && (
+            <div className="flex items-center gap-1.5 text-[11px] font-bold tracking-tight opacity-50">
+              <Clock size={13} />
+              <span>{space.operatingHours}</span>
+            </div>
+          )}
+          {space.maxCapacity && (
+            <div className="flex items-center gap-1.5 text-[11px] font-bold tracking-tight opacity-50">
+              <Users size={13} />
+              <span>최대 {space.maxCapacity}인</span>
+            </div>
+          )}
+          {space.isReservable ? (
+            <div className="flex items-center gap-1.5 text-[11px] font-bold tracking-tight text-[var(--color-accent)]">
+              <CalendarCheck size={13} />
+              <span>예약 후 이용</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1.5 text-[11px] font-bold tracking-tight text-[var(--color-accent)]">
+              <Sparkles size={13} />
+              <span>자유 이용 가능</span>
+            </div>
+          )}
+        </div>
+
+        {/* 부대시설 태그 */}
+        {space.amenities && space.amenities.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {space.amenities.map((amenity, i) => (
+              <span
+                key={i}
+                className="px-2.5 py-1 rounded-full bg-foreground/5 text-[10px] font-bold tracking-tight"
+              >
+                {amenity}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </motion.article>
+  );
+}

--- a/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
+++ b/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
@@ -2,18 +2,20 @@
 
 import { motion } from 'framer-motion';
 import { Clock, Users, CalendarCheck, Sparkles } from 'lucide-react';
+import Link from 'next/link';
 import { CommonSpaceDto } from '../_api';
 
 export function FacilityCard({ space, index }: { space: CommonSpaceDto; index: number }) {
   const fallbackImage = `https://picsum.photos/seed/space${space.spaceId}/800/600`;
 
   return (
-    <motion.article
-      initial={{ opacity: 0, y: 40 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.6, delay: index * 0.08, ease: [0.22, 1, 0.36, 1] }}
-      className="group relative overflow-hidden rounded-[2rem] bg-[var(--color-muted)]/30 border border-foreground/5 transition-all duration-500 hover:shadow-xl hover:border-foreground/10"
-    >
+    <Link href={`/experience/${space.spaceId}`} className="block">
+      <motion.article
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6, delay: index * 0.08, ease: [0.22, 1, 0.36, 1] }}
+        className="group relative overflow-hidden rounded-[2rem] bg-[var(--color-muted)]/30 border border-foreground/5 transition-all duration-500 hover:shadow-xl hover:border-foreground/10"
+      >
       {/* 이미지 */}
       <div className="relative aspect-[16/10] overflow-hidden">
         {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -100,5 +102,6 @@ export function FacilityCard({ space, index }: { space: CommonSpaceDto; index: n
         )}
       </div>
     </motion.article>
+    </Link>
   );
 }

--- a/frontend/src/app/(public)/experience/_hooks/useCommonSpaces.ts
+++ b/frontend/src/app/(public)/experience/_hooks/useCommonSpaces.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { CommonSpaceDto, fetchCommonSpaces } from '../_api';
+
+export function useCommonSpaces() {
+  const [spaces, setSpaces] = useState<CommonSpaceDto[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchCommonSpaces()
+      .then(setSpaces)
+      .catch(console.error)
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { spaces, loading };
+}

--- a/frontend/src/app/(public)/experience/page.tsx
+++ b/frontend/src/app/(public)/experience/page.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useRef } from 'react';
+import { motion, useScroll, useTransform, AnimatePresence } from 'framer-motion';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { useCommonSpaces } from './_hooks/useCommonSpaces';
+import { FacilityCard } from './_components/FacilityCard';
+
+export default function ExperiencePage() {
+  const { spaces, loading } = useCommonSpaces();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollY } = useScroll();
+  const headerScale = useTransform(scrollY, [0, 300], [1, 0.7]);
+  const headerOpacity = useTransform(scrollY, [0, 300], [1, 0]);
+  const headerY = useTransform(scrollY, [0, 300], [0, -80]);
+
+  const reservableCount = spaces.filter(s => s.isReservable).length;
+  const freeCount = spaces.filter(s => !s.isReservable).length;
+
+  return (
+    <div
+      ref={containerRef}
+      className="min-h-screen bg-background text-foreground pb-32 selection:bg-primary selection:text-primary-foreground"
+    >
+      {/* Page Header — Editorial Style */}
+      <motion.section
+        className="px-6 md:px-12 lg:px-24 pt-24 pb-4 overflow-hidden bg-background"
+      >
+        <div className="mx-auto max-w-[1400px]">
+          <motion.div
+            style={{ scale: headerScale, opacity: headerOpacity, y: headerY }}
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 1, ease: [0.22, 1, 0.36, 1] }}
+            className="flex flex-col items-end justify-between gap-12 border-b border-foreground/10 pb-8 md:flex-row"
+          >
+            <div className="max-w-2xl space-y-6">
+              <h1 className="text-6xl md:text-8xl lg:text-[10rem] font-black tracking-tighter leading-[0.85] uppercase">
+                EXPERI
+                <span className="underline underline-offset-[1vw] decoration-[var(--color-accent)]">ENCE.</span>
+              </h1>
+              <p className="text-sm leading-tight font-medium opacity-70 md:text-2xl">
+                함께 누리는 공간, 특별한 일상의 시작
+              </p>
+            </div>
+            <div className="text-right">
+              {!loading && (
+                <motion.p
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="text-xs font-black tracking-[0.3em] uppercase opacity-40"
+                >
+                  {spaces.length} Facilities
+                </motion.p>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      </motion.section>
+
+      {/* Stats Bar */}
+      {!loading && spaces.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.3 }}
+          className="px-6 md:px-12 lg:px-24 py-6 md:py-8 border-b border-foreground/5"
+        >
+          <div className="mx-auto max-w-[1400px] flex flex-wrap items-center gap-4 md:gap-8">
+            <span className="px-5 py-2.5 rounded-full bg-foreground text-background text-[10px] md:text-xs font-black uppercase tracking-widest">
+              전체 {spaces.length}개 시설
+            </span>
+            {reservableCount > 0 && (
+              <span className="px-5 py-2.5 rounded-full border border-[var(--color-accent)] text-[var(--color-accent)] text-[10px] md:text-xs font-black uppercase tracking-widest">
+                예약제 {reservableCount}
+              </span>
+            )}
+            {freeCount > 0 && (
+              <span className="px-5 py-2.5 rounded-full border border-foreground/20 text-foreground/70 text-[10px] md:text-xs font-black uppercase tracking-widest">
+                자유이용 {freeCount}
+              </span>
+            )}
+          </div>
+        </motion.section>
+      )}
+
+      {/* Grid */}
+      <section className="mt-12 md:mt-24 px-6 md:px-12 lg:px-24">
+        <div className="mx-auto max-w-[1400px]">
+          {loading ? (
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="animate-pulse rounded-[2rem] bg-foreground/5 aspect-[4/3]" />
+              ))}
+            </div>
+          ) : spaces.length === 0 ? (
+            <div className="space-y-8 py-48 text-center">
+              <h3 className="text-4xl font-bold tracking-tight opacity-20">NO FACILITIES FOUND</h3>
+              <p className="text-sm opacity-40 font-medium">
+                아직 등록된 공용 시설이 없습니다.
+              </p>
+            </div>
+          ) : (
+            <AnimatePresence mode="popLayout">
+              <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+                {spaces.map((space, index) => (
+                  <FacilityCard key={space.spaceId} space={space} index={index} />
+                ))}
+              </div>
+            </AnimatePresence>
+          )}
+        </div>
+      </section>
+
+      {/* Bottom CTA */}
+      <section className="mt-24 md:mt-48 px-6 md:px-12 lg:px-24">
+        <div className="mx-auto max-w-[1400px] space-y-6 md:space-y-12 rounded-[2rem] md:rounded-[4rem] bg-[#030213] p-8 py-8 md:p-24 text-center text-white">
+          <h2 className="text-2xl md:text-8xl font-black tracking-tighter leading-none">
+            READY TO <span className="text-[var(--color-accent)] underline underline-offset-8">STAY?</span>
+          </h2>
+          <p className="mx-auto max-w-2xl text-sm md:text-2xl font-medium text-white/40">
+            예약이 필요한 시설은 입주 후 STAY 메뉴에서 간편하게 예약하세요.
+          </p>
+          <Link
+            href="/facilities"
+            className="inline-flex items-center gap-3 h-12 md:h-24 px-8 md:px-16 rounded-xl md:rounded-2xl bg-[#2C3424] text-white hover:bg-[#768064] transition-all duration-500 text-xs md:text-xl font-black uppercase tracking-[0.2em]"
+          >
+            시설 예약하기
+            <ArrowRight className="h-4 w-4 md:h-6 md:w-6" />
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/rooms/[id]/_components/RoomGallery.tsx
+++ b/frontend/src/app/(public)/rooms/[id]/_components/RoomGallery.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import type { SpaceImageDTO } from '../../_types';
+
+interface RoomGalleryProps {
+  images: SpaceImageDTO[];
+}
+
+export function RoomGallery({ images }: RoomGalleryProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  if (!images || images.length === 0) return null;
+
+  const handleNext = () => setCurrentIndex((prev) => (prev + 1) % images.length);
+  const handlePrev = () => setCurrentIndex((prev) => (prev === 0 ? images.length - 1 : prev - 1));
+
+  return (
+    <div className="space-y-6">
+      <h3 className="text-sm md:text-base font-black tracking-[0.3em] uppercase opacity-30">
+        Gallery
+      </h3>
+      
+      <div className="p-4 md:p-6 rounded-2xl bg-foreground/[0.02] border border-foreground/[0.05]">
+        <div className="relative overflow-hidden rounded-[2rem] bg-foreground/5 aspect-[16/9] group mb-6">
+          <AnimatePresence mode="wait">
+            <motion.img
+              key={currentIndex}
+              src={images[currentIndex].imageUrl}
+              alt={`Gallery ${currentIndex + 1}`}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.3 }}
+              className="w-full h-full object-cover"
+            />
+          </AnimatePresence>
+
+          {images.length > 1 && (
+            <>
+              <button
+                onClick={handlePrev}
+                className="absolute left-4 md:left-8 top-1/2 -translate-y-1/2 p-3 rounded-full bg-background/80 text-foreground backdrop-blur-md opacity-0 group-hover:opacity-100 transition-opacity hover:scale-110"
+              >
+                <ChevronLeft size={24} />
+              </button>
+              <button
+                onClick={handleNext}
+                className="absolute right-4 md:right-8 top-1/2 -translate-y-1/2 p-3 rounded-full bg-background/80 text-foreground backdrop-blur-md opacity-0 group-hover:opacity-100 transition-opacity hover:scale-110"
+              >
+                <ChevronRight size={24} />
+              </button>
+
+              <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-4 py-2 rounded-full bg-black/50 backdrop-blur-md text-white text-xs font-bold tracking-widest">
+                {currentIndex + 1} / {images.length}
+              </div>
+            </>
+          )}
+        </div>
+
+        {images.length > 1 && (
+          <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory flex-nowrap hide-scrollbar pb-2">
+            {images.map((img, idx) => (
+              <button
+                key={img.spaceImageId || idx}
+                onClick={() => setCurrentIndex(idx)}
+                className={`relative shrink-0 w-20 h-20 md:w-28 md:h-28 rounded-2xl overflow-hidden snap-center transition-all duration-300 ${
+                  currentIndex === idx ? 'ring-2 ring-[var(--color-accent)] ring-offset-2 scale-95 opacity-100' : 'opacity-40 hover:opacity-100'
+                }`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img src={img.imageUrl} alt="Thumbnail" className="w-full h-full object-cover" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(public)/rooms/[id]/page.tsx
+++ b/frontend/src/app/(public)/rooms/[id]/page.tsx
@@ -10,6 +10,7 @@ import type { RoomDTO } from '../_types';
 import { HeroImage } from './_components/ImageCarousel';
 import { SpecGrid } from './_components/SpecTable';
 import { AmenityBadges } from './_components/AmenityBadges';
+import { RoomGallery } from './_components/RoomGallery';
 
 const STATUS_MAP: Record<string, { text: string; className: string }> = {
   AVAILABLE: {
@@ -164,6 +165,14 @@ export default function RoomDetailPage() {
               {/* Amenities */}
               <AmenityBadges amenities={room.amenities} />
             </div>
+
+            {/* Separator */}
+            <div className="h-px bg-foreground/10" />
+
+            {/* Image Gallery (내 도메인 전용 카드) */}
+            {room.images && room.images.length > 0 && (
+              <RoomGallery images={room.images} />
+            )}
           </div>
 
           {/* Reserve CTA — Editorial dark card */}

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -37,6 +37,7 @@ export interface SpaceDTO {
 
   // Images
   images?: {
+    spaceImageId?: number;
     imageUrl: string;
     imageType: string;
     isThumbnail: boolean;
@@ -108,6 +109,12 @@ export const updateSpace = async (spaceId: number, data: Partial<SpaceDTO> & Rec
 
 export const deleteSpace = async (spaceId: number) => {
   return await apiFetch<any>(`/admin/spaces/${spaceId}`, {
+    method: 'DELETE',
+  });
+};
+
+export const deleteSpaceImage = async (spaceId: number, imageId: number) => {
+  return await apiFetch<any>(`/admin/spaces/${spaceId}/images/${imageId}`, {
     method: 'DELETE',
   });
 };

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -44,8 +44,13 @@ export interface SpaceDTO {
   }[];
 }
 
-export const fetchSpaces = async () => {
-  const res = await apiFetch<any>('/admin/spaces');
+export const fetchSpaces = async (params?: { type?: string; status?: string }) => {
+  const query = new URLSearchParams();
+  if (params?.type && params.type !== 'ALL') query.append('type', params.type);
+  if (params?.status && params.status !== 'ALL') query.append('status', params.status);
+  
+  const queryString = query.toString() ? `?${query.toString()}` : '';
+  const res = await apiFetch<any>(`/admin/spaces${queryString}`);
   if (res.data?.content) {
     res.data.content = res.data.content.map((s: any) => ({
       ...s,

--- a/frontend/src/app/admin/spaces/_components/SpaceCreateModal.tsx
+++ b/frontend/src/app/admin/spaces/_components/SpaceCreateModal.tsx
@@ -27,6 +27,13 @@ export default function SpaceCreateModal({
 
   useEffect(() => {
     if (isOpen) {
+      setFormData({
+        type: 'PRIVATE',
+        status: 'AVAILABLE',
+        amenities: [],
+      });
+      setAmenityInput('');
+      setFiles([]);
       fetchRoomTypes()
         .then((res) => setRoomTypes(res.data || []))
         .catch(console.error);

--- a/frontend/src/app/admin/spaces/_components/SpaceCreateModal.tsx
+++ b/frontend/src/app/admin/spaces/_components/SpaceCreateModal.tsx
@@ -154,6 +154,24 @@ export default function SpaceCreateModal({
                 </select>
               </div>
             )}
+
+            {/* 예약 가능 여부 (COMMON만) */}
+            {formData.type === 'COMMON' && (
+              <div className="col-span-2 sm:col-span-1">
+                <label className="block text-sm font-bold mb-2">예약 가능 여부</label>
+                <button
+                  type="button"
+                  onClick={() => setFormData({ ...formData, isReservable: !formData.isReservable })}
+                  className={`w-full px-4 py-3 rounded-2xl font-bold tracking-tight transition-all duration-300 border ${
+                    formData.isReservable
+                      ? 'bg-[var(--color-accent)] text-white border-[var(--color-accent)]'
+                      : 'bg-[var(--color-muted)] text-[var(--foreground)]/60 border-transparent'
+                  }`}
+                >
+                  {formData.isReservable ? '✓ 예약제 (시설 예약 필요)' : '자유 이용 (예약 불필요)'}
+                </button>
+              </div>
+            )}
             <div className="col-span-1">
               <label className="block text-sm font-bold mb-2">해당 층</label>
               <input

--- a/frontend/src/app/admin/spaces/_components/SpaceEditModal.tsx
+++ b/frontend/src/app/admin/spaces/_components/SpaceEditModal.tsx
@@ -19,6 +19,7 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [roomTypes, setRoomTypes] = useState<RoomTypeDTO[]>([]);
   const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [amenityInput, setAmenityInput] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -26,6 +27,7 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
       setFormData({ ...space });
       setShowDeleteConfirm(false);
       setNewFiles([]);
+      setAmenityInput('');
     }
   }, [space]);
 
@@ -75,6 +77,23 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
         alert('이미지 삭제에 실패했습니다.');
       }
     }
+  };
+
+  const addAmenity = () => {
+    if (amenityInput.trim()) {
+      setFormData({
+        ...formData,
+        amenities: [...(formData.amenities || []), amenityInput.trim()],
+      });
+      setAmenityInput('');
+    }
+  };
+
+  const removeAmenity = (index: number) => {
+    setFormData({
+      ...formData,
+      amenities: formData.amenities?.filter((_, i) => i !== index),
+    });
   };
 
   const handleDragOver = (e: React.DragEvent) => e.preventDefault();
@@ -221,6 +240,31 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
                 value={formData.description || ''}
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setFormData({ ...formData, description: e.target.value })}
               />
+            </div>
+
+            {/* 옵션 / 부대시설 */}
+            <div className="mb-4">
+              <label className="block text-sm font-bold mb-2">옵션 / 부대시설 (어메니티)</label>
+              <div className="flex gap-2 mb-3">
+                <input
+                  type="text"
+                  value={amenityInput}
+                  onChange={(e) => setAmenityInput(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && addAmenity()}
+                  className="flex-1 px-4 py-3 rounded-2xl bg-[var(--color-muted)] text-[var(--foreground)] outline-none"
+                  placeholder="예: 에어컨 (입력 후 엔터)"
+                />
+                <button type="button" onClick={addAmenity} className="px-4 py-3 bg-[var(--color-accent)] text-white rounded-2xl font-bold">
+                  추가
+                </button>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {formData.amenities?.map((am, i) => (
+                  <span key={i} className="flex items-center gap-1 bg-black/10 px-3 py-1 rounded-full text-sm font-bold tracking-tight">
+                    {am} <button type="button" onClick={() => removeAmenity(i)}><X size={12} /></button>
+                  </span>
+                ))}
+              </div>
             </div>
 
             {/* PRIVATE 상세 */}

--- a/frontend/src/app/admin/spaces/_components/SpaceEditModal.tsx
+++ b/frontend/src/app/admin/spaces/_components/SpaceEditModal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Save, Trash2 } from 'lucide-react';
-import { updateSpace, deleteSpace, fetchRoomTypes, SpaceDTO, RoomTypeDTO } from '../_api/spaceAdminApi';
+import { X, Save, Trash2, UploadCloud } from 'lucide-react';
+import { updateSpace, deleteSpace, deleteSpaceImage, uploadSpaceImage, fetchRoomTypes, SpaceDTO, RoomTypeDTO } from '../_api/spaceAdminApi';
 
 interface SpaceEditModalProps {
   isOpen: boolean;
@@ -18,11 +18,14 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
   const [isDeleting, setIsDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [roomTypes, setRoomTypes] = useState<RoomTypeDTO[]>([]);
+  const [newFiles, setNewFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (space) {
       setFormData({ ...space });
       setShowDeleteConfirm(false);
+      setNewFiles([]);
     }
   }, [space]);
 
@@ -41,6 +44,11 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
     setIsSubmitting(true);
     try {
       await updateSpace(space.spaceId, formData);
+      
+      for (const [idx, file] of newFiles.entries()) {
+        await uploadSpaceImage(space.spaceId, file, !formData.images?.length && idx === 0);
+      }
+
       onUpdated();
       onClose();
     } catch (e: unknown) {
@@ -52,6 +60,33 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
     } finally {
       setIsSubmitting(false);
     }
+  };
+
+  const handleRemoveExistingImage = async (imageId?: number) => {
+    if (!space?.spaceId || !imageId) return;
+    if (confirm('이 이미지를 즉시 삭제하시겠습니까?')) {
+      try {
+        await deleteSpaceImage(space.spaceId, imageId);
+        setFormData(prev => ({
+          ...prev,
+          images: prev.images?.filter(img => img.spaceImageId !== imageId)
+        }));
+      } catch (e) {
+        alert('이미지 삭제에 실패했습니다.');
+      }
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent) => e.preventDefault();
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    if (e.dataTransfer.files) setNewFiles(prev => [...prev, ...Array.from(e.dataTransfer.files!)]);
+  };
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) setNewFiles(prev => [...prev, ...Array.from(e.target.files!)]);
+  };
+  const removeNewFile = (index: number) => {
+    setNewFiles(newFiles.filter((_, i) => i !== index));
   };
 
   const handleDelete = async () => {
@@ -110,6 +145,24 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
                 {space.type === 'PRIVATE' ? '개인 공간 (PRIVATE)' : '공용 공간 (COMMON)'}
               </div>
             </div>
+
+            {/* 예약 가능 여부 (COMMON만) */}
+            {space.type === 'COMMON' && (
+              <div className="mb-4">
+                <label className="block text-sm font-bold mb-2">예약 가능 여부</label>
+                <button
+                  type="button"
+                  onClick={() => setFormData({ ...formData, isReservable: !formData.isReservable })}
+                  className={`w-full px-4 py-3 rounded-2xl font-bold tracking-tight transition-all duration-300 border ${
+                    formData.isReservable
+                      ? 'bg-[var(--color-accent)] text-white border-[var(--color-accent)]'
+                      : 'bg-[var(--color-muted)] text-[var(--foreground)]/60 border-transparent'
+                  }`}
+                >
+                  {formData.isReservable ? '✓ 예약제 (시설 예약 필요)' : '자유 이용 (예약 불필요)'}
+                </button>
+              </div>
+            )}
 
             {/* 공간명 */}
             <div className="mb-4">
@@ -231,6 +284,59 @@ export default function SpaceEditModal({ isOpen, space, onClose, onUpdated }: Sp
                 </div>
               </div>
             )}
+
+            {/* 이미지 관리 */}
+            <div className="mt-6 border-t border-[var(--color-border)] pt-4">
+              <label className="block text-sm font-bold mb-2">이미지 관리</label>
+              
+              {/* 기존 이미지 */}
+              {formData.images && formData.images.length > 0 && (
+                <div className="mb-4">
+                  <p className="text-xs font-bold mb-2 opacity-60">기존 업로드된 이미지 (삭제 시 즉시 반영됩니다)</p>
+                  <div className="flex flex-wrap gap-3">
+                    {formData.images.map((img, i) => (
+                      <div key={i} className="relative w-20 h-20 rounded-2xl bg-black/10 flex items-center justify-center overflow-hidden group">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={img.imageUrl} alt="Space image" className="w-full h-full object-cover" />
+                        <button onClick={(e) => { e.stopPropagation(); handleRemoveExistingImage(img.spaceImageId); }} className="absolute bg-red-500 text-white p-1 rounded-full top-1 right-1 opacity-0 group-hover:opacity-100 transition cursor-pointer">
+                          <X size={12} />
+                        </button>
+                        {img.isThumbnail && (
+                          <span className="absolute bottom-1 left-1 bg-black/60 text-white text-[10px] px-1 py-0.5 rounded">대표</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* 새 이미지 드래그앤드롭 업로드 */}
+              <div 
+                onDragOver={handleDragOver}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+                className="w-full h-32 border-2 border-dashed border-[var(--color-border)] rounded-3xl flex flex-col items-center justify-center text-[var(--color-secondary)] hover:bg-black/5 transition cursor-pointer mb-4"
+              >
+                <UploadCloud size={32} className="mb-2" />
+                <p className="text-sm font-bold tracking-tighter cursor-pointer">여기를 클릭하거나 파일을 끌어다 놓아 새 이미지를 추가하세요</p>
+                <input type="file" multiple className="hidden" ref={fileInputRef} onChange={handleFileChange} />
+              </div>
+              
+              {/* 새 이미지 미리보기 */}
+              {newFiles.length > 0 && (
+                <div className="flex flex-wrap gap-3">
+                  {newFiles.map((f, i) => (
+                    <div key={i} className="relative w-20 h-20 rounded-2xl bg-black/10 flex items-center justify-center overflow-hidden group">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img src={URL.createObjectURL(f)} alt="Preview" className="w-full h-full object-cover" />
+                      <button onClick={(e) => { e.stopPropagation(); removeNewFile(i); }} className="absolute bg-red-500 text-white p-1 rounded-full top-1 right-1 opacity-0 group-hover:opacity-100 transition">
+                        <X size={12} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
 
             {/* 버튼 영역 */}
             <div className="flex items-center justify-between mt-6 gap-3">

--- a/frontend/src/app/admin/spaces/page.tsx
+++ b/frontend/src/app/admin/spaces/page.tsx
@@ -16,10 +16,15 @@ export default function SpacesPage() {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [editingSpace, setEditingSpace] = useState<SpaceDTO | null>(null);
 
+  // 필터 상태
+  const [filterType, setFilterType] = useState<'ALL' | 'PRIVATE' | 'COMMON'>('ALL');
+
   const loadSpaces = async () => {
     try {
-      const res = await fetchSpaces();
-      setSpaces(res.data?.content || []);
+      const res = await fetchSpaces({ type: filterType });
+      // 프론트엔드에서 간편하게 정렬 (이름순)
+      const sorted = (res.data?.content || []).sort((a: SpaceDTO, b: SpaceDTO) => a.name.localeCompare(b.name));
+      setSpaces(sorted);
     } catch (e) {
       console.error(e);
     }
@@ -27,7 +32,7 @@ export default function SpacesPage() {
 
   useEffect(() => {
     loadSpaces();
-  }, []);
+  }, [filterType]);
 
   const getStatusDisplay = (space: SpaceDTO) => {
     if (space.type === 'PRIVATE') {
@@ -93,7 +98,25 @@ export default function SpacesPage() {
 
       {/* 공간 관리 탭 */}
       {activeTab === 'spaces' && (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        <>
+          {/* 타입 필터 칩 */}
+          <div className="flex gap-2 mb-6">
+            {['ALL', 'PRIVATE', 'COMMON'].map((type) => (
+              <button
+                key={type}
+                onClick={() => setFilterType(type as any)}
+                className={`px-4 py-2 rounded-full text-xs font-bold tracking-widest uppercase transition-all
+                  ${filterType === type 
+                    ? 'bg-[var(--color-accent)] text-white shadow-md' 
+                    : 'bg-black/5 text-foreground hover:bg-black/10'
+                  }`}
+              >
+                {type === 'ALL' ? '전체 보기' : type}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
           {spaces.map((space: SpaceDTO, idx: number) => {
             const status = getStatusDisplay(space);
             const thumbnailUrl = space.images?.find(img => img.isThumbnail)?.imageUrl || space.images?.[0]?.imageUrl;
@@ -147,7 +170,8 @@ export default function SpacesPage() {
               </motion.div>
             );
           })}
-        </div>
+          </div>
+        </>
       )}
 
       {/* 방 유형 관리 탭 */}

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -22,6 +22,7 @@ const navItems: NavItem[] = [
     name: "Space",
     children: [
       { name: "Living", path: "/rooms" },
+      { name: "Experience", path: "/experience" },
       { name: "Stay", path: "/facilities" },
     ],
   },


### PR DESCRIPTION
Feat/59 공간 CRUD 버그 수정 및 갤러리 UI 추가

## 💡 배경 및 목적 (Why)
- 관리자 페이지의 공간(Space) 정보 수정/삭제 기능 중 발생하던 상태 캐싱 및 JPA 영속성 버그 해결
- 사용자 페이지(방/공용시설 상세)에 이미지 갤러리 슬라이드 뷰 추가

## 🔑 주요 변경 사항 (What)
- **[Back]** 관리자 이미지 단일 삭제 시 적용되지 않던 버그 수정 (JPA Cascade 문제 해결을 위해 검증 로직을 [existsById](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminSpacePersistenceAdapter.java:77:4-80:5)로 변경)
- **[Front-Admin]** 공간 생성 모달 닫기/재오픈 시 이전 입력 데이터가 남아있던 현상 초기화 기능 추가
- **[Front-Admin]** 공간 수정 모달에 누락되었던 '옵션/부대시설(Amenities)' 추가 및 삭제 기능 구현
- **[Front-Public]** [RoomGallery](cci:1://file:///c:/team1_cokkiri/frontend/src/app/%28public%29/rooms/%5Bid%5D/_components/RoomGallery.tsx:11:0-81:1), [FacilityGallery](cci:1://file:///c:/team1_cokkiri/frontend/src/app/%28public%29/experience/%5Bid%5D/_components/FacilityGallery.tsx:11:0-81:1) 이미지 슬라이드 컴포넌트 추가

## 🔗 연관된 이슈 (Issue / Ticket)
- Closes #59

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 프론트엔드 갤러리 컴포넌트는 글로벌 폴더가 아닌 도메인 하위 `_components`에 콜로케이션 룰을 준수하여 작성했습니다.
- 백엔드 JPA 삭제 이슈는 `@SQLDelete` 와 영속성 데이터(Cascade)가 충돌하여 발생하던 문제였으며, `existsById` 방식으로 안전하게 우회 처리했습니다.
