### PR TITLE
✨ [USR] 비밀번호 수정 기능 추가

### DIFF
--- a/frontend/src/app/(common)/profile/_components/password-change-modal.tsx
+++ b/frontend/src/app/(common)/profile/_components/password-change-modal.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { KeyRound, X } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/api";
+import { useAuthStore } from "@/store/useAuthStore";
+
+interface PasswordChangeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function PasswordChangeModal({ isOpen, onClose }: PasswordChangeModalProps) {
+  const logout = useAuthStore((state) => state.logout);
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordConfirm, setNewPasswordConfirm] = useState("");
+  
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setCurrentPassword("");
+      setNewPassword("");
+      setNewPasswordConfirm("");
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (newPassword !== newPasswordConfirm) {
+      setError("새 비밀번호가 서로 일치하지 않습니다.");
+      return;
+    }
+
+    const pattern = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]).{8,}$/;
+    if (!pattern.test(newPassword)) {
+      setError("비밀번호는 영문, 숫자, 특수문자를 포함하여 8자 이상이어야 합니다.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      await apiFetch("/users/me/password", {
+        method: "PUT",
+        body: JSON.stringify({ currentPassword, newPassword, newPasswordConfirm }),
+      });
+      alert("비밀번호가 성공적으로 변경되었습니다. 다시 로그인해주세요.");
+      onClose();
+      await logout();
+    } catch (err: any) {
+      setError(err instanceof ApiError ? err.message : "비밀번호 변경 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-[100] overflow-y-auto">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.3 }}
+            className="fixed inset-0 bg-primary/30 backdrop-blur-sm"
+            onClick={onClose}
+          />
+          <div className="flex min-h-full items-center justify-center p-6">
+
+          <motion.div
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.95 }}
+            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            className="relative w-full max-w-md rounded-[2rem] bg-background shadow-2xl"
+          >
+            <button
+              onClick={onClose}
+              className="absolute right-6 top-6 text-muted-foreground hover:text-foreground z-10 transition-colors"
+              aria-label="닫기"
+            >
+              <X className="h-6 w-6" />
+            </button>
+            <div className="p-8 md:p-10">
+              <div className="mb-6 flex items-center justify-center">
+                <div className="flex h-16 w-16 items-center justify-center rounded-full bg-secondary/10">
+                  <KeyRound className="h-8 w-8 text-primary" strokeWidth={1.5} />
+                </div>
+              </div>
+
+              <div className="text-center mb-8">
+                <h3 className="mb-2 text-2xl font-black tracking-tighter text-foreground uppercase">
+                  비밀번호 변경
+                </h3>
+                <p className="text-sm font-medium tracking-tight text-muted-foreground">
+                  계정 보호를 위해 새로운 비밀번호를 설정해주세요.
+                </p>
+              </div>
+
+              <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/70">
+                    현재 비밀번호
+                  </label>
+                  <input
+                    type="password"
+                    value={currentPassword}
+                    onChange={(e) => setCurrentPassword(e.target.value)}
+                    className="w-full rounded-xl border border-secondary/20 bg-background px-4 py-3 text-sm font-medium text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
+                    placeholder="현재 비밀번호 입력"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/70">
+                    새 비밀번호
+                  </label>
+                  <input
+                    type="password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                    className="w-full rounded-xl border border-secondary/20 bg-background px-4 py-3 text-sm font-medium text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
+                    placeholder="영문, 숫자, 특수문자 조합 8자 이상"
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/70">
+                    새 비밀번호 확인
+                  </label>
+                  <input
+                    type="password"
+                    value={newPasswordConfirm}
+                    onChange={(e) => setNewPasswordConfirm(e.target.value)}
+                    className="w-full rounded-xl border border-secondary/20 bg-background px-4 py-3 text-sm font-medium text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
+                    placeholder="새 비밀번호 다시 입력"
+                    required
+                  />
+                </div>
+
+                <AnimatePresence>
+                  {error && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: "auto" }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="overflow-hidden"
+                    >
+                      <p className="text-sm font-bold text-red-500 mt-2">
+                        {error}
+                      </p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+
+                <div className="mt-4 flex flex-col gap-3 font-sans">
+                  <motion.button
+                    type="submit"
+                    disabled={isLoading}
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    className="w-full rounded-xl bg-primary px-6 py-4 text-sm font-bold tracking-widest text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed uppercase"
+                  >
+                    {isLoading ? "변경 중..." : "비밀번호 변경하기"}
+                  </motion.button>
+                </div>
+              </form>
+            </div>
+          </motion.div>
+          </div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/app/(common)/profile/_components/profile-info.tsx
+++ b/frontend/src/app/(common)/profile/_components/profile-info.tsx
@@ -5,11 +5,14 @@ import { apiFetch, ApiError } from "@/lib/api";
 import { Profile } from "../_types/profile";
 import { UserRound } from "lucide-react";
 import { motion } from "framer-motion";
+import { PasswordChangeModal } from "./password-change-modal";
 
 export default function ProfileInfo() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -141,12 +144,18 @@ export default function ProfileInfo() {
           <motion.button 
             whileHover={{ scale: 1.02, y: -2 }}
             whileTap={{ scale: 0.98 }}
+            onClick={() => setIsPasswordModalOpen(true)}
             className="rounded-none border border-primary/20 bg-transparent px-8 py-4 text-primary transition-colors hover:bg-primary/5 hover:border-primary text-xs font-black uppercase tracking-[0.2em]"
           >
             비밀번호 변경
           </motion.button>
         </div>
       </div>
+
+      <PasswordChangeModal 
+        isOpen={isPasswordModalOpen} 
+        onClose={() => setIsPasswordModalOpen(false)} 
+      />
     </motion.div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -39,7 +39,18 @@ export async function apiFetch<T>(
       );
     }
     if (response.status === 401) {
-      if (path !== '/auth/login' && path !== '/auth/refresh' && path !== '/auth/logout' && !isRefreshing) {
+      let isTokenError = true;
+      let parsedData: ApiResponse<T> | null = null;
+      
+      if (looksJson && trimmed.length > 0) {
+        parsedData = parseApiJson<T>(trimmed);
+        const eCode = (parsedData as any).errorCode || (parsedData as any).error_code;
+        if (eCode && eCode !== 'UNAUTHORIZED' && eCode !== 'TOKEN_EXPIRED') {
+          isTokenError = false;
+        }
+      }
+
+      if (isTokenError && path !== '/auth/login' && path !== '/auth/refresh' && path !== '/auth/logout' && !isRefreshing) {
         isRefreshing = true;
         try {
           const refreshRes = await fetch(`${BASE_URL}/auth/refresh`, { method: 'POST', credentials: 'include' });
@@ -60,10 +71,10 @@ export async function apiFetch<T>(
         }
       }
 
-      // 백엔드가 JSON 에러 메시지를 보낸 경우(예: 로그인 실패) 그것을 우선 사용
-      if (looksJson && trimmed.length > 0) {
-        const data = parseApiJson<T>(trimmed);
-        throw new ApiError(data.message || LOGIN_REQUIRED_MESSAGE, data.error_code || 'UNAUTHORIZED');
+      // 백엔드가 JSON 에러 메시지를 보낸 경우(예: 로그인 실패, 비밀번호 불일치 등) 그것을 우선 사용
+      if (parsedData) {
+        const eCode = (parsedData as any).errorCode || (parsedData as any).error_code;
+        throw new ApiError(parsedData.message || LOGIN_REQUIRED_MESSAGE, eCode || 'UNAUTHORIZED');
       }
       throw new ApiError(LOGIN_REQUIRED_MESSAGE, 'UNAUTHORIZED');
     }
@@ -81,7 +92,8 @@ export async function apiFetch<T>(
   const data = parseApiJson<T>(trimmed);
 
   if (!data.success) {
-    throw new ApiError(data.message || '요청에 실패했습니다', data.error_code);
+    const eCode = (data as any).errorCode || (data as any).error_code;
+    throw new ApiError(data.message || '요청에 실패했습니다', eCode);
   }
 
   return data;


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 사용자가 능동적으로 계정 보안을 갱신/강화할 수 있는 안전한 비밀번호 수정 플로우를 신규 도입합니다.
- 개인정보 보호 가이드라인을 준수하며, 정보 변경 직후 기존 세션(토큰) 파기를 통한 보안 취약점 사전 차단이 목적입니다.

## 🔑 주요 변경 사항 (What)
- **[Backend] 비밀번호 수정 비즈니스 로직 및 API 구현 ([ProfileService](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/profile/application/service/ProfileService.java:15:0-52:1), [ProfileController](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/profile/adapter/in/web/ProfileController.java:23:0-73:1))**
  - 기존 비밀번호 일치 심사 및 새로운 비밀번호의 BCrypt 해싱 저장 로직 구현
  - 영문+숫자+특수문자 조합을 강제하는 8자 이상 정규식 백엔드 단독 검증 추가
  - 이전과 완벽히 동일한 비밀번호 변경 방지 처리 (`SAME_PASSWORD(400)` 예외)
  - 암호 변경 성공 직후 `LogoutUseCase` 연동을 통한 모든 발급된 토큰(Access, Refresh) 즉시 블랙리스트 파기
- **[Frontend] [PasswordChangeModal](cci:1://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28common%29/profile/_components/password-change-modal.tsx:13:0-181:1) 신규 UI 컴포넌트 추가**
  - **Moss & Aloe Editorial** 디자인 시스템을 엄격히 적용한 프리미엄 테마 모달 구현
  - 브라우저 뷰포트 크기가 작을 때 화면 하단이 잘리는 현상 방지를 위해, 모달 오버레이 래퍼 전체에 `overflow-y-auto` 스크롤 대응 추가
- **[Frontend] API 글로벌 패치 모듈([api.ts](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/lib/api.ts:0:0-0:0)) 401 무한루프 버그 핫픽스**
  - Spring Boot에서 직렬화 응답된 JSON 필드 낙타표기법(`errorCode`)을 프론트엔드가 제대로 파싱하지 못해, 정상적인 비즈니스 오류(`INVALID_PASSWORD(401)`)를 토큰 만료로 오인해 재시도(Refresh) 루프에 빠지던 문제를 완전히 해결

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves # (이슈 번호 작성)

## 💻 테스트 방법 (How to Test)
1. 프론트엔드 및 백엔드 로컬 서버 구동 후 로그인하여 `http://localhost:3000/profile` ('내 프로필') 로 진입
2. [비밀번호 변경] 버튼을 눌러 모달 창을 띄우고 아래와 같은 실패/검증 분기 케이스를 테스트합니다.
   - 현재 암호를 틀리거나 이전과 동일한 비밀번호 입력 -> 화면 내 로컬 에러 모달 메시지 확인
   - 새 보안 기준(영문+숫자+특수문자 8자 이상) 미충족 -> 검증 차단 확인
3. 현재 사용 중인 올바른 비밀번호와 갱신할 새 비밀번호를 정상적으로 입력 후 확인 클릭
4. 모달이 닫히며 즉각적으로 메인(`/`) 화면 혹은 로그인 폼으로 강제 로그아웃됨을 확인합니다.
5. 이전 방식에 탈취된 구버전의 캐시된 복사본 토큰으로 다시 강제 접근이 막히는지 확인합니다 (Token Blacklist).

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- (뷰어용 내 프로필 화면 비밀번호 모달 오픈 / 입력 예시 화면 캡처 업로드 예정)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 프론트엔드의 전역 인터셉터 격인 [api.ts](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/lib/api.ts:0:0-0:0) 에서 향후 백엔드에서 뱉는 `error_code` 키 값을 백엔드 디폴트 응답인 `errorCode` 형태로도 유연하게 매핑할 수 있도록 수정했습니다. 덕분에 401 무한 루프 에러가 앞으로 더는 뜨지 않게 픽스했으니 참고해 주세요!
- 비밀번호만 바뀌어도 보안 차원에서 [ProfileController](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/profile/adapter/in/web/ProfileController.java:23:0-73:1) 컨트롤러 내에서 직접적으로 `LogoutUseCase`를 엮어 기존 남은 서버쪽 세션까지 다 태워버리도록 하드하게 설계했습니다.
- 관련된 기능을 확인하실 분들을 멘션합니다. @username

Closes #53 
