### PR TITLE
🐛 fix: 알림 클릭 시 잘못된 경로(/profile/contracts 등)로 리다이렉트되는 문제 수정

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -47,11 +47,11 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
           targetPath = `/profile/vocs/${refId}`;
         }
       } else if (refType === "CONTRACT") {
-        targetPath = `/profile/contracts`; // 계약 상세 페이지가 생기면 `/profile/contracts/${refId}`로 변경 예정
+        targetPath = `/my-contracts`; 
       } else if (refType === "RESERVATION") {
-        targetPath = `/profile/reservations`;
+        targetPath = `/my-history/reservation`;
       } else if (refType === "PAYMENT") {
-        targetPath = `/profile/payments`;
+        targetPath = `/my-payments`;
       }
     }
 


### PR DESCRIPTION
입주 신청 및 계약 관련 알림 클릭 시 /profile/contracts로 연결되어 404 에러가 발생하는 문제를 수정했습니다.
실제 경로인 /my-contracts로 연결되도록 변경했습니다.
예약 및 결제 관련 알림 경로도 각각 /my-history/reservation, /my-payments로 올바르게 수정했습니다.