### PR TITLE
[USR/feat] 회원가입 양식 준수 로직 추가, 버그 수정

### DIFF
--- a/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java
@@ -38,7 +38,8 @@ public class RegisterRequestDto {
 
     private String nationality;
 
-    @Pattern(regexp = "^(02-\\d{3,4}-\\d{4}|0\\d{2}-\\d{3,4}-\\d{4}|)$", message = "올바른 연락처 형식이 아닙니다.")
+    @NotBlank(message = "연락처를 입력해주세요.")
+    @Pattern(regexp = "^(02-\\d{3,4}-\\d{4}|0\\d{2}-\\d{3,4}-\\d{4})$", message = "올바른 연락처 형식이 아닙니다.")
     private String phone;
 
     @NotBlank(message = "이메일을 입력해주세요.")

--- a/backend/src/main/java/com/coliving/common/auth/application/service/AuthService.java
+++ b/backend/src/main/java/com/coliving/common/auth/application/service/AuthService.java
@@ -44,15 +44,23 @@ public class AuthService implements RegisterUseCase, LoginUseCase, RefreshUseCas
     @Override
     @Transactional
     public void register(RegisterCommand command) {
+        java.util.Map<String, String> errors = new java.util.HashMap<>();
+
         if (!command.getPassword().equals(command.getPasswordConfirm())) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "비밀번호가 일치하지 않습니다.");
+            errors.put("passwordConfirm", "비밀번호가 일치하지 않습니다.");
         }
 
         if (authRepositoryPort.existsByLoginId(command.getLoginId())) {
-            throw new BusinessException(ErrorCode.DUPLICATE_LOGIN_ID);
+            errors.put("loginId", "이미 사용 중인 로그인 ID입니다.");
         }
 
-        /* 이메일 중복 체크가 필요한 경우 여기에 추가 */
+        if (authRepositoryPort.existsByEmail(command.getEmail())) {
+            errors.put("email", "이미 사용 중인 이메일입니다.");
+        }
+
+        if (!errors.isEmpty()) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, errors);
+        }
         
         String encodedPassword = passwordEncoder.encode(command.getPassword());
         

--- a/backend/src/main/java/com/coliving/global/dto/ApiResponse.java
+++ b/backend/src/main/java/com/coliving/global/dto/ApiResponse.java
@@ -49,4 +49,13 @@ public class ApiResponse<T> {
                 .errorCode(code.name())
                 .build();
     }
+
+    public static <T> ApiResponse<T> error(ErrorCode code, T data) {
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(code.getMessage())
+                .errorCode(code.name())
+                .data(data)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/coliving/global/error/BusinessException.java
+++ b/backend/src/main/java/com/coliving/global/error/BusinessException.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class BusinessException extends RuntimeException {
 
     private final ErrorCode errorCode;
+    private java.util.Map<String, String> errors;
 
     public BusinessException(ErrorCode errorCode) {
         super(errorCode.getMessage());
@@ -15,5 +16,11 @@ public class BusinessException extends RuntimeException {
     public BusinessException(ErrorCode errorCode, String message) {
         super(message);
         this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, java.util.Map<String, String> errors) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errors = errors;
     }
 }

--- a/backend/src/main/java/com/coliving/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/coliving/global/error/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
     ACTIVE_CONTRACT_EXISTS(HttpStatus.CONFLICT, "활성 계약이 존재하여 진행할 수 없습니다"),
     UNPAID_PAYMENT_EXISTS(HttpStatus.CONFLICT, "미납금이 존재하여 진행할 수 없습니다"),
     DUPLICATE_LOGIN_ID(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID입니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다"),
+    DUPLICATE_BOTH(HttpStatus.CONFLICT, "이미 사용 중인 로그인 ID 및 이메일입니다"),
 
     // ── 계정 찾기 ──
     ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 계정 없음"),

--- a/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java
@@ -24,6 +24,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
         log.warn("BusinessException: {}", e.getMessage());
+        if (e.getErrors() != null && !e.getErrors().isEmpty()) {
+            return ResponseEntity
+                    .status(errorCode.getStatus())
+                    .body(ApiResponse.error(errorCode, e.getErrors()));
+        }
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode, e.getMessage()));
@@ -52,7 +57,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();
         for (FieldError fieldError : e.getBindingResult().getFieldErrors()) {
             errors.put(fieldError.getField(), fieldError.getDefaultMessage());
@@ -60,7 +65,7 @@ public class GlobalExceptionHandler {
         log.warn("Validation failed: {}", errors);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.error(ErrorCode.VALIDATION_ERROR));
+                .body(ApiResponse.error(ErrorCode.VALIDATION_ERROR, errors));
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -20,7 +20,7 @@ export default function LoginPage() {
             href="/register" 
             className="inline-flex h-12 w-full items-center justify-center rounded-xl border border-primary text-primary font-black tracking-tighter hover:bg-primary/5 transition-colors"
           >
-            회원가입 하러가기
+            회원가입
           </Link>
         </div>
       </div>

--- a/frontend/src/app/(auth)/register/_components/register-form.tsx
+++ b/frontend/src/app/(auth)/register/_components/register-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiFetch, ApiError } from '@/lib/api';
 import { Button } from '@/components/ui/button';
@@ -29,6 +29,34 @@ export default function RegisterForm() {
   const [isDateWidgetOpen, setIsDateWidgetOpen] = useState(false);
   const [dateWidgetStep, setDateWidgetStep] = useState<'YEAR' | 'MONTH' | 'DAY'>('YEAR');
   const [tempDate, setTempDate] = useState({ year: 2000, month: 1, day: 1 });
+
+  const genderRef = useRef<HTMLDivElement>(null);
+  const dateRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (genderRef.current && !genderRef.current.contains(e.target as Node)) {
+        setIsGenderOpen(false);
+      }
+      if (dateRef.current && !dateRef.current.contains(e.target as Node)) {
+        setIsDateWidgetOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout;
+    if (globalError) {
+      timeoutId = setTimeout(() => {
+        setGlobalError(null);
+      }, 5000);
+    }
+    return () => {
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [globalError]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     let { name, value } = e.target;
@@ -65,12 +93,40 @@ export default function RegisterForm() {
     if (globalError) setGlobalError(null);
   };
 
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    let error = '';
+
+    if (name === 'loginId') {
+      if (!value) error = "아이디를 입력해주세요.";
+      else if (value.length < 4 || value.length > 50 || !/^[a-zA-Z0-9]+$/.test(value)) error = "아이디는 4~50자의 영문자와 숫자로만 구성되어야 합니다.";
+    } else if (name === 'password') {
+      if (!value) error = "비밀번호를 입력해주세요.";
+      else if (value.length < 8 || !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]+$/.test(value)) error = "비밀번호는 영문자, 숫자, 특수문자를 포함해 8자 이상이어야 합니다.";
+    } else if (name === 'passwordConfirm') {
+      if (!value) error = "비밀번호 확인을 입력해주세요.";
+      else if (value !== formData.password) error = "비밀번호가 일치하지 않습니다.";
+    } else if (name === 'name') {
+      if (!value) error = "이름을 입력해주세요.";
+      else if (value.length < 2 || value.length > 50) error = "이름은 2~50자로 입력해주세요.";
+    } else if (name === 'email') {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!value) error = "이메일을 입력해주세요.";
+      else if (!emailRegex.test(value)) error = "올바른 이메일 형식이 아닙니다.";
+    } else if (name === 'phone') {
+      if (!value) error = "연락처를 입력해주세요.";
+      else if (!/^(02-\d{3,4}-\d{4}|0\d{2}-\d{3,4}-\d{4})$/.test(value)) error = "올바른 연락처 형식이 아닙니다.";
+    }
+
+    if (error) {
+      setFieldErrors(prev => ({ ...prev, [name]: error }));
+    }
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setGlobalError(null);
     setFieldErrors({});
-
-    const errors: Record<string, string> = {};
 
     let finalBirthDate = formData.birthDate;
     if (finalBirthDate.includes('-')) {
@@ -78,46 +134,6 @@ export default function RegisterForm() {
       if (parts.length === 3) {
         finalBirthDate = parts[0].slice(2) + parts[1] + parts[2];
       }
-    }
-
-    if (!formData.loginId) errors.loginId = "아이디를 입력해주세요.";
-    else if (formData.loginId.length < 4 || formData.loginId.length > 50 || !/^[a-zA-Z0-9]+$/.test(formData.loginId)) {
-      errors.loginId = "아이디는 4~50자의 영문자와 숫자로만 구성되어야 합니다.";
-    }
-
-    if (!formData.password) errors.password = "비밀번호를 입력해주세요.";
-    else if (formData.password.length < 8 || !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]+$/.test(formData.password)) {
-      errors.password = "비밀번호는 영문자, 숫자, 특수문자를 포함해 8자 이상이어야 합니다.";
-    }
-
-    if (!formData.passwordConfirm) errors.passwordConfirm = "비밀번호 확인을 입력해주세요.";
-    else if (formData.password !== formData.passwordConfirm) {
-      errors.passwordConfirm = "비밀번호가 일치하지 않습니다.";
-    }
-
-    if (!formData.name) errors.name = "이름을 입력해주세요.";
-    else if (formData.name.length < 2 || formData.name.length > 50) {
-      errors.name = "이름은 2~50자로 입력해주세요.";
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!formData.email) errors.email = "이메일을 입력해주세요.";
-    else if (!emailRegex.test(formData.email)) {
-      errors.email = "올바른 이메일 형식이 아닙니다.";
-    }
-
-    if (finalBirthDate && !/^\d{6}$/.test(finalBirthDate)) {
-      errors.birthDate = "생년월일은 올바른 날짜로 입력해주세요.";
-    }
-
-    if (formData.phone && !/^(02-\d{3,4}-\d{4}|0\d{2}-\d{3,4}-\d{4})$/.test(formData.phone)) {
-      errors.phone = "올바른 연락처 형식이 아닙니다.";
-    }
-
-    if (Object.keys(errors).length > 0) {
-      setFieldErrors(errors);
-      setGlobalError("입력 정보를 다시 확인해주세요.");
-      return;
     }
 
     try {
@@ -135,7 +151,16 @@ export default function RegisterForm() {
       }, 1500);
     } catch (err) {
       if (err instanceof ApiError) {
-        setGlobalError(err.message);
+        if (err.errorCode === 'VALIDATION_ERROR') {
+          if (err.data && typeof err.data === 'object' && Object.keys(err.data).length > 0) {
+            setFieldErrors(err.data);
+            setGlobalError("입력 정보를 다시 확인해주세요.");
+          } else {
+            setGlobalError(err.message);
+          }
+        } else {
+          setGlobalError(err.message);
+        }
       } else {
         setGlobalError('알 수 없는 오류가 발생했습니다.');
       }
@@ -184,17 +209,24 @@ export default function RegisterForm() {
       animate="visible"
       onSubmit={handleSubmit} 
       className="flex flex-col gap-10"
+      noValidate
     >
       <AnimatePresence>
         {globalError && (
           <motion.div 
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            exit={{ opacity: 0, height: 0 }}
-            className="overflow-hidden"
+            initial={{ opacity: 0, y: 50, x: "-50%" }}
+            animate={{ opacity: 1, y: 0, x: "-50%" }}
+            exit={{ opacity: 0, y: 50, x: "-50%" }}
+            className="fixed bottom-12 left-1/2 z-[100] shadow-2xl w-[90%] max-w-sm rounded-[1rem] overflow-hidden bg-red-950/90 backdrop-blur-xl border border-red-500/30"
           >
-            <div className="flex items-center gap-3 rounded-2xl bg-red-500/10 p-4 text-sm font-medium text-red-600 mb-6">
-              <AlertCircle className="h-5 w-5 shrink-0" />
+            <motion.div 
+              initial={{ width: "0%" }} 
+              animate={{ width: "100%" }} 
+              transition={{ duration: 5, ease: "linear" }}
+              className="h-[3px] bg-red-500/80"
+            />
+            <div className="flex items-center justify-center gap-3 px-6 py-4 text-sm font-medium tracking-tight text-red-100">
+              <AlertCircle className="h-5 w-5 shrink-0 text-red-400" />
               <p>{globalError}</p>
             </div>
           </motion.div>
@@ -202,64 +234,65 @@ export default function RegisterForm() {
       </AnimatePresence>
 
       <motion.div variants={itemVariants} className="space-y-10">
-        <div>
+        <div className="relative">
           <label className={labelClasses}>LOGIN ID *</label>
-          <input name="loginId" value={formData.loginId} onChange={handleChange} className={getInputClasses(!!fieldErrors.loginId)} placeholder="아이디를 입력하세요 (4자 이상)" />
-          {fieldErrors.loginId && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.loginId}</p>}
+          <input name="loginId" value={formData.loginId} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.loginId)} placeholder="아이디를 입력하세요 (4자 이상)" />
+          {fieldErrors.loginId && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.loginId}</p>}
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
-          <div>
+          <div className="relative">
             <label className={labelClasses}>PASSWORD *</label>
-            <input name="password" type="password" value={formData.password} onChange={handleChange} className={getInputClasses(!!fieldErrors.password)} placeholder="비밀번호" />
-            <p className="text-primary/40 text-xs mt-2 font-medium tracking-tight">8자 이상, 영문+숫자+특수문자 조합</p>
-            {fieldErrors.password && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.password}</p>}
+            <input name="password" type="password" value={formData.password} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.password)} placeholder="비밀번호" />
+            {fieldErrors.password ? (
+              <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.password}</p>
+            ) : (
+              <p className="absolute top-full left-0 mt-1.5 text-primary/40 text-[11px] font-medium tracking-tight">8자 이상, 영문+숫자+특수문자 조합</p>
+            )}
           </div>
-          <div>
+          <div className="relative">
             <label className={labelClasses}>CONFIRM PASSWORD *</label>
-            <input name="passwordConfirm" type="password" value={formData.passwordConfirm} onChange={handleChange} className={getInputClasses(!!fieldErrors.passwordConfirm)} placeholder="비밀번호 재입력" />
-            {fieldErrors.passwordConfirm && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.passwordConfirm}</p>}
+            <input name="passwordConfirm" type="password" value={formData.passwordConfirm} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.passwordConfirm)} placeholder="비밀번호 재입력" />
+            {fieldErrors.passwordConfirm && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.passwordConfirm}</p>}
           </div>
         </div>
       </motion.div>
 
       <motion.div variants={itemVariants} className="space-y-10">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-10">
-          <div>
+          <div className="relative">
             <label className={labelClasses}>FULL NAME *</label>
-            <input name="name" value={formData.name} onChange={handleChange} className={getInputClasses(!!fieldErrors.name)} placeholder="이름을 입력하세요" />
-            {fieldErrors.name && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.name}</p>}
+            <input name="name" value={formData.name} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.name)} placeholder="이름을 입력하세요" />
+            {fieldErrors.name && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.name}</p>}
           </div>
-          <div>
+          <div className="relative">
             <label className={labelClasses}>EMAIL ADDRESS *</label>
-            <input name="email" type="email" value={formData.email} onChange={handleChange} className={getInputClasses(!!fieldErrors.email)} placeholder="cokkiri@example.com" />
-            {fieldErrors.email && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.email}</p>}
+            <input name="email" type="email" value={formData.email} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.email)} placeholder="cokkiri@example.com" />
+            {fieldErrors.email && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.email}</p>}
           </div>
         </div>
 
-        <div>
-          <label className={labelClasses}>PHONE NUMBER</label>
-          <input name="phone" value={formData.phone} onChange={handleChange} className={getInputClasses(!!fieldErrors.phone)} placeholder="010-0000-0000" />
-          {fieldErrors.phone && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.phone}</p>}
+        <div className="relative">
+          <label className={labelClasses}>PHONE NUMBER *</label>
+          <input name="phone" value={formData.phone} onChange={handleChange} onBlur={handleBlur} className={getInputClasses(!!fieldErrors.phone)} placeholder="010-0000-0000" />
+          {fieldErrors.phone && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.phone}</p>}
         </div>
       </motion.div>
 
       <motion.div variants={itemVariants} className="space-y-10">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
-          <div className="col-span-1 md:col-span-1 relative flex flex-col justify-end z-20">
+          <div className="col-span-1 md:col-span-1 relative flex flex-col justify-end z-20" ref={genderRef}>
              <label className={labelClasses}>M/F</label>
              <div 
-               onClick={() => setIsGenderOpen(!isGenderOpen)}
+               onClick={() => {
+                 setIsGenderOpen(!isGenderOpen);
+                 setIsDateWidgetOpen(false);
+               }}
                className={`${getInputClasses(false)} cursor-pointer flex justify-between items-center`}
              >
                <span>{formData.gender === 'MALE' ? 'MALE (남성)' : 'FEMALE (여성)'}</span>
                <motion.span animate={{ rotate: isGenderOpen ? 180 : 0 }} className="text-[10px] text-primary/40">▼</motion.span>
              </div>
-             
-             {/* Backdrop to close when clicking outside */}
-             {isGenderOpen && (
-               <div className="fixed inset-0 z-40" onClick={() => setIsGenderOpen(false)} />
-             )}
              
              <AnimatePresence>
                {isGenderOpen && (
@@ -290,12 +323,13 @@ export default function RegisterForm() {
                )}
              </AnimatePresence>
           </div>
-          <div className="col-span-1 md:col-span-1 flex flex-col justify-end relative z-30">
+          <div className="col-span-1 md:col-span-1 flex flex-col justify-end relative z-30" ref={dateRef}>
             <label className={labelClasses}>BIRTH DATE</label>
             <div 
               onClick={() => {
-                setIsDateWidgetOpen(true);
+                setIsDateWidgetOpen(!isDateWidgetOpen);
                 setDateWidgetStep('YEAR');
+                setIsGenderOpen(false);
               }}
               className={`${getInputClasses(!!fieldErrors.birthDate)} cursor-pointer flex items-center justify-between`}
             >
@@ -304,11 +338,6 @@ export default function RegisterForm() {
                </span>
             </div>
             
-            {/* Backdrop to close date widget */}
-            {isDateWidgetOpen && (
-               <div className="fixed inset-0 z-40" onClick={() => setIsDateWidgetOpen(false)} />
-            )}
-
             <AnimatePresence>
               {isDateWidgetOpen && (
                 <motion.div 
@@ -361,7 +390,7 @@ export default function RegisterForm() {
                  </motion.div>
               )}
             </AnimatePresence>
-            {fieldErrors.birthDate && <p className="text-red-500 text-xs mt-2 font-medium">{fieldErrors.birthDate}</p>}
+            {fieldErrors.birthDate && <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.birthDate}</p>}
           </div>
           <div className="col-span-1 md:col-span-1 flex flex-col justify-end">
             <label className={labelClasses}>NATION</label>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,13 +74,14 @@ export async function apiFetch<T>(
       // 백엔드가 JSON 에러 메시지를 보낸 경우(예: 로그인 실패, 비밀번호 불일치 등) 그것을 우선 사용
       if (parsedData) {
         const eCode = (parsedData as any).errorCode || (parsedData as any).error_code;
-        throw new ApiError(parsedData.message || LOGIN_REQUIRED_MESSAGE, eCode || 'UNAUTHORIZED');
+        throw new ApiError(parsedData.message || LOGIN_REQUIRED_MESSAGE, eCode || 'UNAUTHORIZED', (parsedData as any).data);
       }
       throw new ApiError(LOGIN_REQUIRED_MESSAGE, 'UNAUTHORIZED');
     }
     if (looksJson && trimmed.length > 0) {
       const data = parseApiJson<T>(trimmed);
-      throw new ApiError(data.message || '요청에 실패했습니다', data.error_code);
+      const eCode = (data as any).errorCode || (data as any).error_code;
+      throw new ApiError(data.message || '요청에 실패했습니다', eCode, (data as any).data);
     }
     throw new ApiError(`요청에 실패했습니다 (${response.status})`, undefined);
   }
@@ -93,7 +94,7 @@ export async function apiFetch<T>(
 
   if (!data.success) {
     const eCode = (data as any).errorCode || (data as any).error_code;
-    throw new ApiError(data.message || '요청에 실패했습니다', eCode);
+    throw new ApiError(data.message || '요청에 실패했습니다', eCode, data.data);
   }
 
   return data;
@@ -102,7 +103,8 @@ export async function apiFetch<T>(
 export class ApiError extends Error {
   constructor(
     message: string,
-    public errorCode?: string
+    public errorCode?: string,
+    public data?: any
   ) {
     super(message);
     this.name = 'ApiError';

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -18,6 +18,7 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover, 
 input:-webkit-autofill:focus, 
 input:-webkit-autofill:active {
+  -webkit-box-shadow: 0 0 0 1000px var(--color-background, #DADED8) inset !important;
+  -webkit-text-fill-color: var(--color-primary, #2C3424) !important;
   transition: background-color 5000s ease-in-out 0s;
-  -webkit-text-fill-color: var(--primary) !important;
 }


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 회원가입 양식의 유효성 검사 진행 시 오류 확인이 파편화되어 있고 각 필드별 대응이 어려웠던 문제를 근본적으로 해결하기 위해 작성된 PR입니다.
- 웹 브라우저의 기본 제공 기능(자동 완성 배경색)과 기존 UI 간 충돌로 인해 에디토리얼 프리미엄 무드가 훼손되는 문제를 해결함과 동시에, 서버 검증(Backend Validation)을 클라이언트가 완벽하게 수용하도록 아키텍처를 개선했습니다.

## 🔑 주요 변경 사항 (What)
- **백엔드 서버 유효성 동시 검증 체계 구현**
  - [AuthService](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/auth/application/service/AuthService.java:34:0-224:1)의 중복 검사 로직(로그인 ID, 이메일) 및 비밀번호 확인 일치 판단 로직을 하나로 취합하여, 에러를 순차적으로 뱉지 않고 `Map<String, String>`에 모아 동시다발적으로 반환하도록 리팩터링.
  - [ApiResponse](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/global/dto/ApiResponse.java:9:0-60:1) 및 [BusinessException](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/global/error/BusinessException.java:4:0-25:1)에 필드별 에러(`data`)를 담을 수 있도록 페이로드 확장 및 [GlobalExceptionHandler](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/global/error/GlobalExceptionHandler.java:18:0-93:1) 적용.
  - [RegisterRequestDto](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/auth/adapter/in/web/dto/req/RegisterRequestDto.java:11:0-47:1) 연락처(`phone`) 필드를 필수값(`@NotBlank`)으로 지정 및 정규 표현식 강화.
- **프론트엔드 UI/UX 완성도 향상**
  - 입력 상자 포커스가 벗어날 때 즉각적으로 유효성 에러를 표출하는 `onBlur` 실시간 검사 로직 도입.
  - 제출(Submit) 클릭 시 프론트엔드의 방어 로직을 해제하고 백엔드의 철저한 반환값(Field Validation Map)을 그대로 상속받아 모든 입력 상자 하단에 에러를 한 번에 띄울 수 있도록 동기화.
  - 입력 오류 시 레이아웃의 높이가 흔들리면서 스크롤바가 생기던 문제를 방지하고자 에러 메시지에 뷰포트 절대 좌표(`absolute`) 정렬 적용.
- **Global Toast Notification (오류 알림) 개선**
  - 단순 팝업 대신 화면 하단에 플로팅 되는 프리미엄 토스트 애니메이션(Framer Motion 적용) 도입.
  - 5초 후 자동으로 사라지며, 사용자가 시간을 직관적으로 인지할 수 있는 타이머 로딩 바 추가.
- **스타일 및 카피라이팅 디테일 수정**
  - 크롬 등 웹 브라우저의 자동 완성(Autofill) 기능 사용 시 입력창이 흰색으로 강제 덮어씌워지는 현상을 방어하기 위해 [index.css](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/styles/index.css:0:0-0:0)에 `-webkit-box-shadow: 1000px inset`을 활용한 커스텀 스타일 전역 브라우저 오버라이드.
  - 로그인 페이지 하단의 번거로운 "회원가입 하러가기" 문구를 "회원가입"으로 간결하게 변경.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #230

## 💻 테스트 방법 (How to Test)
1. 백엔드 및 모의 IoT 서버를 가동합니다. (