### PR TITLE
[CS/fix] 민원/댓글 알림 및 notifications DB 정합

### DIFF
--- a/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedEvent.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedEvent.java
@@ -1,0 +1,15 @@
+package com.coliving.common.comment.application.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 댓글 저장 커밋 이후 알림 발송용.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CommentPostedEvent {
+    private final Long postId;
+    private final Long actorId;
+    private final Long parentCommentId;
+}

--- a/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
@@ -1,0 +1,93 @@
+package com.coliving.common.comment.application.event;
+
+import com.coliving.common.comment.application.port.out.CommentRepositoryPort;
+import com.coliving.common.community.application.port.out.CommunityRepositoryPort;
+import com.coliving.common.notification.application.command.CreateNotificationCommand;
+import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
+import com.coliving.common.notification.model.NotificationType;
+import com.coliving.common.notification.model.ReferenceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommentPostedNotificationListener {
+
+    private final CommunityRepositoryPort communityRepositoryPort;
+    private final CommentRepositoryPort commentRepositoryPort;
+    private final CreateNotificationUseCase createNotificationUseCase;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onCommentPosted(CommentPostedEvent event) {
+        if (event == null || event.getPostId() == null || event.getActorId() == null) {
+            return;
+        }
+
+        try {
+            notifyPostAuthor(event);
+            notifyParentCommentAuthor(event);
+        } catch (Exception e) {
+            log.warn("댓글 알림 발송 실패 postId={}: {}", event.getPostId(), e.getMessage());
+        }
+    }
+
+    private void notifyPostAuthor(CommentPostedEvent event) {
+        communityRepositoryPort.findPostById(event.getPostId()).ifPresent(post -> {
+            if (post.getUserId().equals(event.getActorId())) {
+                return;
+            }
+            try {
+                createNotificationUseCase.create(CreateNotificationCommand.builder()
+                        .userId(post.getUserId())
+                        .type(NotificationType.COMMUNITY_COMMENT)
+                        .title("새로운 댓글")
+                        .message(String.format("내 게시글 '%s'에 새로운 댓글이 달렸습니다.", truncateTitle(post.getTitle())))
+                        .referenceType(ReferenceType.COMMUNITY)
+                        .referenceId(post.getPostId())
+                        .build());
+            } catch (Exception e) {
+                log.warn("게시글 작성자 댓글 알림 실패 userId={}: {}", post.getUserId(), e.getMessage());
+            }
+        });
+    }
+
+    private void notifyParentCommentAuthor(CommentPostedEvent event) {
+        if (event.getParentCommentId() == null) {
+            return;
+        }
+        commentRepositoryPort.findCommentById(event.getParentCommentId()).ifPresent(parent -> {
+            if (parent.getUserId().equals(event.getActorId())) {
+                return;
+            }
+            boolean isPostOwner = communityRepositoryPort.findPostById(event.getPostId())
+                    .map(p -> p.getUserId().equals(parent.getUserId()))
+                    .orElse(false);
+            if (isPostOwner) {
+                return;
+            }
+            try {
+                createNotificationUseCase.create(CreateNotificationCommand.builder()
+                        .userId(parent.getUserId())
+                        .type(NotificationType.COMMUNITY_COMMENT)
+                        .title("새로운 답글")
+                        .message("내 댓글에 새로운 답글이 달렸습니다.")
+                        .referenceType(ReferenceType.COMMUNITY)
+                        .referenceId(event.getPostId())
+                        .build());
+            } catch (Exception e) {
+                log.warn("원댓글 작성자 답글 알림 실패 userId={}: {}", parent.getUserId(), e.getMessage());
+            }
+        });
+    }
+
+    private static String truncateTitle(String title) {
+        if (title == null) {
+            return "";
+        }
+        return title.length() > 10 ? title.substring(0, 10) + "..." : title;
+    }
+}

--- a/backend/src/main/java/com/coliving/common/comment/application/service/CommentService.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/service/CommentService.java
@@ -4,35 +4,26 @@ import com.coliving.common.comment.application.command.*;
 import com.coliving.common.comment.application.port.in.CommentUseCase;
 import com.coliving.common.comment.application.port.out.CommentRepositoryPort;
 import com.coliving.common.comment.application.result.CommentResult;
-import com.coliving.common.community.application.port.out.CommunityRepositoryPort;
 import com.coliving.common.community.model.ActorRole;
 import com.coliving.common.community.model.Comment;
-import com.coliving.common.community.model.Post;
-import com.coliving.common.notification.application.command.CreateNotificationCommand;
-import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
-import com.coliving.common.notification.model.NotificationType;
-import com.coliving.common.notification.model.ReferenceType;
+import com.coliving.common.comment.application.event.CommentPostedEvent;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.stereotype.Service;
 
-@Slf4j
 @Service
 public class CommentService implements CommentUseCase {
     private static final String DELETED_WITH_REPLY_PLACEHOLDER = "[삭제된 댓글입니다.]";
 
     private final CommentRepositoryPort commentRepositoryPort;
-    private final CommunityRepositoryPort communityRepositoryPort;
-    private final CreateNotificationUseCase createNotificationUseCase;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CommentService(CommentRepositoryPort commentRepositoryPort,
-                          CommunityRepositoryPort communityRepositoryPort,
-                          CreateNotificationUseCase createNotificationUseCase) {
+                          ApplicationEventPublisher eventPublisher) {
         this.commentRepositoryPort = commentRepositoryPort;
-        this.communityRepositoryPort = communityRepositoryPort;
-        this.createNotificationUseCase = createNotificationUseCase;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -45,58 +36,16 @@ public class CommentService implements CommentUseCase {
                 command.getContent()
         );
 
-        // 알림 처리: 비즈니스 로직(댓글 등록)에 영향을 주지 않도록 예외 처리
-        try {
-            // 1. 게시글 작성자에게 알림 (본인이 단 댓글이 아닐 때만)
-            communityRepositoryPort.findPostById(command.getPostId()).ifPresent(post -> {
-                if (!post.getUserId().equals(command.getActorId())) {
-                    createNotificationUseCase.create(CreateNotificationCommand.builder()
-                            .userId(post.getUserId())
-                            .type(NotificationType.COMMUNITY_COMMENT)
-                            .title("새로운 댓글")
-                            .message(String.format("내 게시글 '%s'에 새로운 댓글이 달렸습니다.", truncateTitle(post.getTitle())))
-                            .referenceType(ReferenceType.COMMUNITY)
-                            .referenceId(post.getPostId())
-                            .build());
-                }
-            });
-
-            // 2. 답글인 경우 원댓글 작성자에게 알림 (본인이 단 답글이 아니고, 게시글 작성자와 다른 경우만 - 중복 방지)
-            if (command.getParentCommentId() != null) {
-                commentRepositoryPort.findCommentById(command.getParentCommentId()).ifPresent(parent -> {
-                    if (!parent.getUserId().equals(command.getActorId())) {
-                        // 게시글 작성자와 원댓글 작성자가 다를 때만 별도 알림 (같으면 위에서 이미 보냄)
-                        boolean isPostOwner = communityRepositoryPort.findPostById(command.getPostId())
-                                .map(p -> p.getUserId().equals(parent.getUserId()))
-                                .orElse(false);
-                        
-                        if (!isPostOwner) {
-                            createNotificationUseCase.create(CreateNotificationCommand.builder()
-                                    .userId(parent.getUserId())
-                                    .type(NotificationType.COMMUNITY_COMMENT)
-                                    .title("새로운 답글")
-                                    .message("내 댓글에 새로운 답글이 달렸습니다.")
-                                    .referenceType(ReferenceType.COMMUNITY)
-                                    .referenceId(command.getPostId())
-                                    .build());
-                        }
-                    }
-                });
-            }
-        } catch (Exception e) {
-            log.error("Failed to send comment notification for postId: {}", command.getPostId(), e);
-        }
+        eventPublisher.publishEvent(new CommentPostedEvent(
+                command.getPostId(),
+                command.getActorId(),
+                command.getParentCommentId()));
 
         return CommentResult.builder()
                 .commentId(created.getCommentId())
                 .postId(created.getPostId())
                 .createdAt(created.getCreatedAt())
                 .build();
-    }
-
-    private String truncateTitle(String title) {
-        if (title == null) return "";
-        return title.length() > 10 ? title.substring(0, 10) + "..." : title;
     }
 
     @Override

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -9,6 +9,7 @@ import com.coliving.common.community.model.ActorRole;
 import com.coliving.common.community.model.Post;
 import com.coliving.common.community.model.PostAttachment;
 import com.coliving.common.community.model.PostCategory;
+import com.coliving.common.comment.application.event.CommentPostedEvent;
 import com.coliving.common.community.model.Comment;
 import com.coliving.common.notification.application.command.CreateNotificationCommand;
 import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
@@ -30,6 +31,7 @@ import com.coliving.global.html.PostBodyHtmlSanitizer;
 import com.coliving.global.validation.PlainTextFieldValidation;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,15 +49,18 @@ public class CommunityService implements CommunityUseCase {
     private final CommunityLikeActionGuard likeActionGuard;
     private final CreateNotificationUseCase createNotificationUseCase;
     private final AdminUserRepositoryPort adminUserRepositoryPort;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CommunityService(CommunityRepositoryPort repositoryPort,
             CommunityLikeActionGuard likeActionGuard,
             CreateNotificationUseCase createNotificationUseCase,
-            AdminUserRepositoryPort adminUserRepositoryPort) {
+            AdminUserRepositoryPort adminUserRepositoryPort,
+            ApplicationEventPublisher eventPublisher) {
         this.repositoryPort = repositoryPort;
         this.likeActionGuard = likeActionGuard;
         this.createNotificationUseCase = createNotificationUseCase;
         this.adminUserRepositoryPort = adminUserRepositoryPort;
+        this.eventPublisher = eventPublisher;
     }
 
     @Override
@@ -295,18 +300,10 @@ public class CommunityService implements CommunityUseCase {
                 .createdAt(created.getCreatedAt())
                 .build();
 
-        // 게시글 작성자에게 알림 (내 댓글인 경우 제외)
-        Post post = repositoryPort.findPostById(created.getPostId()).orElse(null);
-        if (post != null && !post.getUserId().equals(created.getUserId())) {
-            createNotificationUseCase.create(CreateNotificationCommand.builder()
-                    .userId(post.getUserId())
-                    .type(NotificationType.COMMUNITY_COMMENT)
-                    .title("내 게시글에 새로운 댓글이 달렸습니다")
-                    .message(String.format("「%s」 글에 새로운 댓글이 등록되었습니다.", post.getTitle()))
-                    .referenceType(ReferenceType.COMMUNITY)
-                    .referenceId(post.getPostId())
-                    .build());
-        }
+        eventPublisher.publishEvent(new CommentPostedEvent(
+                command.getPostId(),
+                command.getActorId(),
+                command.getParentCommentId()));
 
         return result;
     }


### PR DESCRIPTION
## 요약
- 민원 등록 500: 관리자 알림을 트랜잭션 커밋 후(AFTER_COMMIT)로 분리, 알림 실패와 무관하게 민원 저장 유지
- PostgreSQL `notifications_type_check` 정합용 유지보수 SQL 추가
- 알림 저장소/NotificationService null 처리 및 중첩 REQUIRES_NEW 완화
- 공지 수신자 조회 보강(`findActiveUsersWithRoles`)
- 댓글: `COMMUNITY_COMMENT` 알림을 AFTER_COMMIT으로 분리해 댓글 저장과 알림 INSERT 실패 분리

## DB (운영 1회)
`backend/src/main/resources/db/maintenance/postgresql-notifications-type-check.sql` 실행

## 참고
동일 브랜치에 여러 fix 커밋이 포함될 수 있습니다.