### PR TITLE
fix(community): add defensive checks for notice notifications

### DIFF
--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -15,6 +15,7 @@ import com.coliving.common.notification.application.port.in.CreateNotificationUs
 import com.coliving.common.notification.model.NotificationType;
 import com.coliving.common.notification.model.ReferenceType;
 import com.coliving.admin.user.application.port.out.AdminUserRepositoryPort;
+import com.coliving.admin.user.application.result.AdminUserResult;
 import com.coliving.common.auth.model.UserRole;
 import com.coliving.common.auth.model.UserStatus;
 import org.springframework.data.domain.Pageable;
@@ -148,18 +149,23 @@ public class CommunityService implements CommunityUseCase {
     }
 
     private void notifyAllResidentsOfNotice(Post post, String title) {
-        adminUserRepositoryPort.findUsers(UserRole.USER, UserStatus.ACTIVE.name(), null, null, Pageable.unpaged())
-                .getContent()
-                .forEach(user -> {
-                    createNotificationUseCase.create(CreateNotificationCommand.builder()
-                            .userId(user.getId())
-                            .type(NotificationType.COMMUNITY_NOTICE)
-                            .title(title)
-                            .message(String.format("「%s」 공지사항이 등록되었습니다.", post.getTitle()))
-                            .referenceType(ReferenceType.COMMUNITY)
-                            .referenceId(post.getPostId())
-                            .build());
-                });
+        if (post == null) return;
+
+        Page<AdminUserResult> userPage = adminUserRepositoryPort.findUsers(UserRole.USER, UserStatus.ACTIVE.name(), null, null, Pageable.unpaged());
+        if (userPage == null || userPage.getContent() == null || userPage.getContent().isEmpty()) {
+            return;
+        }
+
+        userPage.getContent().forEach(user -> {
+            createNotificationUseCase.create(CreateNotificationCommand.builder()
+                    .userId(user.getId())
+                    .type(NotificationType.COMMUNITY_NOTICE)
+                    .title(title)
+                    .message(String.format("「%s」 공지사항이 등록되었습니다.", post.getTitle()))
+                    .referenceType(ReferenceType.COMMUNITY)
+                    .referenceId(post.getPostId())
+                    .build());
+        });
     }
 
     @Override


### PR DESCRIPTION
- Applied defensive null-checks in CommunityService when broadcasting notices.
- Added missing AdminUserResult import.
- This resolves the 500 error reported during notice creation.
