### PR TITLE
🐛 [USR] 회원가입 양식 자동 완성 및 디자인 수정

### DIFF
--- a/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java
@@ -4,6 +4,7 @@ import com.coliving.common.auth.model.Gender;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,24 +15,30 @@ import lombok.Setter;
 public class RegisterRequestDto {
 
     @NotBlank(message = "아이디를 입력해주세요.")
+    @Size(min = 4, max = 50, message = "아이디는 4자 이상 50자 이하로 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문자와 숫자로만 구성되어야 합니다.")
     private String loginId;
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, message = "비밀번호는 8자 이상 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]+$", message = "비밀번호는 영문자, 숫자, 특수문자를 포함해야 합니다.")
     private String password;
 
     @NotBlank(message = "비밀번호 확인을 입력해주세요.")
     private String passwordConfirm;
 
     @NotBlank(message = "이름을 입력해주세요.")
+    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
     private String name;
 
+    @Pattern(regexp = "^\\d{6}$", message = "생년월일은 YYMMDD 형식의 6자리 숫자로 입력해주세요.")
     private String birthDate;
 
     private Gender gender;
 
     private String nationality;
 
-    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "올바른 연락처 형식(000-0000-0000)이 아닙니다.")
+    @Pattern(regexp = "^(02-\\d{3,4}-\\d{4}|0\\d{2}-\\d{3,4}-\\d{4}|)$", message = "올바른 연락처 형식이 아닙니다.")
     private String phone;
 
     @NotBlank(message = "이메일을 입력해주세요.")

--- a/frontend/src/app/(auth)/register/_components/register-form.tsx
+++ b/frontend/src/app/(auth)/register/_components/register-form.tsx
@@ -21,32 +21,102 @@ export default function RegisterForm() {
     email: '',
   });
   
-  const [error, setError] = useState<string | null>(null);
+  const [globalError, setGlobalError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
+  const [isGenderOpen, setIsGenderOpen] = useState(false);
+  const [isDateWidgetOpen, setIsDateWidgetOpen] = useState(false);
+  const [dateWidgetStep, setDateWidgetStep] = useState<'YEAR' | 'MONTH' | 'DAY'>('YEAR');
+  const [tempDate, setTempDate] = useState({ year: 2000, month: 1, day: 1 });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-    const { name, value } = e.target;
+    let { name, value } = e.target;
+    
+    // Phone auto-format (supports 02- and other region/mobile codes)
+    if (name === 'phone') {
+      value = value.replace(/[^0-9]/g, '');
+      if (value.startsWith('02')) {
+        if (value.length > 10) value = value.slice(0, 10);
+        if (value.length > 2 && value.length <= 5) {
+          value = value.replace(/(\d{2})(\d{1,3})/, '$1-$2');
+        } else if (value.length > 5 && value.length < 10) {
+          value = value.replace(/(\d{2})(\d{3})(\d{1,4})/, '$1-$2-$3');
+        } else if (value.length === 10) {
+          value = value.replace(/(\d{2})(\d{4})(\d{4})/, '$1-$2-$3');
+        }
+      } else {
+        if (value.length > 11) value = value.slice(0, 11);
+        if (value.length > 3 && value.length <= 6) {
+          value = value.replace(/(\d{3})(\d{1,3})/, '$1-$2');
+        } else if (value.length > 6 && value.length < 11) {
+          value = value.replace(/(\d{3})(\d{3})(\d{1,4})/, '$1-$2-$3');
+        } else if (value.length === 11) {
+          value = value.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+        }
+      }
+    }
+
     setFormData(prev => ({ ...prev, [name]: value }));
+    // Clear error for the field being edited
+    if (fieldErrors[name]) {
+      setFieldErrors(prev => ({ ...prev, [name]: '' }));
+    }
+    if (globalError) setGlobalError(null);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    setError(null);
+    setGlobalError(null);
+    setFieldErrors({});
 
-    if (!formData.loginId || !formData.password || !formData.passwordConfirm || !formData.name || !formData.email) {
-      setError('필수 정보를 모두 입력해주세요.');
-      return;
+    const errors: Record<string, string> = {};
+
+    let finalBirthDate = formData.birthDate;
+    if (finalBirthDate.includes('-')) {
+      const parts = finalBirthDate.split('-');
+      if (parts.length === 3) {
+        finalBirthDate = parts[0].slice(2) + parts[1] + parts[2];
+      }
     }
 
-    if (formData.password !== formData.passwordConfirm) {
-      setError('비밀번호가 일치하지 않습니다.');
-      return;
+    if (!formData.loginId) errors.loginId = "아이디를 입력해주세요.";
+    else if (formData.loginId.length < 4 || formData.loginId.length > 50 || !/^[a-zA-Z0-9]+$/.test(formData.loginId)) {
+      errors.loginId = "아이디는 4~50자의 영문자와 숫자로만 구성되어야 합니다.";
+    }
+
+    if (!formData.password) errors.password = "비밀번호를 입력해주세요.";
+    else if (formData.password.length < 8 || !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]+$/.test(formData.password)) {
+      errors.password = "비밀번호는 영문자, 숫자, 특수문자를 포함해 8자 이상이어야 합니다.";
+    }
+
+    if (!formData.passwordConfirm) errors.passwordConfirm = "비밀번호 확인을 입력해주세요.";
+    else if (formData.password !== formData.passwordConfirm) {
+      errors.passwordConfirm = "비밀번호가 일치하지 않습니다.";
+    }
+
+    if (!formData.name) errors.name = "이름을 입력해주세요.";
+    else if (formData.name.length < 2 || formData.name.length > 50) {
+      errors.name = "이름은 2~50자로 입력해주세요.";
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(formData.email)) {
-      setError('올바른 이메일 형식을 입력해주세요.');
+    if (!formData.email) errors.email = "이메일을 입력해주세요.";
+    else if (!emailRegex.test(formData.email)) {
+      errors.email = "올바른 이메일 형식이 아닙니다.";
+    }
+
+    if (finalBirthDate && !/^\d{6}$/.test(finalBirthDate)) {
+      errors.birthDate = "생년월일은 올바른 날짜로 입력해주세요.";
+    }
+
+    if (formData.phone && !/^(02-\d{3,4}-\d{4}|0\d{2}-\d{3,4}-\d{4})$/.test(formData.phone)) {
+      errors.phone = "올바른 연락처 형식이 아닙니다.";
+    }
+
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      setGlobalError("입력 정보를 다시 확인해주세요.");
       return;
     }
 
@@ -54,7 +124,10 @@ export default function RegisterForm() {
       setLoading(true);
       await apiFetch('/auth/register', {
         method: 'POST',
-        body: JSON.stringify(formData),
+        body: JSON.stringify({
+          ...formData,
+          birthDate: finalBirthDate
+        }),
       });
       setSuccess(true);
       setTimeout(() => {
@@ -62,15 +135,16 @@ export default function RegisterForm() {
       }, 1500);
     } catch (err) {
       if (err instanceof ApiError) {
-        setError(err.message);
+        setGlobalError(err.message);
       } else {
-        setError('알 수 없는 오류가 발생했습니다.');
+        setGlobalError('알 수 없는 오류가 발생했습니다.');
       }
       setLoading(false);
     }
   };
 
-  const inputClasses = "w-full border-b border-primary/20 bg-transparent px-0 py-3 text-lg font-medium text-primary outline-none focus:border-accent transition-colors placeholder:text-primary/30";
+  const getInputClasses = (hasError: boolean) => 
+    `w-full border-b bg-transparent px-0 py-3 text-lg font-medium text-primary outline-none transition-colors placeholder:text-primary/30 ${hasError ? 'border-red-500 focus:border-red-500' : 'border-primary/20 focus:border-accent'}`;
   const labelClasses = "block text-[10px] font-black uppercase tracking-[0.3em] text-primary/60 mb-1";
 
   const containerVariants = {
@@ -112,16 +186,16 @@ export default function RegisterForm() {
       className="flex flex-col gap-10"
     >
       <AnimatePresence>
-        {error && (
+        {globalError && (
           <motion.div 
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: 'auto' }}
             exit={{ opacity: 0, height: 0 }}
             className="overflow-hidden"
           >
-            <div className="flex items-center gap-3 rounded-2xl bg-red-500/10 p-4 text-sm font-medium text-red-600">
+            <div className="flex items-center gap-3 rounded-2xl bg-red-500/10 p-4 text-sm font-medium text-red-600 mb-6">
               <AlertCircle className="h-5 w-5 shrink-0" />
-              <p>{error}</p>
+              <p>{globalError}</p>
             </div>
           </motion.div>
         )}
@@ -130,17 +204,21 @@ export default function RegisterForm() {
       <motion.div variants={itemVariants} className="space-y-10">
         <div>
           <label className={labelClasses}>LOGIN ID *</label>
-          <input name="loginId" value={formData.loginId} onChange={handleChange} className={inputClasses} placeholder="아이디를 입력하세요 (4자 이상)" />
+          <input name="loginId" value={formData.loginId} onChange={handleChange} className={getInputClasses(!!fieldErrors.loginId)} placeholder="아이디를 입력하세요 (4자 이상)" />
+          {fieldErrors.loginId && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.loginId}</p>}
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
           <div>
             <label className={labelClasses}>PASSWORD *</label>
-            <input name="password" type="password" value={formData.password} onChange={handleChange} className={inputClasses} placeholder="비밀번호" />
+            <input name="password" type="password" value={formData.password} onChange={handleChange} className={getInputClasses(!!fieldErrors.password)} placeholder="비밀번호" />
+            <p className="text-primary/40 text-xs mt-2 font-medium tracking-tight">8자 이상, 영문+숫자+특수문자 조합</p>
+            {fieldErrors.password && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.password}</p>}
           </div>
           <div>
             <label className={labelClasses}>CONFIRM PASSWORD *</label>
-            <input name="passwordConfirm" type="password" value={formData.passwordConfirm} onChange={handleChange} className={inputClasses} placeholder="비밀번호 재입력" />
+            <input name="passwordConfirm" type="password" value={formData.passwordConfirm} onChange={handleChange} className={getInputClasses(!!fieldErrors.passwordConfirm)} placeholder="비밀번호 재입력" />
+            {fieldErrors.passwordConfirm && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.passwordConfirm}</p>}
           </div>
         </div>
       </motion.div>
@@ -149,36 +227,145 @@ export default function RegisterForm() {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
           <div>
             <label className={labelClasses}>FULL NAME *</label>
-            <input name="name" value={formData.name} onChange={handleChange} className={inputClasses} placeholder="이름을 입력하세요" />
+            <input name="name" value={formData.name} onChange={handleChange} className={getInputClasses(!!fieldErrors.name)} placeholder="이름을 입력하세요" />
+            {fieldErrors.name && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.name}</p>}
           </div>
           <div>
             <label className={labelClasses}>EMAIL ADDRESS *</label>
-            <input name="email" type="email" value={formData.email} onChange={handleChange} className={inputClasses} placeholder="cokkiri@example.com" />
+            <input name="email" type="email" value={formData.email} onChange={handleChange} className={getInputClasses(!!fieldErrors.email)} placeholder="cokkiri@example.com" />
+            {fieldErrors.email && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.email}</p>}
           </div>
         </div>
 
         <div>
           <label className={labelClasses}>PHONE NUMBER</label>
-          <input name="phone" value={formData.phone} onChange={handleChange} className={inputClasses} placeholder="010-0000-0000" />
+          <input name="phone" value={formData.phone} onChange={handleChange} className={getInputClasses(!!fieldErrors.phone)} placeholder="010-0000-0000" />
+          {fieldErrors.phone && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.phone}</p>}
         </div>
       </motion.div>
 
       <motion.div variants={itemVariants} className="space-y-10">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
-          <div className="col-span-1 md:col-span-1">
+          <div className="col-span-1 md:col-span-1 relative flex flex-col justify-end z-20">
              <label className={labelClasses}>M/F</label>
-             <select name="gender" value={formData.gender} onChange={handleChange} className={`${inputClasses} appearance-none cursor-pointer`}>
-               <option value="MALE">MALE (남성)</option>
-               <option value="FEMALE">FEMALE (여성)</option>
-             </select>
+             <div 
+               onClick={() => setIsGenderOpen(!isGenderOpen)}
+               className={`${getInputClasses(false)} cursor-pointer flex justify-between items-center`}
+             >
+               <span>{formData.gender === 'MALE' ? 'MALE (남성)' : 'FEMALE (여성)'}</span>
+               <motion.span animate={{ rotate: isGenderOpen ? 180 : 0 }} className="text-[10px] text-primary/40">▼</motion.span>
+             </div>
+             
+             {/* Backdrop to close when clicking outside */}
+             {isGenderOpen && (
+               <div className="fixed inset-0 z-40" onClick={() => setIsGenderOpen(false)} />
+             )}
+             
+             <AnimatePresence>
+               {isGenderOpen && (
+                 <motion.div 
+                   initial={{ opacity: 0, y: 10, filter: 'blur(4px)' }}
+                   animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                   exit={{ opacity: 0, y: 10, filter: 'blur(4px)' }}
+                   transition={{ duration: 0.2 }}
+                   className="absolute bottom-full left-0 right-0 mb-3 bg-[#e8ebe6] border border-primary/10 rounded-lg shadow-xl overflow-hidden z-50 origin-bottom"
+                 >
+                   <div 
+                     onClick={() => { setFormData(p => ({...p, gender: 'MALE'})); setIsGenderOpen(false); }}
+                     className="px-5 py-4 cursor-pointer hover:bg-primary/5 transition-colors flex items-center justify-between border-b border-primary/5 group relative"
+                   >
+                     {formData.gender === 'MALE' && <motion.div layoutId="gender-active" className="absolute left-0 top-0 bottom-0 w-1 bg-accent" />}
+                     <span className="font-black tracking-tight text-primary group-hover:tracking-widest transition-all duration-300">MALE</span>
+                     <span className="text-[10px] text-primary/50 font-bold uppercase tracking-[0.2em]">남성</span>
+                   </div>
+                   <div 
+                     onClick={() => { setFormData(p => ({...p, gender: 'FEMALE'})); setIsGenderOpen(false); }}
+                     className="px-5 py-4 cursor-pointer hover:bg-primary/5 transition-colors flex items-center justify-between group relative"
+                   >
+                     {formData.gender === 'FEMALE' && <motion.div layoutId="gender-active" className="absolute left-0 top-0 bottom-0 w-1 bg-accent" />}
+                     <span className="font-black tracking-tight text-primary group-hover:tracking-widest transition-all duration-300">FEMALE</span>
+                     <span className="text-[10px] text-primary/50 font-bold uppercase tracking-[0.2em]">여성</span>
+                   </div>
+                 </motion.div>
+               )}
+             </AnimatePresence>
           </div>
-          <div className="col-span-1 md:col-span-1">
+          <div className="col-span-1 md:col-span-1 flex flex-col justify-end relative z-30">
             <label className={labelClasses}>BIRTH DATE</label>
-            <input name="birthDate" value={formData.birthDate} onChange={handleChange} className={inputClasses} placeholder="YYMMDD" />
+            <div 
+              onClick={() => {
+                setIsDateWidgetOpen(true);
+                setDateWidgetStep('YEAR');
+              }}
+              className={`${getInputClasses(!!fieldErrors.birthDate)} cursor-pointer flex items-center justify-between`}
+            >
+               <span className={formData.birthDate ? 'text-primary' : 'text-primary/30'}>
+                 {formData.birthDate ? formData.birthDate : 'YYYY-MM-DD'}
+               </span>
+            </div>
+            
+            {/* Backdrop to close date widget */}
+            {isDateWidgetOpen && (
+               <div className="fixed inset-0 z-40" onClick={() => setIsDateWidgetOpen(false)} />
+            )}
+
+            <AnimatePresence>
+              {isDateWidgetOpen && (
+                <motion.div 
+                   initial={{ opacity: 0, y: 10, filter: 'blur(4px)' }}
+                   animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
+                   exit={{ opacity: 0, y: 10, filter: 'blur(4px)' }}
+                   transition={{ duration: 0.2 }}
+                   className="absolute bottom-full left-0 md:-left-20 w-[290px] mb-3 p-5 bg-[#e8ebe6] border border-primary/10 rounded-lg shadow-xl z-50 origin-bottom"
+                 >
+                   <div className="flex justify-between border-b border-primary/10 pb-3 mb-4 text-xs tracking-widest font-bold text-primary/50 uppercase">
+                      <button type="button" onClick={() => setDateWidgetStep('YEAR')} className={`hover:text-primary transition-colors ${dateWidgetStep === 'YEAR' ? 'text-primary border-b-2 border-accent pb-1 -mb-3' : ''}`}>{tempDate.year || 'YYYY'}</button>
+                      <span className="font-thin">/</span>
+                      <button type="button" onClick={() => setDateWidgetStep('MONTH')} className={`hover:text-primary transition-colors ${dateWidgetStep === 'MONTH' ? 'text-primary border-b-2 border-accent pb-1 -mb-3' : ''}`}>{tempDate.month ? String(tempDate.month).padStart(2, '0') : 'MM'}</button>
+                      <span className="font-thin">/</span>
+                      <button type="button" onClick={() => setDateWidgetStep('DAY')} className={`hover:text-primary transition-colors ${dateWidgetStep === 'DAY' ? 'text-primary border-b-2 border-accent pb-1 -mb-3' : ''}`}>{tempDate.day ? String(tempDate.day).padStart(2, '0') : 'DD'}</button>
+                   </div>
+                   
+                   <div className="h-48 overflow-y-auto [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-primary/20 [&::-webkit-scrollbar-thumb]:rounded-full pr-2">
+                     {dateWidgetStep === 'YEAR' && (
+                       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="grid grid-cols-4 gap-2">
+                         {Array.from({length: 70}, (_, i) => new Date().getFullYear() - 69 + i).reverse().map(y => (
+                           <div key={y} onClick={() => { setTempDate(p => ({...p, year: y})); setDateWidgetStep('MONTH'); }} className={`text-center py-2 cursor-pointer rounded-lg text-sm transition-colors ${tempDate.year === y ? 'bg-primary text-background font-bold' : 'hover:bg-primary/5 text-primary'}`}>{y}</div>
+                         ))}
+                       </motion.div>
+                     )}
+                     {dateWidgetStep === 'MONTH' && (
+                       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="grid grid-cols-4 gap-2">
+                         {Array.from({length: 12}, (_, i) => i + 1).map(m => (
+                           <div key={m} onClick={() => { setTempDate(p => ({...p, month: m})); setDateWidgetStep('DAY'); }} className={`text-center py-2 cursor-pointer rounded-lg text-sm transition-colors ${tempDate.month === m ? 'bg-primary text-background font-bold' : 'hover:bg-primary/5 text-primary'}`}>{m}</div>
+                         ))}
+                       </motion.div>
+                     )}
+                     {dateWidgetStep === 'DAY' && (
+                       <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="grid grid-cols-5 gap-2">
+                         {Array.from({length: new Date(tempDate.year, tempDate.month, 0).getDate()}, (_, i) => i + 1).map(d => (
+                           <div key={d} onClick={() => { 
+                                setTempDate(p => ({...p, day: d}));
+                                const finalDate = `${tempDate.year}-${String(tempDate.month).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+                                setFormData(p => ({...p, birthDate: finalDate})); 
+                                setIsDateWidgetOpen(false); 
+                              }} 
+                              className={`text-center py-2 cursor-pointer rounded-lg text-sm transition-colors ${tempDate.day === d ? 'bg-primary text-background font-bold' : 'hover:bg-primary/5 text-primary'}`}
+                           >
+                             {d}
+                           </div>
+                         ))}
+                       </motion.div>
+                     )}
+                   </div>
+                 </motion.div>
+              )}
+            </AnimatePresence>
+            {fieldErrors.birthDate && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.birthDate}</p>}
           </div>
-          <div className="col-span-1 md:col-span-1">
+          <div className="col-span-1 md:col-span-1 flex flex-col justify-end">
             <label className={labelClasses}>NATION</label>
-            <input name="nationality" value={formData.nationality} onChange={handleChange} className={inputClasses} placeholder="대한민국" />
+            <input name="nationality" value={formData.nationality} onChange={handleChange} className={getInputClasses(false)} placeholder="대한민국" />
           </div>
         </div>
       </motion.div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -12,3 +12,12 @@
     text-wrap: balance;
   }
 }
+
+/* Fix for Webkit autofill background */
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active {
+  transition: background-color 5000s ease-in-out 0s;
+  -webkit-text-fill-color: var(--primary) !important;
+}


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 회원가입(Registration) 폼의 데이터 무결성을 보장하기 위해 백엔드와 프론트엔드 양측에 강력한 유효성 검사를 구축합니다.
- 단순한 정보 입력을 넘어 프로젝트의 차별화된 **'Moss & Aloe Editorial'** 디자인 가이드라인에 완벽히 부합하도록 낡은 브라우저 기본 입력 형태를 대체하고, 하이엔드 포맷팅 기술과 커스텀 애니메이션을 통해 최상의 사용자 경험(UX)을 제공하기 위함입니다.

## 🔑 주요 변경 사항 (What)
- **강력한 데이터 유효성 검사 (BE/FE 연동):** [RegisterRequestDto](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java:11:0-46:1) 및 [register-form.tsx](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28auth%29/register/_components/register-form.tsx:0:0-0:0)에 정규식(Regex) 기반의 엄격한 유효성 필터(아이디, 비밀번호, 생년월일, 이메일, 폰번호) 도입
- **스마트 전화번호 포매팅:** 사용자가 입력 시 일반 `010` 모바일 번호와 `02` 국선 지역번호를 실시간으로 지능적으로 구분하여 알맞은 위치에 하이픈(-) 자동 추가 및 자릿수 제한 처리
- **에디토리얼 스타일 위젯 구현 (Framer Motion):**
  - `<select>` 태그를 제거하고 블러 트랜지션 및 다이내믹 호버 효과(`tracking-widest`)가 적용된 **M/F 성별 커스텀 드롭다운** 구현
  - `<input type="date">` 달력을 치워버리고, Year → Month → Day 순으로 직관적으로 짚고 넘어가는 유니크한 **생년월일(Birth Date) 커스텀 그리드 위젯** 개발
- **레이아웃 스크롤 버그 개선:** 팝업 위젯이 하단으로 열려 발생하던 '수직 스크롤바 생성 및 화면 꿀렁임' 현상을 막기 위해, 위젯의 모션 앵커를 위 방향(Upward)으로 전면 튜닝
- **전역 CSS 픽스:** 브라우저 자동 완성 시 입력창 배경색이 하얗게 덮이는 `:-webkit-autofill` 스타일 버그를 테마에 동화되도록 픽스

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #224

## 💻 테스트 방법 (How to Test)
1. 로컬 환경에서 브라우저를 띄워 `/register` 경로로 이동합니다.
2. 전화번호 입력란에 `0212345678`과 `01012345678`을 연속 타이핑해보고, 길이가 다른 02 규칙과 010 규칙 모두 하이픈(-)이 정상적으로 쪼개져 보이는지 확인합니다.
3. `M/F` 칸과 `BIRTH DATE` 칸을 클릭하여, 팝업이 아래 방향이 아닌 **위 방향**으로 깔끔하게 솟아오르는지(레이아웃 겹침이 없는지) 위젯 애니메이션을 확인합니다.
4. 백엔드를 기동한 후 일부러 형식이 틀린 정보(비밀번호 정책 미만 등)를 입력하고 Submit을 날려 올바른 에러 메시지가 서버/클라이언트 단에서 노출되는지 체크합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
*(리뷰어가 시각적으로 파악하기 쉽도록 커스텀화 된 연/월/일 날짜 위젯 화면 캡처나 부드럽게 위로 열리는 드롭다운 애니메이션 GIF를 여기에 첨부해 주세요.)*

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- Framer Motion을 적극 활용하여 기존의 밋밋한 폼을 에디토리얼 형식의 커스텀 위젯으로 완전히 교체해 보았습니다. 스크롤 충돌을 막기 위해 팝업을 상단으로 쏘아 올리도록 애니메이션 기준점(`origin-bottom`)을 조절해 두었습니다. 잔잔한 속도나 블러 트랜지션에 대한 사용 경험 피드백 나눠주시면 감사하겠습니다! 
- 여기서 구현한 날짜 커스텀 위젯의 반응이 좋다면, 추후 다른 도메인의 폼(예: 관리자 공간 등록, 계약 신청 폼 등)에도 공용 UI 컴포넌트로 분리하여 점진적으로 이식하는 쪽을 고려 중입니다.
