### PR TITLE
🔀 add admin reservation management and improve facilities UI

### DIFF
--- a/frontend/src/app/(resident-app)/facilities/_components/FacilitiesContent.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/FacilitiesContent.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
+import { CheckCircle, Building2 } from "lucide-react";
 import { FacilityCard } from "./FacilityCard";
 import { WeeklyTimetable } from "./WeeklyTimetable";
 import { fetchFacilities } from "../_api";
@@ -48,7 +49,7 @@ export default function FacilitiesContent() {
   }, [loadFacilities]);
 
   return (
-    <div className="space-y-8 px-6 pt-16 pb-24 md:px-12 md:pt-32">
+    <div className="space-y-6">
       {/* 페이지 헤더 */}
       <motion.header
         initial={{ opacity: 0, y: 20 }}
@@ -85,8 +86,10 @@ export default function FacilitiesContent() {
         </div>
       ) : facilities.length === 0 ? (
         <div className="rounded-[2rem] border border-border bg-surface p-12 text-center">
-          <p className="text-4xl">🏡</p>
-          <p className="mt-4 text-sm font-semibold text-primary">등록된 시설이 없습니다</p>
+          <div className="flex justify-center text-muted-foreground/40 mb-3">
+            <Building2 size={40} strokeWidth={1} />
+          </div>
+          <p className="mt-2 text-sm font-semibold text-primary">등록된 시설이 없습니다</p>
           <p className="mt-1 text-xs text-muted-foreground">관리자에게 문의해 주세요.</p>
         </div>
       ) : (
@@ -138,8 +141,10 @@ export default function FacilitiesContent() {
               />
             ) : (
               <div className="rounded-[2rem] border border-accent/30 bg-accent/5 p-8 text-center">
-                <p className="text-3xl">✅</p>
-                <p className="mt-3 text-sm font-bold text-primary">자유 이용 시설</p>
+                <div className="flex justify-center text-accent/60 mb-3">
+                  <CheckCircle size={36} strokeWidth={1.5} />
+                </div>
+                <p className="mt-1 text-sm font-bold text-primary">자유 이용 시설</p>
                 <p className="mt-1 text-xs text-muted-foreground">
                   예약 없이 운영 시간 내 자유롭게 이용하실 수 있습니다.
                 </p>

--- a/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
@@ -4,6 +4,14 @@
 // ui-guideline: Moss & Aloe 디자인 시스템, 시맨틱 클래스만 사용
 
 import { motion } from "framer-motion";
+import {
+  WashingMachine,
+  Coffee,
+  BookOpen,
+  Dumbbell,
+  Building2,
+  type LucideIcon,
+} from "lucide-react";
 import type { Facility } from "../_types";
 
 const STATUS_MAP: Record<string, { label: string; dot: string; border: string }> = {
@@ -24,18 +32,18 @@ const STATUS_MAP: Record<string, { label: string; dot: string; border: string }>
   },
 };
 
-const FACILITY_ICONS: Record<string, string> = {
-  세탁실: "🫧",
-  라운지: "☕",
-  회의실: "📋",
-  헬스장: "💪",
-};
+const FACILITY_ICON_MAP: Array<{ key: string; icon: LucideIcon }> = [
+  { key: "세탁실", icon: WashingMachine },
+  { key: "라운지", icon: Coffee },
+  { key: "회의실", icon: BookOpen },
+  { key: "헬스장", icon: Dumbbell },
+];
 
-function getFacilityIcon(name: string): string {
-  for (const [key, icon] of Object.entries(FACILITY_ICONS)) {
+function getFacilityIcon(name: string): LucideIcon {
+  for (const { key, icon } of FACILITY_ICON_MAP) {
     if (name.includes(key)) return icon;
   }
-  return "🏠";
+  return Building2;
 }
 
 interface FacilityCardProps {
@@ -47,7 +55,7 @@ interface FacilityCardProps {
 
 export function FacilityCard({ facility, selected, onSelect, index }: FacilityCardProps) {
   const status = STATUS_MAP[facility.status] ?? STATUS_MAP.AVAILABLE;
-  const icon = getFacilityIcon(facility.name);
+  const Icon = getFacilityIcon(facility.name);
   const [openTime, closeTime] = facility.operatingHours?.split("-") ?? ["?", "?"];
 
   return (
@@ -72,7 +80,11 @@ export function FacilityCard({ facility, selected, onSelect, index }: FacilityCa
       />
 
       {/* 아이콘 */}
-      <div className="text-3xl">{icon}</div>
+      <div className={`${
+        selected ? "text-primary-foreground/90" : "text-primary"
+      }`}>
+        <Icon size={28} strokeWidth={1.5} />
+      </div>
 
       {/* 시설명 */}
       <p className={`mt-3 text-sm font-bold tracking-tight ${
@@ -92,7 +104,10 @@ export function FacilityCard({ facility, selected, onSelect, index }: FacilityCa
       <div className={`mt-3 flex items-center gap-3 text-[10px] font-semibold ${
         selected ? "text-primary-foreground/80" : "text-muted-foreground"
       }`}>
-        <span>👤 {facility.maxCapacity}명</span>
+        <span className="flex items-center gap-1">
+          <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          {facility.maxCapacity}명
+        </span>
         {facility.usageFee > 0 && (
           <span>₩{facility.usageFee.toLocaleString()}/시간</span>
         )}

--- a/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
@@ -4,13 +4,15 @@
 // functional-specification §3.2.2: 가로=요일, 세로=시간대, 색상 구분
 // ui-guideline: Moss & Aloe 시맨틱 클래스, framer-motion 마이크로 애니메이션
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react";
 import { fetchTimeSlots, createReservation } from "../_api";
 import type { Facility } from "../_types";
 import { ApiError } from "@/lib/api";
 import { ReservationRequestModal } from "./ReservationRequestModal";
 import { ReservationBlockedModal } from "./ReservationBlockedModal";
+
 
 // ──────────────────────────────────────────
 // 상수
@@ -90,6 +92,139 @@ function parseSlots(
     }
   }
   return result;
+}
+
+// ──────────────────────────────────────────
+// 미니 달력 팝업 컴포넌트
+// ──────────────────────────────────────────
+
+const CAL_DAYS = ["월", "화", "수", "목", "금", "토", "일"];
+
+interface MiniCalendarProps {
+  weekStart: Date;
+  onSelectDate: (date: Date) => void;
+  onClose: () => void;
+}
+
+function MiniCalendar({ weekStart, onSelectDate, onClose }: MiniCalendarProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const [viewYear, setViewYear] = useState(weekStart.getFullYear());
+  const [viewMonth, setViewMonth] = useState(weekStart.getMonth()); // 0-indexed
+
+  // 외부 클릭 감지
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [onClose]);
+
+  // 해당 월의 날짜 그리드 생성 (월요일 시작)
+  const firstDay = new Date(viewYear, viewMonth, 1);
+  // 월요일 기준 시작 오프셋 (0=월,1=화,...,6=일)
+  const startOffset = (firstDay.getDay() + 6) % 7;
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const cells: (Date | null)[] = [
+    ...Array(startOffset).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => new Date(viewYear, viewMonth, i + 1)),
+  ];
+  // 7의 배수로 맞추기
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const shiftMonth = (delta: number) => {
+    const d = new Date(viewYear, viewMonth + delta, 1);
+    setViewYear(d.getFullYear());
+    setViewMonth(d.getMonth());
+  };
+
+  // 현재 weekStart의 주 범위
+  const wsStart = new Date(weekStart);
+  wsStart.setHours(0, 0, 0, 0);
+  const wsEnd = new Date(wsStart);
+  wsEnd.setDate(wsEnd.getDate() + 6);
+
+  const isInSelectedWeek = (d: Date) => d >= wsStart && d <= wsEnd;
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: -8, scale: 0.97 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -8, scale: 0.97 }}
+      transition={{ duration: 0.18 }}
+      className="absolute left-1/2 top-full z-50 mt-2 w-72 -translate-x-1/2 rounded-[1.5rem] border border-border bg-background shadow-xl shadow-primary/10"
+    >
+      {/* 월 이동 헤더 */}
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <button
+          onClick={() => shiftMonth(-1)}
+          className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+        >
+          <ChevronLeft size={16} />
+        </button>
+        <p className="text-sm font-bold text-primary">
+          {viewYear}년 {viewMonth + 1}월
+        </p>
+        <button
+          onClick={() => shiftMonth(1)}
+          className="rounded-lg p-1.5 text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+        >
+          <ChevronRight size={16} />
+        </button>
+      </div>
+
+      {/* 요일 행 */}
+      <div className="grid grid-cols-7 border-b border-border/50 px-3 pt-2 pb-1">
+        {CAL_DAYS.map((d) => (
+          <div key={d} className="text-center text-[10px] font-black uppercase tracking-widest text-muted-foreground">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* 날짜 그리드 */}
+      <div className="grid grid-cols-7 gap-y-0.5 p-3">
+        {cells.map((date, idx) => {
+          if (!date) return <div key={`empty-${idx}`} />;
+          const isToday = date.getTime() === today.getTime();
+          const inSelectedWeek = isInSelectedWeek(date);
+          return (
+            <button
+              key={date.toISOString()}
+              onClick={() => { onSelectDate(date); onClose(); }}
+              className={`mx-auto flex h-8 w-8 items-center justify-center rounded-xl text-xs font-bold transition-all
+                ${
+                  inSelectedWeek
+                    ? "bg-primary text-primary-foreground"
+                    : isToday
+                    ? "border border-accent text-accent"
+                    : "text-primary hover:bg-muted/50"
+                }
+              `}
+            >
+              {date.getDate()}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 오늘로 이동 버튼 */}
+      <div className="border-t border-border/50 px-4 py-2.5">
+        <button
+          onClick={() => { onSelectDate(new Date()); onClose(); }}
+          className="w-full rounded-xl py-1.5 text-xs font-bold text-accent transition hover:bg-accent/10"
+        >
+          오늘로 이동
+        </button>
+      </div>
+    </motion.div>
+  );
 }
 
 // ──────────────────────────────────────────
@@ -175,6 +310,7 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
   const [timetable, setTimetable] = useState<TimetableData>({});
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [calendarOpen, setCalendarOpen] = useState(false);
 
   // 선택: { date, startTime, endTime(=startTime+30분) }
   const [selectedSlots, setSelectedSlots] = useState<{ date: string; time: string }[]>([]);
@@ -380,33 +516,57 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
     });
   };
 
+  const handleDateSelect = (date: Date) => {
+    setWeekStart(getWeekStart(date));
+  };
+
   return (
     <div className="space-y-4">
       {/* 주 이동 헤더 */}
-      <div className="flex items-center justify-between rounded-2xl border border-border bg-surface px-4 py-3">
+      <div className="relative flex items-center justify-between rounded-2xl border border-border bg-surface px-4 py-3">
         <button
           onClick={() => shiftWeek(-1)}
-          className="rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+          className="flex items-center gap-1 rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
         >
-          ← 이전 주
+          <ChevronLeft size={16} />
+          <span className="hidden sm:inline">이전 주</span>
         </button>
 
-        <div className="text-center">
-          <p className="text-xs font-black uppercase tracking-[0.2em] text-muted-foreground">
-            {weekStart.getFullYear()}년
-          </p>
-          <p className="text-sm font-bold text-primary">
-            {weekStart.getMonth() + 1}월 {weekStart.getDate()}일 –{" "}
-            {weekDates[6].getMonth() + 1}월 {weekDates[6].getDate()}일
-          </p>
-        </div>
+        {/* 날짜 범위 클릭 → 달력 팝업 */}
+        <button
+          onClick={() => setCalendarOpen((v) => !v)}
+          className="flex items-center gap-2 rounded-xl px-3 py-1.5 text-center transition hover:bg-muted/30"
+        >
+          <CalendarDays size={15} className="text-accent" />
+          <div className="text-center">
+            <p className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground">
+              {weekStart.getFullYear()}년
+            </p>
+            <p className="text-sm font-bold text-primary">
+              {weekStart.getMonth() + 1}월 {weekStart.getDate()}일 –{" "}
+              {weekDates[6].getMonth() + 1}월 {weekDates[6].getDate()}일
+            </p>
+          </div>
+        </button>
 
         <button
           onClick={() => shiftWeek(1)}
-          className="rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
+          className="flex items-center gap-1 rounded-xl px-3 py-1.5 text-sm font-bold text-muted-foreground transition hover:bg-muted/40 hover:text-primary"
         >
-          다음 주 →
+          <span className="hidden sm:inline">다음 주</span>
+          <ChevronRight size={16} />
         </button>
+
+        {/* 달력 팝업 */}
+        <AnimatePresence>
+          {calendarOpen && (
+            <MiniCalendar
+              weekStart={weekStart}
+              onSelectDate={handleDateSelect}
+              onClose={() => setCalendarOpen(false)}
+            />
+          )}
+        </AnimatePresence>
       </div>
 
       {/* 범례 */}

--- a/frontend/src/app/(resident-app)/facilities/page.tsx
+++ b/frontend/src/app/(resident-app)/facilities/page.tsx
@@ -5,7 +5,7 @@ export default function FacilitiesPage() {
   return (
     <Suspense
       fallback={
-        <div className="space-y-8 px-6 pt-16 pb-24 md:px-12 md:pt-32">
+        <div className="space-y-6">
           <div className="space-y-2">
             <div className="h-3 w-16 rounded bg-muted/30 animate-pulse" />
             <div className="h-8 w-48 rounded bg-muted/30 animate-pulse" />

--- a/frontend/src/app/admin/reservations/_api/index.ts
+++ b/frontend/src/app/admin/reservations/_api/index.ts
@@ -1,0 +1,27 @@
+import { apiFetch } from '@/lib/api';
+import type { AdminReservationListParams, AdminReservationPage } from '../_types';
+
+export async function fetchAdminReservations(params?: AdminReservationListParams) {
+  const query = new URLSearchParams();
+
+  if (params?.status) {
+    query.set('status', params.status);
+  }
+
+  query.set('p', String(params?.p ?? 0));
+  query.set('s', String(params?.s ?? 10));
+
+  return apiFetch<AdminReservationPage>(`/admin/reservations?${query.toString()}`);
+}
+
+export async function approveReservation(reservationId: number) {
+  return apiFetch<void>(`/admin/reservations/${reservationId}/approve`, {
+    method: 'POST',
+  });
+}
+
+export async function cancelReservationByAdmin(reservationId: number) {
+  return apiFetch<void>(`/admin/reservations/${reservationId}/cancel`, {
+    method: 'POST',
+  });
+}

--- a/frontend/src/app/admin/reservations/_components/AdminReservationManager.tsx
+++ b/frontend/src/app/admin/reservations/_components/AdminReservationManager.tsx
@@ -1,0 +1,533 @@
+'use client';
+
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  CalendarDays,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsUpDown,
+  Loader2,
+  RefreshCw,
+  Search,
+  SearchX,
+} from 'lucide-react';
+import { ApiError } from '@/lib/api';
+import { Button } from '@/components/ui/button';
+import { approveReservation, cancelReservationByAdmin, fetchAdminReservations } from '../_api';
+import type { AdminReservationItem, AdminReservationPage, AdminReservationStatus } from '../_types';
+import { ReservationActionModal } from './ReservationActionModal';
+import { ReservationStatusBadge } from './ReservationStatusBadge';
+
+const PAGE_SIZE = 10;
+const STATUS_FILTERS: Array<{ value: 'ALL' | AdminReservationStatus; label: string }> = [
+  { value: 'ALL', label: '전체' },
+  { value: 'APPROVED', label: '예약 확정' },
+  { value: 'CANCELLED', label: '취소됨' },
+  { value: 'COMPLETED', label: '이용 완료' },
+];
+
+const ACTIONABLE_STATUSES: Record<AdminReservationStatus, Array<'approve' | 'cancel'>> = {
+  PENDING: ['approve', 'cancel'],
+  APPROVED: ['cancel'],
+  CANCELLED: [],
+  COMPLETED: [],
+};
+
+type PendingAction = { type: 'approve' | 'cancel'; reservation: AdminReservationItem } | null;
+
+const formatTime = (value: string) => value.slice(0, 5);
+
+function getSearchableText(reservation: AdminReservationItem) {
+  return [
+    reservation.id,
+    reservation.userName,
+    reservation.spaceName,
+    reservation.userId,
+    reservation.spaceId,
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
+export function AdminReservationManager() {
+  const [pageData, setPageData] = useState<AdminReservationPage | null>(null);
+  const [statusFilter, setStatusFilter] = useState<'ALL' | AdminReservationStatus>('ALL');
+  const [searchTerm, setSearchTerm] = useState('');
+  const deferredSearchTerm = useDeferredValue(searchTerm.trim().toLowerCase());
+  const [isLoading, setIsLoading] = useState(true);
+  const [isReloading, setIsReloading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; text: string } | null>(
+    null,
+  );
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [idSortOrder, setIdSortOrder] = useState<'asc' | 'desc'>('desc');
+  const hasLoadedOnceRef = useRef(false);
+
+  useEffect(() => {
+    const loadReservations = async () => {
+      if (hasLoadedOnceRef.current) {
+        setIsReloading(true);
+      } else {
+        setIsLoading(true);
+      }
+
+      setError(null);
+
+      try {
+        const response = await fetchAdminReservations({
+          status: statusFilter === 'ALL' ? undefined : statusFilter,
+          p: currentPage,
+          s: PAGE_SIZE,
+        });
+        setPageData(response.data);
+        hasLoadedOnceRef.current = true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '예약 목록을 불러오지 못했습니다.');
+      } finally {
+        setIsLoading(false);
+        setIsReloading(false);
+      }
+    };
+
+    void loadReservations();
+  }, [currentPage, statusFilter]);
+
+  useEffect(() => {
+    setCurrentPage(0);
+  }, [statusFilter]);
+
+  useEffect(() => {
+    if (!feedback) return;
+
+    const timer = window.setTimeout(() => setFeedback(null), 2800);
+    return () => window.clearTimeout(timer);
+  }, [feedback]);
+
+  const reservations = useMemo(() => pageData?.content ?? [], [pageData]);
+
+  const filteredReservations = useMemo(() => {
+    if (!deferredSearchTerm) {
+      return reservations;
+    }
+
+    return reservations.filter((reservation) =>
+      getSearchableText(reservation).includes(deferredSearchTerm),
+    );
+  }, [deferredSearchTerm, reservations]);
+
+  const sortedReservations = useMemo(() => {
+    return [...filteredReservations].sort((a, b) =>
+      idSortOrder === 'asc' ? a.id - b.id : b.id - a.id,
+    );
+  }, [filteredReservations, idSortOrder]);
+
+  const summaryItems = useMemo(() => {
+    return [
+      {
+        label: 'Current Page',
+        value: String(filteredReservations.length).padStart(2, '0'),
+        description: '현재 화면에 보이는 예약',
+      },
+      {
+        label: 'Pending',
+        value: String(reservations.filter((item) => item.status === 'PENDING').length).padStart(
+          2,
+          '0',
+        ),
+        description: '즉시 검토가 필요한 예약',
+      },
+      {
+        label: 'Approved',
+        value: String(reservations.filter((item) => item.status === 'APPROVED').length).padStart(
+          2,
+          '0',
+        ),
+        description: '승인 완료된 예약',
+      },
+      {
+        label: 'Total',
+        value: String(pageData?.totalElements ?? 0).padStart(2, '0'),
+        description: '현재 필터 기준 전체 예약 수',
+      },
+    ];
+  }, [filteredReservations.length, pageData?.totalElements, reservations]);
+
+  const handleRefresh = async () => {
+    setIsReloading(true);
+    setError(null);
+
+    try {
+      const response = await fetchAdminReservations({
+        status: statusFilter === 'ALL' ? undefined : statusFilter,
+        p: currentPage,
+        s: PAGE_SIZE,
+      });
+      setPageData(response.data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '예약 목록을 새로고침하지 못했습니다.');
+    } finally {
+      setIsReloading(false);
+    }
+  };
+
+  const handleConfirmAction = async () => {
+    if (!pendingAction) return;
+
+    setIsSubmitting(true);
+    setFeedback(null);
+
+    try {
+      if (pendingAction.type === 'approve') {
+        await approveReservation(pendingAction.reservation.id);
+        setFeedback({
+          type: 'success',
+          text: `예약 #${pendingAction.reservation.id}을 승인했습니다.`,
+        });
+      } else {
+        await cancelReservationByAdmin(pendingAction.reservation.id);
+        setFeedback({
+          type: 'success',
+          text: `예약 #${pendingAction.reservation.id}을 취소 처리했습니다.`,
+        });
+      }
+
+      setPendingAction(null);
+      await handleRefresh();
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : '예약 상태 변경에 실패했습니다.';
+      setFeedback({ type: 'error', text: message });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="p-6 md:p-12 lg:px-24">
+        <header className="mb-12 flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-5">
+            <p className="text-muted-foreground text-[10px] font-black tracking-[0.35em] uppercase">
+              Admin · Reservation
+            </p>
+            <h1 className="text-[12vw] leading-[0.85] font-black tracking-tighter text-[#2C3424] uppercase md:text-[6vw]">
+              Reservation <span className="text-[#768064]">Control</span>
+            </h1>
+            <p className="max-w-2xl text-base font-medium tracking-tight text-balance text-[#4C583E] md:text-lg">
+              현재 페이지 데이터 안에서 빠르게 검색하고, 승인 대기 예약을 검토하거나 예약을 즉시
+              취소할 수 있는 관리자용 운영 보드입니다.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              variant="outline"
+              className="rounded-full px-5"
+              onClick={() => void handleRefresh()}
+              disabled={isReloading}
+            >
+              {isReloading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+              새로고침
+            </Button>
+          </div>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {summaryItems.map((item) => (
+            <div
+              key={item.label}
+              className="border-border bg-background rounded-[2rem] border p-6 shadow-sm"
+            >
+              <p className="text-muted-foreground text-[10px] font-black tracking-[0.24em] uppercase">
+                {item.label}
+              </p>
+              <p className="text-foreground mt-4 text-4xl font-black tracking-tighter">
+                {item.value}
+              </p>
+              <p className="text-muted-foreground mt-3 text-sm font-medium tracking-tight">
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </section>
+
+        <section className="border-border bg-background mt-10 rounded-[2rem] border p-6 shadow-sm">
+          <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              {STATUS_FILTERS.map((filter) => (
+                <button
+                  key={filter.value}
+                  type="button"
+                  onClick={() => setStatusFilter(filter.value)}
+                  className={`rounded-full px-4 py-2 text-[10px] font-black tracking-[0.18em] uppercase transition-all ${
+                    statusFilter === filter.value
+                      ? 'bg-primary text-primary-foreground'
+                      : 'border-border bg-background text-muted-foreground hover:border-primary/20 hover:text-foreground border'
+                  }`}
+                >
+                  {filter.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="border-border bg-muted/20 focus-within:border-primary/25 flex w-full max-w-md items-center gap-3 rounded-full border px-4 py-3 xl:w-[360px]">
+              <Search className="text-muted-foreground size-4" />
+              <input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="현재 페이지에서 예약 ID, 신청자, 시설명 검색"
+                className="text-foreground placeholder:text-muted-foreground w-full bg-transparent text-sm font-medium outline-none"
+              />
+            </div>
+          </div>
+
+          <div className="text-muted-foreground mt-5 flex flex-wrap items-center gap-3 text-sm font-medium">
+            <span>
+              페이지 {pageData ? pageData.number + 1 : 1} / {pageData?.totalPages ?? 1}
+            </span>
+            <span className="text-border">·</span>
+            <span>서버 필터 기준 전체 {pageData?.totalElements ?? 0}건</span>
+            {deferredSearchTerm ? (
+              <>
+                <span className="text-border">·</span>
+                <span>현재 페이지 검색 결과 {filteredReservations.length}건</span>
+              </>
+            ) : null}
+          </div>
+        </section>
+
+        <AnimatePresence>
+          {feedback ? (
+            <motion.div
+              initial={{ opacity: 0, y: -14 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className={`fixed top-4 left-1/2 z-50 -translate-x-1/2 rounded-2xl border px-5 py-3 text-sm font-semibold shadow-lg ${
+                feedback.type === 'success'
+                  ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                  : 'border-red-200 bg-red-50 text-red-600'
+              }`}
+            >
+              {feedback.text}
+            </motion.div>
+          ) : null}
+        </AnimatePresence>
+
+        <section className="border-border bg-background mt-8 overflow-hidden rounded-[2rem] border shadow-sm">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[980px] text-left text-sm">
+              <thead>
+                <tr className="border-border bg-muted/20 border-b">
+                  <th className="text-muted-foreground px-6 py-4 text-[10px] font-black tracking-[0.28em] uppercase">
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setIdSortOrder((current) => (current === 'asc' ? 'desc' : 'asc'))
+                      }
+                      className="hover:text-foreground flex items-center gap-2 transition"
+                    >
+                      예약 ID
+                      <ChevronsUpDown className="size-3.5" />
+                      <span className="text-muted-foreground text-[9px] tracking-[0.2em]">
+                        {idSortOrder === 'asc' ? 'ASC' : 'DESC'}
+                      </span>
+                    </button>
+                  </th>
+                  {['신청자', '시설', '예약 일시', '상태', '액션'].map((header) => (
+                    <th
+                      key={header}
+                      className="text-muted-foreground px-6 py-4 text-[10px] font-black tracking-[0.28em] uppercase"
+                    >
+                      {header}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {isLoading ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-24">
+                      <div className="flex flex-col items-center justify-center gap-4 text-center">
+                        <Loader2 className="text-primary size-10 animate-spin" />
+                        <p className="text-muted-foreground text-[10px] font-black tracking-[0.28em] uppercase">
+                          Loading reservations
+                        </p>
+                      </div>
+                    </td>
+                  </tr>
+                ) : error ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-24">
+                      <div className="mx-auto max-w-md rounded-[2rem] border border-red-200 bg-red-50/80 p-8 text-center">
+                        <p className="text-foreground text-lg font-black tracking-tighter">
+                          예약 목록을 불러오지 못했습니다
+                        </p>
+                        <p className="text-muted-foreground mt-3 text-sm font-medium">{error}</p>
+                      </div>
+                    </td>
+                  </tr>
+                ) : filteredReservations.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-6 py-24">
+                      <div className="flex flex-col items-center justify-center gap-4 text-center">
+                        <SearchX className="text-primary/60 size-10" />
+                        <p className="text-foreground text-2xl font-black tracking-tighter">
+                          {deferredSearchTerm
+                            ? '현재 페이지 검색 결과가 없습니다'
+                            : '표시할 예약이 없습니다'}
+                        </p>
+                        <p className="text-muted-foreground max-w-md text-sm font-medium">
+                          {deferredSearchTerm
+                            ? '검색어를 바꾸거나 다른 페이지, 다른 상태 필터에서 다시 확인해보세요.'
+                            : '선택한 조건에 해당하는 예약이 아직 없습니다.'}
+                        </p>
+                      </div>
+                    </td>
+                  </tr>
+                ) : (
+                  sortedReservations.map((reservation) => {
+                    const actions = ACTIONABLE_STATUSES[reservation.status];
+
+                    return (
+                      <tr
+                        key={reservation.id}
+                        className="border-border/70 hover:bg-muted/10 border-b last:border-b-0"
+                      >
+                        <td className="px-6 py-5 align-top">
+                          <div className="text-foreground font-black tracking-tight">
+                            #{reservation.id}
+                          </div>
+                          <div className="text-muted-foreground mt-1 text-xs font-medium">
+                            USER #{reservation.userId}
+                          </div>
+                        </td>
+                        <td className="px-6 py-5 align-top">
+                          <div className="text-foreground font-black tracking-tight">
+                            {reservation.userName}
+                          </div>
+                        </td>
+                        <td className="px-6 py-5 align-top">
+                          <div className="text-foreground font-black tracking-tight">
+                            {reservation.spaceName}
+                          </div>
+                          <div className="text-muted-foreground mt-1 text-xs font-medium">
+                            SPACE #{reservation.spaceId}
+                          </div>
+                        </td>
+                        <td className="px-6 py-5 align-top">
+                          <div className="flex items-start gap-3">
+                            <div className="bg-primary/8 text-primary mt-0.5 rounded-full p-2">
+                              <CalendarDays className="size-4" />
+                            </div>
+                            <div>
+                              <div className="text-foreground font-black tracking-tight">
+                                {reservation.reservationDate}
+                              </div>
+                              <div className="text-muted-foreground mt-1 text-xs font-medium">
+                                {formatTime(reservation.startTime)} -{' '}
+                                {formatTime(reservation.endTime)}
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                        <td className="px-6 py-5 align-top">
+                          <ReservationStatusBadge status={reservation.status} />
+                        </td>
+                        <td className="px-6 py-5 align-top">
+                          {actions.length === 0 ? (
+                            <span className="text-muted-foreground text-xs font-semibold">
+                              처리 완료
+                            </span>
+                          ) : (
+                            <div className="flex flex-wrap gap-2">
+                              {actions.includes('approve') ? (
+                                <Button
+                                  size="sm"
+                                  className="rounded-full"
+                                  onClick={() => setPendingAction({ type: 'approve', reservation })}
+                                >
+                                  승인
+                                </Button>
+                              ) : null}
+                              {actions.includes('cancel') ? (
+                                <Button
+                                  size="sm"
+                                  variant="outline"
+                                  className="rounded-full border-red-200 text-red-600 hover:bg-red-50"
+                                  onClick={() => setPendingAction({ type: 'cancel', reservation })}
+                                >
+                                  취소
+                                </Button>
+                              ) : null}
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="border-border bg-muted/10 flex flex-col gap-4 border-t px-6 py-5 md:flex-row md:items-center md:justify-between">
+            <p className="text-muted-foreground text-sm font-medium">
+              검색은 현재 페이지에 로드된 예약만 대상으로 동작합니다.
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setCurrentPage((page) => Math.max(page - 1, 0))}
+                disabled={!pageData || pageData.first || isReloading}
+              >
+                <ChevronLeft className="size-4" />
+                이전
+              </Button>
+              <div className="text-foreground min-w-24 text-center text-sm font-black tracking-tight">
+                {pageData
+                  ? `${pageData.number + 1} / ${Math.max(pageData.totalPages, 1)}`
+                  : '1 / 1'}
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setCurrentPage((page) =>
+                    pageData ? Math.min(page + 1, Math.max(pageData.totalPages - 1, 0)) : page + 1,
+                  )
+                }
+                disabled={!pageData || pageData.last || isReloading}
+              >
+                다음
+                <ChevronRight className="size-4" />
+              </Button>
+            </div>
+          </div>
+        </section>
+      </div>
+
+      {pendingAction ? (
+        <ReservationActionModal
+          action={pendingAction.type}
+          reservation={pendingAction.reservation}
+          isSubmitting={isSubmitting}
+          onClose={() => setPendingAction(null)}
+          onConfirm={() => void handleConfirmAction()}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/app/admin/reservations/_components/ReservationActionModal.tsx
+++ b/frontend/src/app/admin/reservations/_components/ReservationActionModal.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { Loader2, TriangleAlert, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { AdminReservationItem } from '../_types';
+
+interface ReservationActionModalProps {
+  action: 'approve' | 'cancel';
+  reservation: AdminReservationItem;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const actionMeta = {
+  approve: {
+    title: '예약 승인',
+    description: '이 예약을 승인 처리하시겠습니까?',
+    confirmLabel: '승인하기',
+    confirmVariant: 'default' as const,
+  },
+  cancel: {
+    title: '예약 취소',
+    description: '이 예약을 관리자 권한으로 취소 처리하시겠습니까?',
+    confirmLabel: '취소 처리',
+    confirmVariant: 'destructive' as const,
+  },
+};
+
+export function ReservationActionModal({
+  action,
+  reservation,
+  isSubmitting,
+  onClose,
+  onConfirm,
+}: ReservationActionModalProps) {
+  const meta = actionMeta[action];
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+      <button
+        type="button"
+        aria-label="모달 닫기"
+        className="absolute inset-0 bg-black/45 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      <div className="border-border bg-background relative z-10 w-full max-w-lg rounded-[2rem] border p-7 shadow-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-4">
+            <div className="bg-primary/8 text-primary flex size-12 shrink-0 items-center justify-center rounded-2xl">
+              <TriangleAlert className="size-5" />
+            </div>
+            <div className="space-y-2">
+              <p className="text-muted-foreground text-[10px] font-black tracking-[0.32em] uppercase">
+                Confirm Action
+              </p>
+              <h2 className="text-foreground text-2xl font-black tracking-tighter">{meta.title}</h2>
+              <p className="text-muted-foreground text-sm leading-6 font-medium">
+                {meta.description}
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:bg-muted hover:text-foreground rounded-full p-2 transition"
+            aria-label="닫기"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="border-border bg-muted/20 mt-6 rounded-[1.5rem] border p-5">
+          <div className="grid gap-3 text-sm">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground font-semibold">예약 ID</span>
+              <span className="text-foreground font-black">#{reservation.id}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground font-semibold">신청자</span>
+              <span className="text-foreground font-black">{reservation.userName}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground font-semibold">시설</span>
+              <span className="text-foreground font-black">{reservation.spaceName}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground font-semibold">예약 일정</span>
+              <span className="text-foreground text-right font-black">
+                {reservation.reservationDate} {reservation.startTime.slice(0, 5)} -{' '}
+                {reservation.endTime.slice(0, 5)}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-7 flex justify-end gap-3">
+          <Button variant="outline" onClick={onClose} disabled={isSubmitting}>
+            닫기
+          </Button>
+          <Button variant={meta.confirmVariant} onClick={onConfirm} disabled={isSubmitting}>
+            {isSubmitting ? <Loader2 className="size-4 animate-spin" /> : null}
+            {meta.confirmLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/reservations/_components/ReservationStatusBadge.tsx
+++ b/frontend/src/app/admin/reservations/_components/ReservationStatusBadge.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import type { AdminReservationStatus } from '../_types';
+
+const statusMeta: Record<AdminReservationStatus, { label: string; className: string }> = {
+  PENDING: {
+    label: '승인 대기',
+    className: 'border-amber-200 bg-amber-50 text-amber-700',
+  },
+  APPROVED: {
+    label: '예약 확정',
+    className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  },
+  CANCELLED: {
+    label: '취소됨',
+    className: 'border-slate-200 bg-slate-100 text-slate-600',
+  },
+  COMPLETED: {
+    label: '이용 완료',
+    className: 'border-primary/10 bg-primary/10 text-primary',
+  },
+};
+
+export function ReservationStatusBadge({ status }: { status: AdminReservationStatus }) {
+  const meta = statusMeta[status];
+
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        'rounded-full px-3 py-1 text-[10px] font-black tracking-[0.24em] uppercase',
+        meta.className,
+      )}
+    >
+      {meta.label}
+    </Badge>
+  );
+}

--- a/frontend/src/app/admin/reservations/_types/index.ts
+++ b/frontend/src/app/admin/reservations/_types/index.ts
@@ -1,0 +1,30 @@
+export type AdminReservationStatus = 'PENDING' | 'APPROVED' | 'CANCELLED' | 'COMPLETED';
+
+export interface AdminReservationItem {
+  id: number;
+  userId: number;
+  userName: string;
+  spaceId: number;
+  spaceName: string;
+  status: AdminReservationStatus;
+  reservationDate: string;
+  startTime: string;
+  endTime: string;
+  approvedBy: number | null;
+}
+
+export interface AdminReservationPage {
+  content: AdminReservationItem[];
+  number: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+}
+
+export interface AdminReservationListParams {
+  status?: AdminReservationStatus;
+  p?: number;
+  s?: number;
+}

--- a/frontend/src/app/admin/reservations/page.tsx
+++ b/frontend/src/app/admin/reservations/page.tsx
@@ -1,8 +1,11 @@
+import { AdminReservationManager } from './_components/AdminReservationManager';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: '예약 관리 | Admin',
+};
+
 export default function ReservationsPage() {
-  return (
-    <div>
-      <h1 className="text-3xl font-bold">예약 관리</h1>
-      <p className="mt-2 text-muted-foreground">예약 현황 및 취소 처리 페이지입니다.</p>
-    </div>
-  );
+  return <AdminReservationManager />;
 }


### PR DESCRIPTION
## 작업 개요
관리자 예약 관리 페이지(`/admin/reservations`)를 실제 운영 가능한 화면으로 구현하고,
동시에 Facilities 페이지의 상단 여백/아이콘/주 선택 UX를 개선했습니다.

---

## 관리자 예약 관리 페이지 구현
- `/admin/reservations` 플레이스홀더 페이지를 실제 관리 화면으로 교체
- 관리자 페이지 UI 가이드를 따르는 테이블 기반 예약 관리 화면 구현
- 예약 목록 조회 API 연동
- 상태 필터 연동
- 현재 페이지 데이터 기준 검색 기능 추가
  - 예약 ID
  - 신청자명
  - 시설명
- 예약 ID 헤더 클릭 시 오름차순 / 내림차순 정렬 토글 추가
- 승인/취소 액션 버튼 추가
- 승인/취소 전 확인 모달 추가
- 액션 성공 후 목록 재조회 및 피드백 메시지 표시
- 로딩 / 에러 / 빈 상태 UI 추가
- 승인 컬럼 제거
- 상단 필터 탭에서 `승인 대기` 항목 제거

---

## Facilities 페이지 개선
### 1. 상단 여백 축소
파일: `FacilitiesContent.tsx`, `page.tsx`
- `pt-16 md:pt-32` 제거
- 레이아웃 `<main>`의 `pt-20`과 중복되던 상단 패딩 정리
- 헤더와 콘텐츠 사이의 과도한 빈 공간 해소

### 2. 시설 카드 아이콘 이모지 → lucide-react 모노톤 아이콘
파일: `FacilityCard.tsx`

- 세탁실: `🫧` → `WashingMachine`
- 라운지: `☕` → `Coffee`
- 회의실: `📋` → `BookOpen`
- 헬스장: `💪` → `Dumbbell`
- 기타: `🏠` → `Building2`
- 수용인원: `👤` → 인라인 SVG (`Users`)

추가 변경
- 선택 상태에 따라 아이콘 색상 자동 전환
  - `text-primary`
  - `text-primary-foreground/90`

### 3. 빈 상태 / 자유이용 시설 이모지 → 아이콘
파일: `FacilitiesContent.tsx`

- 등록된 시설 없음: `🏡` → `Building2`
- 자유이용 시설 안내: `✅` → `CheckCircle`

### 4. 달력 팝업으로 주 선택 기능 추가
파일: `WeeklyTimetable.tsx`

- 주 이동 헤더 중앙 날짜 범위(`📅 + 텍스트`) 클릭 시 미니 달력 팝업 표시
- 달력에서 날짜 클릭 시 해당 날짜가 포함된 주로 즉시 이동
- 현재 표시 중인 주 날짜들 `bg-primary` 하이라이트
- 오늘 날짜 `border-accent`로 구분
- 달력 내 월 이동(`‹ / ›`) 지원
- `오늘로 이동` 단축 버튼 추가
- 팝업 외부 클릭 시 자동 닫힘 (`mousedown` 이벤트 감지)
- 이전/다음 주 버튼을 lucide `ChevronLeft` / `ChevronRight` 아이콘으로 교체

---

## 확인 사항
- 관리자 예약 페이지는 서버 페이지네이션 + 클라이언트 검색/정렬 조합으로 동작합니다.
- 검색은 현재 페이지에 로드된 데이터에 대해서만 수행됩니다.
- 예약 승인/취소 액션은 처리 후 목록을 다시 조회하도록 구성했습니다.

---
