### PR TITLE
[CS/fix] 알림(reference_type), 댓글 알림, 계약 신청 JSON

### DIFF
--- a/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Objects;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -37,7 +39,7 @@ public class CommentPostedNotificationListener {
 
     private void notifyPostAuthor(CommentPostedEvent event) {
         communityRepositoryPort.findPostById(event.getPostId()).ifPresent(post -> {
-            if (post.getUserId().equals(event.getActorId())) {
+            if (Objects.equals(post.getUserId(), event.getActorId())) {
                 return;
             }
             try {
@@ -60,11 +62,11 @@ public class CommentPostedNotificationListener {
             return;
         }
         commentRepositoryPort.findCommentById(event.getParentCommentId()).ifPresent(parent -> {
-            if (parent.getUserId().equals(event.getActorId())) {
+            if (Objects.equals(parent.getUserId(), event.getActorId())) {
                 return;
             }
             boolean isPostOwner = communityRepositoryPort.findPostById(event.getPostId())
-                    .map(p -> p.getUserId().equals(parent.getUserId()))
+                    .map(p -> Objects.equals(p.getUserId(), parent.getUserId()))
                     .orElse(false);
             if (isPostOwner) {
                 return;

--- a/backend/src/main/java/com/coliving/common/notification/adapter/out/persistence/NotificationPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/out/persistence/NotificationPersistenceAdapter.java
@@ -57,8 +57,9 @@ public class NotificationPersistenceAdapter implements NotificationRepositoryPor
         }
 
         try {
-            // 중복 방어: 이미 동일한 알림이 있는지 1차 확인
-            if (exists(userId, type, referenceType, referenceId)) {
+            // 댓글 알림은 같은 글(postId)에 여러 번 와야 하므로 (user,type,ref) exists 로 막지 않음
+            if (type != NotificationType.COMMUNITY_COMMENT
+                    && exists(userId, type, referenceType, referenceId)) {
                 log.info("Notification already exists for user: {}, type: {}, refId: {}", userId, type, referenceId);
                 return null;
             }

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationService.java
@@ -12,6 +12,7 @@ import com.coliving.common.notification.application.result.MarkNotificationReadR
 import com.coliving.common.notification.application.result.NotificationItemResult;
 import com.coliving.common.notification.application.result.NotificationListResult;
 import com.coliving.common.notification.model.Notification;
+import com.coliving.common.notification.model.NotificationType;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
 import org.springframework.data.domain.Page;
@@ -90,7 +91,11 @@ public class NotificationService implements NotificationUseCase, CreateNotificat
             throw new BusinessException(ErrorCode.VALIDATION_ERROR);
         }
 
-        if (command.getReferenceType() != null && command.getReferenceId() != null) {
+        // 댓글 알림은 referenceId가 글(postId)로 같아서 매 댓글마다 별도 알림이 필요함.
+        // (userId, COMMUNITY_COMMENT, COMMUNITY, postId) 기준 exists 는 첫 댓글 이후 전부 스킵되는 버그가 됨.
+        if (command.getType() != NotificationType.COMMUNITY_COMMENT
+                && command.getReferenceType() != null
+                && command.getReferenceId() != null) {
             boolean exists = notificationRepositoryPort.exists(
                     command.getUserId(),
                     command.getType(),

--- a/backend/src/main/java/com/coliving/user/contract/adapter/in/web/dto/req/ContractApplyRequestDto.java
+++ b/backend/src/main/java/com/coliving/user/contract/adapter/in/web/dto/req/ContractApplyRequestDto.java
@@ -1,5 +1,6 @@
 package com.coliving.user.contract.adapter.in.web.dto.req;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ContractApplyRequestDto {
     private Long contractId;
 

--- a/backend/src/main/resources/db/maintenance/postgresql-notifications-type-check.sql
+++ b/backend/src/main/resources/db/maintenance/postgresql-notifications-type-check.sql
@@ -1,7 +1,20 @@
--- notifications.type CHECK 제약이 애플리케이션 NotificationType enum 과 불일치하면
--- (예: VOC_CREATED 미포함) 민원 등록 시 관리자 알림 INSERT가 실패하고 전체 트랜잭션이 롤백될 수 있습니다.
+-- notifications 테이블 CHECK 제약을 Java NotificationType / ReferenceType enum 과 맞춥니다.
 -- 배포 DB에서 한 번 실행하세요.
 
+-- reference_type: 댓글·공지 알림은 COMMUNITY (기존 스키마는 CONTRACT/RESERVATION/VOC 만 허용하는 경우가 많음)
+ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
+
+ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (
+    reference_type IS NULL OR reference_type IN (
+        'CONTRACT',
+        'RESERVATION',
+        'VOC',
+        'COMMUNITY',
+        'PAYMENT'
+    )
+);
+
+-- type
 ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check;
 
 ALTER TABLE notifications ADD CONSTRAINT notifications_type_check CHECK (type IN (


### PR DESCRIPTION
## 요약
- **DB**: `notifications_reference_type_check`에 `COMMUNITY`, `PAYMENT` 등 허용 목록 반영 유지보수 SQL 추가(운영 DB에는 이미 DROP/ADD로 적용 완료).
- **댓글 알림**: 알림 저장·중복 처리 및 커밋 후 리스너 쪽 정리.
- **계약 신청**: `ContractApplyRequestDto`에 `@JsonIgnoreProperties(ignoreUnknown = true)` 적용해 `termsAgreed` 등 미인식 필드로 인한 역직렬화 오류 방지.

## 운영 DB
다음은 이미 실행한 경우 생략 가능합니다.
```sql
ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (reference_type IS NULL OR reference_type IN ('CONTRACT','RESERVATION','VOC','COMMUNITY','PAYMENT'));