### PR TITLE
🔀 show contract-expired booking error modal

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/DataInitializer.java
@@ -403,7 +403,7 @@ public class DataInitializer implements ApplicationRunner {
         SpaceEntity s402 = privateSpaces.stream().filter(s -> s.getName().contains("402")).findFirst().orElse(privateSpaces.get(3));
         ensureContract(user4.getUserId(), s402.getSpaceId(), ContractStatus.ACTIVE, ContractOrigin.ADMIN_INITIATED,
                 null, null, null, null, null, null,
-                admin.getUserId(), LocalDate.now().minusMonths(3), LocalDate.now().plusMonths(9),
+                admin.getUserId(), LocalDate.of(2026, 4, 8), LocalDate.of(2026, 5, 1),
                 new BigDecimal("550000"), new BigDecimal("6000000"), null, OffsetDateTime.now().minusMonths(3));
 
         // 5) REJECTED — demo 유저가 501호에 신청했다가 거절됨

--- a/backend/src/main/java/com/coliving/global/dto/ApiResponse.java
+++ b/backend/src/main/java/com/coliving/global/dto/ApiResponse.java
@@ -41,4 +41,12 @@ public class ApiResponse<T> {
                 .errorCode(code.name())
                 .build();
     }
+
+    public static ApiResponse<?> error(ErrorCode code, String message) {
+        return ApiResponse.builder()
+                .success(false)
+                .message(message)
+                .errorCode(code.name())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
@@ -26,7 +26,7 @@ public class GlobalExceptionHandler {
         log.warn("BusinessException: {}", e.getMessage());
         return ResponseEntity
                 .status(errorCode.getStatus())
-                .body(ApiResponse.error(errorCode));
+                .body(ApiResponse.error(errorCode, e.getMessage()));
     }
 
     /**

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -9,6 +9,9 @@ import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.exception.ReservationOverlapException;
+import com.coliving.user.contract.adapter.out.jpa.ContractEntity;
+import com.coliving.user.contract.adapter.out.jpa.ContractJpaRepository;
+import com.coliving.user.contract.model.ContractStatus;
 import com.coliving.admin.space.adapter.out.jpa.SpaceEntity;
 import com.coliving.admin.space.adapter.out.jpa.SpaceJpaRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +43,7 @@ public class ReservationCommandService implements ReservationCommandUseCase {
     private final ReservationJpaRepository reservationRepository;
     private final UserJpaRepository userRepository;
     private final SpaceJpaRepository spaceRepository;
+    private final ContractJpaRepository contractJpaRepository;
 
     /**
      * 시설 예약 신청
@@ -48,9 +52,10 @@ public class ReservationCommandService implements ReservationCommandUseCase {
      * 1. 시간 범위 유효성 검사 (종료 > 시작)
      * 2. 사용자 조회
      * 3. 시설 조회
-     * 4. 최대 이용 시간(2시간) 검증
-     * 5. 동시성 체크 — 동일 시설/날짜/시간대에 APPROVED 예약 존재 시 ReservationOverlapException
-     * 6. 엔티티 생성(APPROVED) 및 저장
+     * 4. 활성 계약 종료일(endDate) 검증
+     * 5. 최대 이용 시간(2시간) 검증
+     * 6. 동시성 체크 — 동일 시설/날짜/시간대에 APPROVED 예약 존재 시 ReservationOverlapException
+     * 7. 엔티티 생성(APPROVED) 및 저장
      */
     @Override
     @Transactional
@@ -58,10 +63,6 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         // 1. 시간 범위 유효성 검사
         if (!request.isValidTimeRange()) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR, "종료 시간은 시작 시간보다 이후여야 합니다.");
-        }
-
-        if (!request.isWithinMaxUsageMinutes(MAX_RESERVATION_MINUTES)) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "공용시설 예약은 최대 2시간까지만 가능합니다.");
         }
 
         // 2. 요청 사용자 조회
@@ -74,7 +75,26 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         SpaceEntity spaceEntity = spaceRepository.findById(request.getSpaceId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND, "시설을 찾을 수 없습니다."));
 
-        // 4. 동시성 체크: 해당 시간에 APPROVED 중복 예약 여부 확인
+        // 4. 활성 계약 종료일 검증 (종료일 당일 포함)
+        ContractEntity activeContract = contractJpaRepository.findByUserIdAndStatus(userId, ContractStatus.ACTIVE)
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_ACTIVE_CONTRACT, "유효한 활성 계약이 없어 예약할 수 없습니다."));
+
+        if (activeContract.getEndDate() == null) {
+            throw new BusinessException(ErrorCode.NO_ACTIVE_CONTRACT, "유효한 활성 계약 종료일이 없어 예약할 수 없습니다.");
+        }
+
+        if (request.getReservationDate().isAfter(activeContract.getEndDate())) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "입주 기간 종료로 인해 예약이 불가능합니다");
+        }
+
+        // 5. 최대 이용 시간(2시간) 검증
+        if (!request.isWithinMaxUsageMinutes(MAX_RESERVATION_MINUTES)) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "공용시설 예약은 최대 2시간까지만 가능합니다.");
+        }
+
+        // 6. 동시성 체크: 해당 시간에 APPROVED 중복 예약 여부 확인
         // TODO: (고도화) 다중 인스턴스 환경에서 완벽한 동시성 제어를 위해 Redisson 분산 락, DB Partial Unique Index 도입 고려
         boolean hasOverlap = reservationRepository.existsOverlappingReservation(
                 request.getSpaceId(),
@@ -90,7 +110,7 @@ public class ReservationCommandService implements ReservationCommandUseCase {
             throw new ReservationOverlapException("선택한 시간에 이미 다른 확정된 예약이 존재합니다.");
         }
 
-        // 5. 예약 엔티티 생성 (초기 상태: APPROVED) 및 저장
+        // 7. 예약 엔티티 생성 (초기 상태: APPROVED) 및 저장
         @SuppressWarnings("null")
         ReservationEntity savedReservation = reservationRepository.save(
                 ReservationEntity.builder()

--- a/frontend/src/app/(resident-app)/facilities/_components/ReservationBlockedModal.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/ReservationBlockedModal.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+
+interface ReservationBlockedModalProps {
+  isOpen: boolean;
+  title?: string;
+  message: string;
+  onClose: () => void;
+}
+
+export function ReservationBlockedModal({
+  isOpen,
+  title = "예약 불가 안내",
+  message,
+  onClose,
+}: ReservationBlockedModalProps) {
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <div className="fixed inset-0 z-[130] flex items-center justify-center p-4 md:p-6">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-primary/35 backdrop-blur-sm"
+            onClick={onClose}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, y: 18, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 18, scale: 0.97 }}
+            transition={{ type: "spring", damping: 24, stiffness: 280 }}
+            className="relative w-full max-w-md rounded-[2rem] border border-red-200 bg-background p-6 shadow-2xl md:p-8"
+          >
+            <div className="space-y-3">
+              <p className="text-[10px] font-black uppercase tracking-[0.28em] text-red-500">
+                Reservation Alert
+              </p>
+              <h3 className="text-2xl font-black tracking-tight text-primary">{title}</h3>
+              <p className="rounded-[1.5rem] border border-red-200 bg-red-50 px-5 py-4 text-sm font-medium leading-6 text-red-700">
+                {message}
+              </p>
+            </div>
+
+            <div className="mt-8">
+              <button
+                type="button"
+                onClick={onClose}
+                className="w-full rounded-xl bg-primary px-5 py-3 text-sm font-black tracking-tight text-primary-foreground transition hover:opacity-90"
+              >
+                확인
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
@@ -10,6 +10,7 @@ import { fetchTimeSlots, createReservation } from "../_api";
 import type { Facility } from "../_types";
 import { ApiError } from "@/lib/api";
 import { ReservationRequestModal } from "./ReservationRequestModal";
+import { ReservationBlockedModal } from "./ReservationBlockedModal";
 
 // ──────────────────────────────────────────
 // 상수
@@ -180,6 +181,7 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
   const [booking, setBooking] = useState(false);
   const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
   const [isReservationModalOpen, setIsReservationModalOpen] = useState(false);
+  const [blockedReservationMessage, setBlockedReservationMessage] = useState<string | null>(null);
   const [dragState, setDragState] = useState<{ active: boolean; anchorDate: string | null; anchorTime: string | null }>({
     active: false,
     anchorDate: null,
@@ -354,8 +356,16 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
       loadSlots();
       onReserved?.();
     } catch (e) {
-      if (e instanceof ApiError) setFeedback({ type: "error", msg: e.message });
-      else setFeedback({ type: "error", msg: "예약 신청에 실패했습니다." });
+      if (e instanceof ApiError) {
+        if (e.message.includes("입주 기간 종료로 인해 예약이 불가능합니다")) {
+          setIsReservationModalOpen(false);
+          setBlockedReservationMessage("계약 종료 이후에는 공용시설 예약이 불가능합니다. 계약 기간을 확인해주세요.");
+        } else {
+          setFeedback({ type: "error", msg: e.message });
+        }
+      } else {
+        setFeedback({ type: "error", msg: "예약 신청에 실패했습니다." });
+      }
     } finally {
       setBooking(false);
     }
@@ -579,6 +589,12 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
           isSubmitting={booking}
         />
       ) : null}
+
+      <ReservationBlockedModal
+        isOpen={blockedReservationMessage !== null}
+        message={blockedReservationMessage ?? ""}
+        onClose={() => setBlockedReservationMessage(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 계약 종료일 이후 날짜로 공용시설 예약을 시도할 때 서버에서 차단은 되지만, 프론트에서는 에러가 토스트/텍스트로만 보여 인지가 어렵다는 문제가 있었습니다.
- 이번 PR은 “계약 종료 이후 예약 불가” 케이스를 사용자가 명확히 인지하도록 **팝업 안내**를 추가하고, 백엔드에서 **커스텀 에러 메시지가 그대로 전달**되도록 응답 포맷을 보완합니다.

## 🔑 주요 변경 사항 (What)
- `BusinessException`의 커스텀 메시지가 API 응답 `message`로 내려가도록 `ApiResponse`/`GlobalExceptionHandler` 수정
- 계약 종료 이후 예약 불가 에러(`입주 기간 종료로 인해 예약이 불가능합니다`)를 프론트에서 감지해 **팝업 모달로 안내**
- `user4` ACTIVE 계약 종료일 시드를 `2026-05-01`로 고정(테스트 재현 용이)

## 🔗 연관된 이슈 (Issue / Ticket)
- Closes #

## 💻 테스트 방법 (How to Test)
- `docker compose up -d db redis mock-iot`
- 백엔드 실행: `cd backend && ./gradlew bootRun`
- 프론트 실행: `cd frontend && npm run dev`
- `user4 / Passw0rd!`로 로그인
- 시설 예약 화면에서 **계약 종료일(2026-05-01) 이후 날짜**로 예약 신청
- 예약 요청이 실패하면서 **“계약 종료 이후 예약 불가” 팝업**이 표시되는지 확인

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- `BusinessException` 응답 메시지 전달 방식 변경은 전역 영향이 있어, 다른 도메인의 에러 메시지 표시에 의도치 않은 영향이 없는지 확인 부탁드립니다.
- 시드의 `user4` 계약 종료일 변경은 DB에 이미 데이터가 있으면 자동 반영되지 않아, 로컬 DB 초기화 없이 테스트할 경우 SQL 업데이트가 필요할 수 있습니다.

Closes #120
