### PR TITLE
Feat/241: 관리자용 층별 배경 도면 및 어노테이션(비공간 요소) 에디터 뷰어 도입

### DIFF
--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminFloorController.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminFloorController.java
@@ -1,0 +1,62 @@
+package com.coliving.admin.space.adapter.in.web;
+
+import com.coliving.admin.space.adapter.in.web.dto.req.SaveFloorPlanRequestDto;
+import com.coliving.admin.space.adapter.in.web.dto.res.FloorPlanResponseDto;
+import com.coliving.admin.space.application.command.SaveFloorPlanCommand;
+import com.coliving.admin.space.application.port.in.FloorPlanUseCase;
+import com.coliving.admin.space.application.result.FloorPlanResult;
+import com.coliving.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "Admin Floor Plan", description = "관리자 평면도 배경/어노테이션 API")
+@RestController
+@RequestMapping("/api/admin/floors")
+@RequiredArgsConstructor
+public class AdminFloorController {
+
+    private final FloorPlanUseCase floorPlanUseCase;
+
+    @Operation(summary = "평면도 조회 (blueprint + annotations)")
+    @GetMapping("/{floor}/plan")
+    public ApiResponse<FloorPlanResponseDto> getFloorPlan(@PathVariable Integer floor) {
+        FloorPlanResult result = floorPlanUseCase.getFloorPlan(floor);
+        return ApiResponse.ok(FloorPlanResponseDto.from(result));
+    }
+
+    @Operation(summary = "평면도 저장 (opacity + annotations)")
+    @PutMapping("/{floor}/plan")
+    public ApiResponse<FloorPlanResponseDto> saveFloorPlan(
+            @PathVariable Integer floor,
+            @RequestBody SaveFloorPlanRequestDto request) {
+
+        SaveFloorPlanCommand command = SaveFloorPlanCommand.builder()
+                .floor(floor)
+                .blueprintOpacity(request.getBlueprintOpacity())
+                .annotations(request.getAnnotations())
+                .build();
+
+        FloorPlanResult result = floorPlanUseCase.saveFloorPlan(command);
+        return ApiResponse.ok(FloorPlanResponseDto.from(result), "평면도가 저장되었습니다.");
+    }
+
+    @Operation(summary = "배경 도면 이미지 업로드")
+    @PostMapping("/{floor}/plan/blueprint")
+    public ApiResponse<FloorPlanResponseDto> uploadBlueprint(
+            @PathVariable Integer floor,
+            @RequestParam("file") MultipartFile file) {
+
+        FloorPlanResult result = floorPlanUseCase.uploadBlueprint(floor, file);
+        return ApiResponse.ok(FloorPlanResponseDto.from(result), "도면이 업로드되었습니다.");
+    }
+
+    @Operation(summary = "배경 도면 이미지 삭제")
+    @DeleteMapping("/{floor}/plan/blueprint")
+    public ApiResponse<Void> deleteBlueprint(@PathVariable Integer floor) {
+        floorPlanUseCase.deleteBlueprint(floor);
+        return ApiResponse.ok(null, "도면이 삭제되었습니다.");
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/req/SaveFloorPlanRequestDto.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/req/SaveFloorPlanRequestDto.java
@@ -1,0 +1,16 @@
+package com.coliving.admin.space.adapter.in.web.dto.req;
+
+import com.coliving.admin.space.model.FloorAnnotation;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class SaveFloorPlanRequestDto {
+
+    private BigDecimal blueprintOpacity;
+    private List<FloorAnnotation> annotations;
+}

--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/res/FloorPlanResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/res/FloorPlanResponseDto.java
@@ -1,0 +1,32 @@
+package com.coliving.admin.space.adapter.in.web.dto.res;
+
+import com.coliving.admin.space.application.result.FloorPlanResult;
+import com.coliving.admin.space.model.FloorAnnotation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FloorPlanResponseDto {
+
+    private Long floorPlanId;
+    private Integer floor;
+    private String blueprintUrl;
+    private BigDecimal blueprintOpacity;
+    private List<FloorAnnotation> annotations;
+
+    public static FloorPlanResponseDto from(FloorPlanResult result) {
+        return FloorPlanResponseDto.builder()
+                .floorPlanId(result.getFloorPlanId())
+                .floor(result.getFloor())
+                .blueprintUrl(result.getBlueprintUrl())
+                .blueprintOpacity(result.getBlueprintOpacity())
+                .annotations(result.getAnnotations())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/FloorPlanEntity.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/FloorPlanEntity.java
@@ -1,0 +1,64 @@
+package com.coliving.admin.space.adapter.out.jpa;
+
+import com.coliving.admin.space.model.FloorAnnotation;
+import com.coliving.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "floor_plans", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "floor")
+})
+@SQLRestriction("deleted_at IS NULL")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class FloorPlanEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "floor_plan_id")
+    private Long floorPlanId;
+
+    @Column(name = "floor", nullable = false, unique = true)
+    private Integer floor;
+
+    @Column(name = "blueprint_url")
+    private String blueprintUrl;
+
+    @Builder.Default
+    @Column(name = "blueprint_opacity", precision = 3, scale = 2)
+    private BigDecimal blueprintOpacity = new BigDecimal("0.30");
+
+    @Builder.Default
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "annotations", columnDefinition = "jsonb")
+    private List<FloorAnnotation> annotations = new ArrayList<>();
+
+    // ── 도메인 행위 ──
+
+    public void updateBlueprint(String blueprintUrl) {
+        this.blueprintUrl = blueprintUrl;
+    }
+
+    public void removeBlueprint() {
+        this.blueprintUrl = null;
+    }
+
+    public void updatePlan(BigDecimal blueprintOpacity, List<FloorAnnotation> annotations) {
+        if (blueprintOpacity != null) {
+            this.blueprintOpacity = blueprintOpacity;
+        }
+        if (annotations != null) {
+            this.annotations = annotations;
+        }
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/FloorPlanJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/FloorPlanJpaRepository.java
@@ -1,0 +1,10 @@
+package com.coliving.admin.space.adapter.out.jpa;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface FloorPlanJpaRepository extends JpaRepository<FloorPlanEntity, Long> {
+
+    Optional<FloorPlanEntity> findByFloor(Integer floor);
+}

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/FloorPlanPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/FloorPlanPersistenceAdapter.java
@@ -1,0 +1,60 @@
+package com.coliving.admin.space.adapter.out.persistence;
+
+import com.coliving.admin.space.adapter.out.jpa.FloorPlanEntity;
+import com.coliving.admin.space.adapter.out.jpa.FloorPlanJpaRepository;
+import com.coliving.admin.space.application.port.out.FloorPlanRepositoryPort;
+import com.coliving.admin.space.model.FloorPlan;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class FloorPlanPersistenceAdapter implements FloorPlanRepositoryPort {
+
+    private final FloorPlanJpaRepository floorPlanJpaRepository;
+
+    @Override
+    public Optional<FloorPlan> findByFloor(Integer floor) {
+        return floorPlanJpaRepository.findByFloor(floor)
+                .map(this::toModel);
+    }
+
+    @Override
+    public FloorPlan save(FloorPlan floorPlan) {
+        FloorPlanEntity entity;
+
+        if (floorPlan.getFloorPlanId() != null) {
+            // 기존 엔티티 업데이트
+            entity = floorPlanJpaRepository.findById(floorPlan.getFloorPlanId())
+                    .orElseThrow(() -> new IllegalStateException("FloorPlan not found: " + floorPlan.getFloorPlanId()));
+            entity.updatePlan(floorPlan.getBlueprintOpacity(), floorPlan.getAnnotations());
+            if (floorPlan.getBlueprintUrl() != null) {
+                entity.updateBlueprint(floorPlan.getBlueprintUrl());
+            }
+        } else {
+            // 신규 생성
+            entity = FloorPlanEntity.builder()
+                    .floor(floorPlan.getFloor())
+                    .blueprintUrl(floorPlan.getBlueprintUrl())
+                    .blueprintOpacity(floorPlan.getBlueprintOpacity())
+                    .annotations(floorPlan.getAnnotations() != null ? floorPlan.getAnnotations() : new ArrayList<>())
+                    .build();
+        }
+
+        FloorPlanEntity saved = floorPlanJpaRepository.save(entity);
+        return toModel(saved);
+    }
+
+    private FloorPlan toModel(FloorPlanEntity entity) {
+        return FloorPlan.builder()
+                .floorPlanId(entity.getFloorPlanId())
+                .floor(entity.getFloor())
+                .blueprintUrl(entity.getBlueprintUrl())
+                .blueprintOpacity(entity.getBlueprintOpacity())
+                .annotations(entity.getAnnotations() != null ? entity.getAnnotations() : new ArrayList<>())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/application/command/SaveFloorPlanCommand.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/command/SaveFloorPlanCommand.java
@@ -1,0 +1,19 @@
+package com.coliving.admin.space.application.command;
+
+import com.coliving.admin.space.model.FloorAnnotation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SaveFloorPlanCommand {
+
+    private final Integer floor;
+    private final BigDecimal blueprintOpacity;
+    private final List<FloorAnnotation> annotations;
+}

--- a/backend/src/main/java/com/coliving/admin/space/application/port/in/FloorPlanUseCase.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/in/FloorPlanUseCase.java
@@ -1,0 +1,29 @@
+package com.coliving.admin.space.application.port.in;
+
+import com.coliving.admin.space.application.command.SaveFloorPlanCommand;
+import com.coliving.admin.space.application.result.FloorPlanResult;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FloorPlanUseCase {
+
+    /**
+     * 특정 층의 평면도 조회 (blueprint + annotations).
+     * 해당 층 데이터가 없으면 빈 기본값 반환.
+     */
+    FloorPlanResult getFloorPlan(Integer floor);
+
+    /**
+     * 평면도 저장 (opacity + annotations 일괄).
+     */
+    FloorPlanResult saveFloorPlan(SaveFloorPlanCommand command);
+
+    /**
+     * 배경 도면 이미지 업로드.
+     */
+    FloorPlanResult uploadBlueprint(Integer floor, MultipartFile file);
+
+    /**
+     * 배경 도면 이미지 삭제.
+     */
+    void deleteBlueprint(Integer floor);
+}

--- a/backend/src/main/java/com/coliving/admin/space/application/port/out/FloorPlanRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/out/FloorPlanRepositoryPort.java
@@ -1,0 +1,12 @@
+package com.coliving.admin.space.application.port.out;
+
+import com.coliving.admin.space.model.FloorPlan;
+
+import java.util.Optional;
+
+public interface FloorPlanRepositoryPort {
+
+    Optional<FloorPlan> findByFloor(Integer floor);
+
+    FloorPlan save(FloorPlan floorPlan);
+}

--- a/backend/src/main/java/com/coliving/admin/space/application/result/FloorPlanResult.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/result/FloorPlanResult.java
@@ -1,0 +1,32 @@
+package com.coliving.admin.space.application.result;
+
+import com.coliving.admin.space.model.FloorAnnotation;
+import com.coliving.admin.space.model.FloorPlan;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FloorPlanResult {
+
+    private final Long floorPlanId;
+    private final Integer floor;
+    private final String blueprintUrl;
+    private final BigDecimal blueprintOpacity;
+    private final List<FloorAnnotation> annotations;
+
+    public static FloorPlanResult from(FloorPlan model) {
+        return FloorPlanResult.builder()
+                .floorPlanId(model.getFloorPlanId())
+                .floor(model.getFloor())
+                .blueprintUrl(model.getBlueprintUrl())
+                .blueprintOpacity(model.getBlueprintOpacity())
+                .annotations(model.getAnnotations())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/application/service/FloorPlanService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/FloorPlanService.java
@@ -1,0 +1,135 @@
+package com.coliving.admin.space.application.service;
+
+import com.coliving.admin.space.application.command.SaveFloorPlanCommand;
+import com.coliving.admin.space.application.port.in.FloorPlanUseCase;
+import com.coliving.admin.space.application.port.out.FileStoragePort;
+import com.coliving.admin.space.application.port.out.FloorPlanRepositoryPort;
+import com.coliving.admin.space.application.result.FloorPlanResult;
+import com.coliving.admin.space.model.FloorPlan;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class FloorPlanService implements FloorPlanUseCase {
+
+    private final FloorPlanRepositoryPort floorPlanRepositoryPort;
+    private final FileStoragePort fileStoragePort;
+
+    /**
+     * 평면도의 blueprint 이미지를 저장할 때 사용하는 가상 spaceId.
+     * LocalFileStorageAdapter가 spaceId 기반으로 디렉토리를 구분하므로,
+     * floor_plans 전용 디렉토리를 위해 0L을 사용한다.
+     */
+    private static final Long FLOOR_PLAN_STORAGE_ID = 0L;
+
+    @Override
+    @Transactional(readOnly = true)
+    public FloorPlanResult getFloorPlan(Integer floor) {
+        FloorPlan model = floorPlanRepositoryPort.findByFloor(floor)
+                .orElse(FloorPlan.builder()
+                        .floor(floor)
+                        .blueprintOpacity(new BigDecimal("0.30"))
+                        .annotations(new ArrayList<>())
+                        .build());
+        return FloorPlanResult.from(model);
+    }
+
+    @Override
+    @Transactional
+    public FloorPlanResult saveFloorPlan(SaveFloorPlanCommand command) {
+        FloorPlan existing = floorPlanRepositoryPort.findByFloor(command.getFloor())
+                .orElse(null);
+
+        FloorPlan toSave;
+        if (existing != null) {
+            toSave = FloorPlan.builder()
+                    .floorPlanId(existing.getFloorPlanId())
+                    .floor(existing.getFloor())
+                    .blueprintUrl(existing.getBlueprintUrl())
+                    .blueprintOpacity(command.getBlueprintOpacity() != null
+                            ? command.getBlueprintOpacity()
+                            : existing.getBlueprintOpacity())
+                    .annotations(command.getAnnotations() != null
+                            ? command.getAnnotations()
+                            : existing.getAnnotations())
+                    .build();
+        } else {
+            toSave = FloorPlan.builder()
+                    .floor(command.getFloor())
+                    .blueprintOpacity(command.getBlueprintOpacity() != null
+                            ? command.getBlueprintOpacity()
+                            : new BigDecimal("0.30"))
+                    .annotations(command.getAnnotations() != null
+                            ? command.getAnnotations()
+                            : new ArrayList<>())
+                    .build();
+        }
+
+        FloorPlan saved = floorPlanRepositoryPort.save(toSave);
+        return FloorPlanResult.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public FloorPlanResult uploadBlueprint(Integer floor, MultipartFile file) {
+        // 파일 저장 (기존 FileStoragePort 재사용)
+        String fileName = fileStoragePort.storeFile(FLOOR_PLAN_STORAGE_ID, file);
+        String blueprintUrl = "/uploads/spaces/" + FLOOR_PLAN_STORAGE_ID + "/" + fileName;
+
+        // 기존 도면이 있으면 이전 파일 삭제
+        FloorPlan existing = floorPlanRepositoryPort.findByFloor(floor).orElse(null);
+        if (existing != null && existing.getBlueprintUrl() != null) {
+            fileStoragePort.deleteFile(existing.getBlueprintUrl());
+        }
+
+        FloorPlan toSave;
+        if (existing != null) {
+            toSave = FloorPlan.builder()
+                    .floorPlanId(existing.getFloorPlanId())
+                    .floor(existing.getFloor())
+                    .blueprintUrl(blueprintUrl)
+                    .blueprintOpacity(existing.getBlueprintOpacity())
+                    .annotations(existing.getAnnotations())
+                    .build();
+        } else {
+            toSave = FloorPlan.builder()
+                    .floor(floor)
+                    .blueprintUrl(blueprintUrl)
+                    .blueprintOpacity(new BigDecimal("0.30"))
+                    .annotations(new ArrayList<>())
+                    .build();
+        }
+
+        FloorPlan saved = floorPlanRepositoryPort.save(toSave);
+        return FloorPlanResult.from(saved);
+    }
+
+    @Override
+    @Transactional
+    public void deleteBlueprint(Integer floor) {
+        FloorPlan existing = floorPlanRepositoryPort.findByFloor(floor).orElse(null);
+        if (existing == null || existing.getBlueprintUrl() == null) {
+            return; // 삭제할 도면 없음 — 멱등
+        }
+
+        // 파일 시스템에서 삭제
+        fileStoragePort.deleteFile(existing.getBlueprintUrl());
+
+        // DB에서 blueprint_url 제거
+        FloorPlan toSave = FloorPlan.builder()
+                .floorPlanId(existing.getFloorPlanId())
+                .floor(existing.getFloor())
+                .blueprintUrl(null)
+                .blueprintOpacity(existing.getBlueprintOpacity())
+                .annotations(existing.getAnnotations())
+                .build();
+
+        floorPlanRepositoryPort.save(toSave);
+    }
+}

--- a/backend/src/main/java/com/coliving/admin/space/model/FloorAnnotation.java
+++ b/backend/src/main/java/com/coliving/admin/space/model/FloorAnnotation.java
@@ -1,0 +1,26 @@
+package com.coliving.admin.space.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 평면도 비공간 요소 (JSONB 직렬화용 VO).
+ * floor_plans.annotations 컬럼에 List 형태로 저장된다.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FloorAnnotation {
+
+    private String id;          // 프론트에서 생성하는 UUID
+    private String label;
+    private String iconType;    // DOOR, STAIRS, GARDEN, ELEVATOR, RESTROOM, CUSTOM
+    private Integer positionX;
+    private Integer positionY;
+    private Integer positionW;
+    private Integer positionH;
+    private String color;       // theme 프리셋 키
+}

--- a/backend/src/main/java/com/coliving/admin/space/model/FloorPlan.java
+++ b/backend/src/main/java/com/coliving/admin/space/model/FloorPlan.java
@@ -1,0 +1,23 @@
+package com.coliving.admin.space.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 평면도 도메인 모델 — 층별 배경 설계도 + 비공간 요소.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class FloorPlan {
+
+    private final Long floorPlanId;
+    private final Integer floor;
+    private final String blueprintUrl;
+    private final BigDecimal blueprintOpacity;
+    private final List<FloorAnnotation> annotations;
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1508,7 +1508,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1581,7 +1580,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2094,7 +2092,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3099,7 +3096,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3273,7 +3269,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5514,7 +5509,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5696,7 +5690,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5706,7 +5699,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5726,7 +5718,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5800,8 +5791,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6507,7 +6497,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6657,7 +6646,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -176,3 +176,40 @@ export const deleteRoomType = async (roomTypeId: number) => {
     method: 'DELETE',
   });
 };
+
+// ===== Floor Plan (평면도 배경/어노테이션) API =====
+
+import type { FloorPlanData, FloorAnnotation } from '../_types/layout';
+
+export const fetchFloorPlan = async (floor: number): Promise<ApiResponse<FloorPlanData>> => {
+  return await apiFetch<FloorPlanData>(`/admin/floors/${floor}/plan`);
+};
+
+export const updateFloorPlan = async (
+  floor: number,
+  data: { blueprintOpacity: number; annotations: FloorAnnotation[] }
+) => {
+  return await apiFetch<FloorPlanData>(`/admin/floors/${floor}/plan`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+};
+
+export const uploadBlueprint = async (floor: number, file: File): Promise<ApiResponse<FloorPlanData>> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const res = await fetch(`/api/admin/floors/${floor}/plan/blueprint`, {
+    method: 'POST',
+    body: formData,
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error('Failed to upload blueprint');
+  return res.json();
+};
+
+export const deleteBlueprint = async (floor: number) => {
+  return await apiFetch<void>(`/admin/floors/${floor}/plan/blueprint`, {
+    method: 'DELETE',
+  });
+};

--- a/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationBlock.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationBlock.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useDraggable } from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { MapPin, X } from 'lucide-react';
+import type { FloorAnnotation } from '../../_types/layout';
+import { ANNOTATION_PRESETS } from '../../_types/layout';
+
+interface AnnotationBlockProps {
+  annotation: FloorAnnotation;
+  cellSize: number;
+  onRemove: (id: string) => void;
+  onUpdate: (id: string, updates: Partial<FloorAnnotation>) => void;
+}
+
+export function AnnotationBlock({ annotation, cellSize, onRemove, onUpdate }: AnnotationBlockProps) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: `anno-${annotation.id}`,
+    data: {
+      type: 'ANNOTATION',
+      annotation,
+    },
+  });
+
+  const style = {
+    position: 'absolute' as const,
+    left: `${annotation.positionX * cellSize}px`,
+    top: `${annotation.positionY * cellSize}px`,
+    width: `${annotation.positionW * cellSize}px`,
+    height: `${annotation.positionH * cellSize}px`,
+    transform: CSS.Translate.toString(transform),
+    zIndex: isDragging ? 50 : 20,
+    opacity: isDragging ? 0.8 : 1,
+    touchAction: 'none',
+  };
+
+  const preset = ANNOTATION_PRESETS[annotation.color] || ANNOTATION_PRESETS.primary;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...listeners}
+      {...attributes}
+      className={`
+        border-2 border-dashed flex flex-col items-center justify-center relative group
+        transition-shadow cursor-grab active:cursor-grabbing hover:shadow-lg
+      `}
+    >
+      {/* Background layer */}
+      <div 
+        className="absolute inset-0 rounded opacity-80 pointer-events-none" 
+        style={{ backgroundColor: preset.bg, borderColor: preset.border }}
+      />
+      
+      {/* Content */}
+      <div className="relative z-10 flex flex-col items-center pointer-events-none gap-1">
+        <MapPin className="w-4 h-4 opacity-70" />
+        <span className="text-[10px] font-bold text-balance text-center uppercase px-1 leading-tight text-[var(--foreground)]">
+          {annotation.label}
+        </span>
+      </div>
+
+      {/* Hover action : Delete */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove(annotation.id);
+        }}
+        className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity z-20 pointer-events-auto shadow-md"
+        onPointerDown={(e) => e.stopPropagation()} // 드래그 이벤트 방지
+      >
+        <X className="w-3 h-3" />
+      </button>
+
+      {/* Resize handle (간이 구현 - 여기서는 크기 조절 생략하거나 추후 추가) */}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationControls.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationControls.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import { FloorAnnotation, ANNOTATION_PRESETS } from '../../_types/layout';
+
+interface AnnotationControlsProps {
+  onAddAnnotation: (annotation: FloorAnnotation) => void;
+}
+
+export function AnnotationControls({ onAddAnnotation }: AnnotationControlsProps) {
+  const [selectedIcon, setSelectedIcon] = useState<FloorAnnotation['iconType']>('DOOR');
+  const [selectedColor, setSelectedColor] = useState<string>('primary');
+  const [labelText, setLabelText] = useState<string>('');
+
+  const icons: FloorAnnotation['iconType'][] = ['DOOR', 'STAIRS', 'ELEVATOR', 'RESTROOM', 'GARDEN', 'CUSTOM'];
+
+  const handleAdd = () => {
+    onAddAnnotation({
+      id: crypto.randomUUID(),
+      label: labelText || selectedIcon,
+      iconType: selectedIcon,
+      positionX: 0, // 기본 위치 좌상단
+      positionY: 0,
+      positionW: 1, // 기본 크기 1x1
+      positionH: 1,
+      color: selectedColor,
+    });
+    setLabelText('');
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-4 py-2 border-b border-border mb-4">
+      <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--foreground)] w-24">
+        요소 추가
+      </h3>
+      
+      <div className="flex items-center gap-2">
+        <select
+          value={selectedIcon}
+          onChange={(e) => setSelectedIcon(e.target.value as FloorAnnotation['iconType'])}
+          className="h-9 px-3 border border-border rounded-lg text-sm bg-[var(--background)] text-[var(--foreground)] outline-none"
+        >
+          {icons.map((icon) => (
+            <option key={icon} value={icon}>
+              {icon}
+            </option>
+          ))}
+        </select>
+        
+        <input
+          type="text"
+          placeholder="라벨 (선택)"
+          value={labelText}
+          onChange={(e) => setLabelText(e.target.value)}
+          className="h-9 px-3 border border-border rounded-lg text-sm bg-[var(--background)] text-[var(--foreground)] outline-none w-28"
+          maxLength={10}
+        />
+        
+        <div className="flex items-center gap-1 mx-2">
+          {Object.entries(ANNOTATION_PRESETS).map(([key, value]) => (
+            <button
+              key={key}
+              onClick={() => setSelectedColor(key)}
+              className={`w-6 h-6 rounded-full border-2 ${
+                selectedColor === key ? 'border-[var(--foreground)]' : 'border-transparent'
+              }`}
+              style={{ backgroundColor: value.bg, borderColor: selectedColor === key ? 'var(--foreground)' : value.border }}
+              title={key}
+            />
+          ))}
+        </div>
+
+        <Button onClick={handleAdd} size="sm" className="flex items-center gap-1">
+          <Plus className="w-4 h-4" /> 추가
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/spaces/_components/floor-plan/BlueprintControls.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/BlueprintControls.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { ChangeEvent, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Upload, Trash2, Image as ImageIcon } from 'lucide-react';
+
+interface BlueprintControlsProps {
+  blueprintUrl: string | null;
+  blueprintOpacity: number;
+  onUpload: (file: File) => void;
+  onDelete: () => void;
+  onOpacityChange: (opacity: number) => void;
+}
+
+export function BlueprintControls({
+  blueprintUrl,
+  blueprintOpacity,
+  onUpload,
+  onDelete,
+  onOpacityChange,
+}: BlueprintControlsProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      onUpload(e.target.files[0]);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-4 py-2 border-b border-border mb-4">
+      <h3 className="text-sm font-bold uppercase tracking-widest text-[var(--foreground)] w-24">
+        배경 도면
+      </h3>
+      <input
+        type="file"
+        accept="image/*"
+        className="hidden"
+        ref={fileInputRef}
+        onChange={handleFileChange}
+      />
+
+      {!blueprintUrl ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => fileInputRef.current?.click()}
+          className="flex items-center gap-2"
+        >
+          <Upload className="w-4 h-4" /> 도면 업로드
+        </Button>
+      ) : (
+        <div className="flex items-center gap-6 flex-1">
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={onDelete}
+            className="flex items-center gap-2"
+          >
+            <Trash2 className="w-4 h-4" /> 도면 삭제
+          </Button>
+
+          <div className="flex items-center gap-3 flex-1 max-w-sm">
+            <ImageIcon className="w-4 h-4 text-[var(--foreground)]/50" />
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={blueprintOpacity}
+              onChange={(e) => onOpacityChange(parseFloat(e.target.value))}
+              className="flex-1 w-full h-1 bg-[var(--foreground)]/20 rounded-lg appearance-none cursor-pointer"
+              title="투명도 조절"
+            />
+            <span className="text-xs font-mono w-8 text-right opacity-80">
+              {Math.round(blueprintOpacity * 100)}%
+            </span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/spaces/_components/floor-plan/FloorPlanEditor.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/FloorPlanEditor.tsx
@@ -16,6 +16,9 @@ import { DEFAULT_LAYOUT } from '../../_types/layout';
 import { FloorSelector } from './FloorSelector';
 import { GridCanvas } from './GridCanvas';
 import { SpaceBlock } from './SpaceBlock';
+import { BlueprintControls } from './BlueprintControls';
+import { AnnotationControls } from './AnnotationControls';
+import { AnnotationBlock } from './AnnotationBlock';
 
 /** 드래그 중 격자 스냅 Modifier */
 function createSnapModifier(gridSize: number): Modifier {
@@ -43,7 +46,15 @@ export function FloorPlanEditor() {
     loading,
     saving,
     dirty,
+    saveAll,
     saveMessage,
+    floorPlan,
+    updateBlueprintOpacity,
+    handleUploadBlueprint,
+    handleDeleteBlueprint,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
   } = useFloorPlan();
 
   const [cellSize, setCellSize] = useState(0);
@@ -62,23 +73,45 @@ export function FloorPlanEditor() {
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, delta } = event;
-      const block = blocks.find((b) => b.spaceId === active.id);
-      if (!block || cellSize === 0) return;
+      if (cellSize === 0) return;
 
-      const newGridX = clamp(
-        block.gridX + Math.round(delta.x / cellSize),
-        0,
-        DEFAULT_LAYOUT.columns - block.gridW,
-      );
-      const newGridY = clamp(
-        block.gridY + Math.round(delta.y / cellSize),
-        0,
-        DEFAULT_LAYOUT.rows - block.gridH,
-      );
+      const type = active.data.current?.type;
 
-      updateBlockPosition(block.spaceId, newGridX, newGridY);
+      if (type === 'ANNOTATION') {
+        const idStr = String(active.id).replace('anno-', '');
+        const anno = floorPlan?.annotations.find((a) => a.id === idStr);
+        if (!anno) return;
+
+        const newGridX = clamp(
+          anno.positionX + Math.round(delta.x / cellSize),
+          0,
+          DEFAULT_LAYOUT.columns - anno.positionW,
+        );
+        const newGridY = clamp(
+          anno.positionY + Math.round(delta.y / cellSize),
+          0,
+          DEFAULT_LAYOUT.rows - anno.positionH,
+        );
+        updateAnnotation(idStr, { positionX: newGridX, positionY: newGridY });
+      } else {
+        const block = blocks.find((b) => b.spaceId === active.id);
+        if (!block) return;
+
+        const newGridX = clamp(
+          block.gridX + Math.round(delta.x / cellSize),
+          0,
+          DEFAULT_LAYOUT.columns - block.gridW,
+        );
+        const newGridY = clamp(
+          block.gridY + Math.round(delta.y / cellSize),
+          0,
+          DEFAULT_LAYOUT.rows - block.gridH,
+        );
+
+        updateBlockPosition(block.spaceId, newGridX, newGridY);
+      }
     },
-    [blocks, cellSize, updateBlockPosition],
+    [blocks, cellSize, updateBlockPosition, floorPlan, updateAnnotation],
   );
 
   const handleResizeEnd = useCallback(
@@ -126,7 +159,7 @@ export function FloorPlanEditor() {
         />
 
         <button
-          onClick={saveLayout}
+          onClick={saveAll}
           disabled={!dirty || saving}
           className={`flex items-center gap-2 px-6 py-3 rounded-full font-black text-sm tracking-tight transition-all duration-300
             ${dirty
@@ -166,15 +199,38 @@ export function FloorPlanEditor() {
         </AnimatePresence>
       </div>
 
+      {/* 도면 관리 및 어노테이션 도구 */}
+      <BlueprintControls
+        blueprintUrl={floorPlan?.blueprintUrl || null}
+        blueprintOpacity={floorPlan?.blueprintOpacity ?? 0.3}
+        onUpload={handleUploadBlueprint}
+        onDelete={handleDeleteBlueprint}
+        onOpacityChange={updateBlueprintOpacity}
+      />
+      <AnnotationControls onAddAnnotation={addAnnotation} />
+
       {/* 도면 격자 */}
       <DndContext
         sensors={sensors}
         modifiers={[snapModifier]}
         onDragEnd={handleDragEnd}
       >
-        <GridCanvas onCellSizeChange={setCellSize}>
+        <GridCanvas 
+          onCellSizeChange={setCellSize}
+          blueprintUrl={floorPlan?.blueprintUrl}
+          blueprintOpacity={floorPlan?.blueprintOpacity}
+        >
           {blocks.map((block) => (
             <SpaceBlock key={block.spaceId} block={block} cellSize={cellSize} onResizeEnd={handleResizeEnd} />
+          ))}
+          {floorPlan?.annotations.map((anno) => (
+            <AnnotationBlock
+              key={anno.id}
+              annotation={anno}
+              cellSize={cellSize}
+              onRemove={removeAnnotation}
+              onUpdate={updateAnnotation}
+            />
           ))}
         </GridCanvas>
       </DndContext>

--- a/frontend/src/app/admin/spaces/_components/floor-plan/GridCanvas.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/GridCanvas.tsx
@@ -8,12 +8,16 @@ interface GridCanvasProps {
   config?: LayoutConfig;
   children: React.ReactNode;
   onCellSizeChange: (cellSize: number) => void;
+  blueprintUrl?: string | null;
+  blueprintOpacity?: number;
 }
 
 export function GridCanvas({
   config = DEFAULT_LAYOUT,
   children,
   onCellSizeChange,
+  blueprintUrl,
+  blueprintOpacity = 0.3,
 }: GridCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [cellSize, setCellSize] = useState(0);
@@ -54,11 +58,26 @@ export function GridCanvas({
         backgroundColor: 'var(--background)',
       }}
     >
+      {/* 백그라운드 이미지 레이어 (격자 뒤) */}
+      {blueprintUrl && (
+        <div
+          className="absolute inset-0 z-0 pointer-events-none bg-center bg-no-repeat bg-cover"
+          style={{
+            backgroundImage: `url(${blueprintUrl})`,
+            opacity: blueprintOpacity,
+          }}
+        />
+      )}
+
       {/* 격자 라벨 (좌상단) */}
       <div className="absolute top-3 left-4 text-[9px] font-black uppercase tracking-[0.2em] opacity-20 select-none pointer-events-none z-10">
         {config.columns}×{config.rows} GRID
       </div>
-      {children}
+      
+      {/* 칠드런 레이어 (블록, 어노테이션 등) */}
+      <div className="relative z-20 w-full h-full pointer-events-auto">
+        {children}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/admin/spaces/_hooks/useFloorPlan.ts
+++ b/frontend/src/app/admin/spaces/_hooks/useFloorPlan.ts
@@ -1,8 +1,17 @@
 'use client';
 
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { fetchSpaces, updateSpaceLayout, SpaceDTO, extractRoomTypeName } from '../_api/spaceAdminApi';
-import type { FloorPlanBlock } from '../_types/layout';
+import {
+  fetchSpaces,
+  updateSpaceLayout,
+  SpaceDTO,
+  extractRoomTypeName,
+  fetchFloorPlan,
+  updateFloorPlan,
+  uploadBlueprint,
+  deleteBlueprint,
+} from '../_api/spaceAdminApi';
+import type { FloorPlanBlock, FloorPlanData, FloorAnnotation } from '../_types/layout';
 
 /** SpaceDTO → FloorPlanBlock 변환 (DB 값 우선, 없으면 기본값) */
 function spaceToBlock(space: SpaceDTO): FloorPlanBlock {
@@ -35,6 +44,10 @@ export function useFloorPlan() {
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  // 평면도 (배경/어노테이션) 상태
+  const [floorPlan, setFloorPlan] = useState<FloorPlanData | null>(null);
+  const [fpDirty, setFpDirty] = useState(false);
 
   // 원본 좌표+크기 스냅샷 (dirty 판별용)
   const originalPositions = useRef<Map<number, OriginalState>>(new Map());
@@ -79,15 +92,30 @@ export function useFloorPlan() {
     loadSpaces();
   }, [loadSpaces]);
 
-  // 선택된 층에 맞는 블록들 생성
+  // 배치가 선택된 층일 때, 해당 층의 평면도 데이터를 가져옴
+  const loadFloorPlan = useCallback(async (floor: number) => {
+    try {
+      const res = await fetchFloorPlan(floor);
+      if (res.data) {
+        setFloorPlan(res.data);
+      }
+      setFpDirty(false);
+    } catch (e) {
+      console.error('Failed to load floor plan:', e);
+    }
+  }, []);
+
+  // 선택된 층에 맞는 블록들 생성 및 평면도 로드
   useEffect(() => {
     if (selectedFloor === null) {
       setBlocks([]);
+      setFloorPlan(null);
       return;
     }
     const filtered = allSpaces.filter((s) => s.floor === selectedFloor);
     setBlocks(filtered.map(spaceToBlock));
-  }, [selectedFloor, allSpaces]);
+    loadFloorPlan(selectedFloor);
+  }, [selectedFloor, allSpaces, loadFloorPlan]);
 
   // 유일한 층 목록
   const floors = [
@@ -161,6 +189,99 @@ export function useFloorPlan() {
     }
   }, [blocks, dirty]);
 
+  // 평면도 저장 (서버 전송)
+  const saveFloorPlanState = useCallback(async () => {
+    if (!fpDirty || selectedFloor === null || !floorPlan) return;
+
+    try {
+      setSaving(true);
+      await updateFloorPlan(selectedFloor, {
+        blueprintOpacity: floorPlan.blueprintOpacity,
+        annotations: floorPlan.annotations,
+      });
+      setFpDirty(false);
+      setSaveMessage((prev) => (prev ? prev + ' 평면도 구성이 저장되었습니다.' : '평면도 구성이 저장되었습니다.'));
+    } catch (e) {
+      console.error('Failed to save floor plan:', e);
+      setSaveMessage('평면도 저장에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  }, [fpDirty, floorPlan, selectedFloor]);
+
+  // 전체 저장 함수 (블록 + 평면도)
+  const saveAll = useCallback(async () => {
+    setSaveMessage(null);
+    if (dirty) await saveLayout();
+    if (fpDirty) await saveFloorPlanState();
+  }, [dirty, fpDirty, saveLayout, saveFloorPlanState]);
+
+  // 평면도 조작 함수들
+  const updateBlueprintOpacity = useCallback((opacity: number) => {
+    setFloorPlan((prev) => (prev ? { ...prev, blueprintOpacity: opacity } : prev));
+    setFpDirty(true);
+  }, []);
+
+  const handleUploadBlueprint = useCallback(
+    async (file: File) => {
+      if (selectedFloor === null) return;
+      try {
+        setSaving(true);
+        const res = await uploadBlueprint(selectedFloor, file);
+        if (res.data) setFloorPlan(res.data);
+        setSaveMessage('도면이 업로드되었습니다.');
+      } catch (e) {
+        console.error(e);
+        setSaveMessage('도면 업로드에 실패했습니다.');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [selectedFloor]
+  );
+
+  const handleDeleteBlueprint = useCallback(async () => {
+    if (selectedFloor === null) return;
+    try {
+      setSaving(true);
+      await deleteBlueprint(selectedFloor);
+      setFloorPlan((prev) => (prev ? { ...prev, blueprintUrl: null } : prev));
+      setSaveMessage('도면이 삭제되었습니다.');
+    } catch (e) {
+      console.error(e);
+      setSaveMessage('도면 삭제에 실패했습니다.');
+    } finally {
+      setSaving(false);
+    }
+  }, [selectedFloor]);
+
+  const addAnnotation = useCallback((annotation: FloorAnnotation) => {
+    setFloorPlan((prev) => {
+      if (!prev) return prev;
+      return { ...prev, annotations: [...prev.annotations, annotation] };
+    });
+    setFpDirty(true);
+  }, []);
+
+  const updateAnnotation = useCallback((id: string, updates: Partial<FloorAnnotation>) => {
+    setFloorPlan((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        annotations: prev.annotations.map((a) => (a.id === id ? { ...a, ...updates } : a)),
+      };
+    });
+    setFpDirty(true);
+  }, []);
+
+  const removeAnnotation = useCallback((id: string) => {
+    setFloorPlan((prev) => {
+      if (!prev) return prev;
+      return { ...prev, annotations: prev.annotations.filter((a) => a.id !== id) };
+    });
+    setFpDirty(true);
+  }, []);
+
   return {
     blocks,
     floors,
@@ -171,7 +292,15 @@ export function useFloorPlan() {
     saveLayout,
     loading,
     saving,
-    dirty,
+    dirty: dirty || fpDirty, // 둘 중 하나라도 더티면 저장 버튼 활성화
+    saveAll,
     saveMessage,
+    floorPlan,
+    updateBlueprintOpacity,
+    handleUploadBlueprint,
+    handleDeleteBlueprint,
+    addAnnotation,
+    updateAnnotation,
+    removeAnnotation,
   };
 }

--- a/frontend/src/app/admin/spaces/_types/layout.ts
+++ b/frontend/src/app/admin/spaces/_types/layout.ts
@@ -17,6 +17,27 @@ export interface FloorPlanBlock {
   hasDeviceError: boolean;
 }
 
+/** 비공간 요소 (문, 계단, 정원 등) 어노테이션 타입 */
+export interface FloorAnnotation {
+  id: string;          // UUID
+  label: string;
+  iconType: 'DOOR' | 'STAIRS' | 'GARDEN' | 'ELEVATOR' | 'RESTROOM' | 'CUSTOM';
+  positionX: number;
+  positionY: number;
+  positionW: number;
+  positionH: number;
+  color: string;       // theme CSS 변수 키 (예: 'primary', 'accent')
+}
+
+/** 백엔드 /api/admin/floors/{floor}/plan 의 응답 타입 */
+export interface FloorPlanData {
+  floorPlanId?: number;
+  floor: number;
+  blueprintUrl: string | null;
+  blueprintOpacity: number;
+  annotations: FloorAnnotation[];
+}
+
 /** 격자 설정 */
 export interface LayoutConfig {
   columns: number;
@@ -48,4 +69,12 @@ export const STATUS_COLORS: Record<string, { bg: string; border: string; label: 
     border: 'rgba(202, 138, 4, 0.6)',
     label: '점검중',
   },
+};
+
+/** 어노테이션 색상 프리셋 (CSS 변수 기반) */
+export const ANNOTATION_PRESETS: Record<string, { bg: string; border: string }> = {
+  primary: { bg: 'rgba(44, 52, 36, 0.2)', border: 'rgba(44, 52, 36, 0.5)' },    // Moss
+  accent: { bg: 'rgba(118, 128, 100, 0.2)', border: 'rgba(118, 128, 100, 0.5)' }, // Olive
+  muted: { bg: 'rgba(76, 88, 62, 0.2)', border: 'rgba(76, 88, 62, 0.4)' },      // Cypress
+  secondary: { bg: 'rgba(149, 149, 129, 0.2)', border: 'rgba(149, 149, 129, 0.5)' }, // Cedar
 };


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자가 단순히 격자 위에 공간 블록만 배치하는 것을 넘어, **실제 층의 구조를 반영하는 배경 도면 이미지** 위에서 호실과 시설물 위치를 한눈에 파악할 수 있는 관리 도구를 도입합니다.
- 공용 구역, 계단, 승강기 위치, 화장실 등 비공간 요소(Annotation)를 자유롭게 생성 및 제어하여 이후 전면 개편될 '사용자 열람용 서비스'를 위한 시각적 토대를 마련합니다.

## 🔑 주요 변경 사항 (What)
- **[(Backend)](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/FloorPlanPersistenceAdapter.java:24:4-48:5) 독립적인 [FloorPlan](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/model/FloorPlan.java:12:0-22:1) 모듈 구축:**
  - 다른 도메인과 엮이지 않는 단독 테이블 `floor_plans`([FloorPlanEntity](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/FloorPlanEntity.java:14:0-63:1)) 생성.
  - JSONB 데이터 타입을 십분 활용해 동적으로 크기가 확장되는 비공간 요소(`annotations`) 일괄 관리.
  - 별도의 [AdminFloorController](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminFloorController.java:14:0-61:1)를 신설해 이미지 업로드 및 투명도 조절 API 엔드포인트 분리.
- **[(Frontend)](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/FloorPlanPersistenceAdapter.java:24:4-48:5) 평면도 배치 대시보드 컴포넌트 대폭 고도화:**
  - [GridCanvas](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/GridCanvas.tsx:14:0-82:1)를 Z-Index 레이어(배경도면 -> 격자/좌표 -> 공간/어노테이션) 방식으로 다중 구현.
  - 업로드 및 실시간 투명도를 조절하는 [BlueprintControls](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/BlueprintControls.tsx:14:0-82:1) 탑재.
  - 테마 변수(`primary`, `accent`) 및 SVG 아이콘을 삽입하는 [AnnotationControls](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationControls.tsx:11:0-80:1) 툴바.
  - `dnd-kit`의 `useDraggable`을 확장한 [AnnotationBlock](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/AnnotationBlock.tsx:15:0-78:1) 인터페이스 구축 및 통합 `saveAll` 상태 관리 연동.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #241

## 💻 테스트 방법 (How to Test)
1. 백엔드 및 프론트엔드를 기동하고 `Admin > 공간 관리 > 배치 대시보드` 에 진입합니다.
2. 좌측 상단 층 번호를 이동시켜 층계별로 독립적인 평면도 정보가 Fetching 되는지 확인합니다.
3. **[배경 도면]** 메뉴에서 `도면 업로드`를 클릭해 층별 건물 구조 이미지(PNG/JPG)를 올리고 투명도(0% ~ 100%) Range 슬라이더가 적용되는지 확인합니다.
4. **[요소 추가]** 메뉴에서 아이콘 종류(STAIRS, ELEVATOR 등)와 색상을 골라 캔버스에 추가하고 마우스로 자유롭게 위치시킵니다.
5. 우측 상단의 `[배치 저장]` 버튼을 누르고 브라우저를 새로고침하여 위치와 스펙 내용이 지속 저장되는지 점검합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
*(기능 확정 및 테스트 완료 후 스크린샷 첨부)*

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?