### PR TITLE
[CS/fix] 알림(reference_type), 댓글·배지, 계약 JSON, 인박스 UI

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { invalidateNotificationsUnreadCount } from "@/lib/notifications-events";
 
 type NotificationItem = {
   notificationId: number;
@@ -19,16 +20,18 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
   const [isRead, setIsRead] = useState(item.isRead);
 
   const handleClick = async () => {
-    console.log("Notification Clicked:", item);
-
     // 1. 읽음 처리 (비동기로 진행하되 페이지 이동을 막지 않음)
     if (!isRead) {
       fetch(`/api/notifications/${item.notificationId}/read`, { method: "PATCH" })
-        .then(res => {
-          if (res.ok) setIsRead(true);
-          else console.warn("Read status update failed", res.status);
+        .then((res) => {
+          if (res.ok) {
+            setIsRead(true);
+            invalidateNotificationsUnreadCount();
+          }
         })
-        .catch(err => console.error("Read status error", err));
+        .catch(() => {
+          /* ignore */
+        });
     }
 
     // 2. 경로 설정로직 최적화 (대소문자 무관하게 체크)
@@ -55,41 +58,61 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
       }
     }
 
-    console.log("Redirecting to:", targetPath);
     router.push(targetPath);
   };
 
   return (
     <li
       onClick={handleClick}
-      className={`group bg-white rounded-[2.5rem] p-10 md:p-14 border transition-all relative overflow-hidden cursor-pointer active:scale-[0.98] ${
-        isRead 
-        ? "border-primary/5 opacity-60 grayscale-[0.3]" 
-        : "border-accent/20 shadow-2xl shadow-accent/5 hover:border-accent/40"
+      className={`group rounded-[2.5rem] p-10 md:p-14 border transition-all relative overflow-hidden cursor-pointer active:scale-[0.98] ${
+        isRead
+          ? "bg-muted/30 border-primary/10"
+          : "bg-white border-l-4 border-l-accent border-accent/25 shadow-xl shadow-accent/10 hover:border-accent/45"
       }`}
     >
       <div className="flex flex-col md:flex-row md:items-start justify-between gap-8 relative z-10">
         <div className="space-y-6 max-w-2xl">
-          <div className="flex items-center gap-4">
-            <span className="text-[10px] font-black tracking-[0.3em] uppercase opacity-30">
-              MSG-00{item.notificationId}
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`text-[10px] font-black tracking-[0.15em] uppercase px-3 py-1.5 rounded-full border ${
+                isRead
+                  ? "border-muted-foreground/25 bg-background text-muted-foreground"
+                  : "border-accent/40 bg-accent/15 text-accent"
+              }`}
+              aria-label={isRead ? "읽은 알림" : "읽지 않은 알림"}
+            >
+              {isRead ? "읽음" : "미읽음"}
             </span>
             <span
               className={`text-[10px] font-black tracking-[0.2em] uppercase px-4 py-1.5 rounded-full ${
-                isRead ? "bg-muted/10 text-muted-foreground" : "bg-accent/10 text-accent"
+                isRead ? "bg-muted/20 text-muted-foreground" : "bg-primary/5 text-primary"
               }`}
             >
               {item.type ?? "NOTICE"}
             </span>
-            {!isRead && (
-              <span className="w-2 h-2 rounded-full bg-accent animate-pulse" />
-            )}
+            <span className="text-[10px] font-mono tracking-wider text-muted-foreground/50">
+              #{item.notificationId}
+            </span>
+            {!isRead ? (
+              <span className="inline-flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-accent">
+                <span className="size-2 rounded-full bg-accent animate-pulse" aria-hidden />
+                확인 필요
+              </span>
+            ) : null}
           </div>
           <div>
-            <h2 className="text-3xl font-black tracking-tighter leading-tight uppercase italic group-hover:text-accent transition-colors">
+            <h2
+              className={`text-3xl font-black tracking-tighter leading-tight uppercase italic transition-colors ${
+                isRead ? "text-primary/70" : "text-primary group-hover:text-accent"
+              }`}
+            >
               {item.title}
             </h2>
-            <p className="mt-4 text-lg font-medium tracking-tight text-primary opacity-60">
+            <p
+              className={`mt-4 text-lg font-medium tracking-tight ${
+                isRead ? "text-muted-foreground" : "text-primary/80"
+              }`}
+            >
               {item.message}
             </p>
           </div>
@@ -106,11 +129,10 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
           </span>
         </div>
       </div>
-      
-      {/* Visual Indicator for Read Status Change */}
-      {!isRead && (
-        <div className="absolute top-0 right-0 w-32 h-32 bg-accent/5 rounded-full -mr-16 -mt-16 blur-3xl group-hover:bg-accent/10 transition-all" />
-      )}
+
+      {!isRead ? (
+        <div className="pointer-events-none absolute top-0 right-0 size-40 rounded-full bg-accent/10 -mr-20 -mt-20 blur-3xl group-hover:bg-accent/15 transition-all" />
+      ) : null}
     </li>
   );
 }

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -108,8 +108,18 @@ export default async function NotificationsPage({ searchParams }: { searchParams
       {/* Stats Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-20">
           {[
-            { label: "TOTAL MESSAGES", value: totalCount.toString().padStart(2, '0'), icon: FileText, desc: "전체 수신 알림" },
-            { label: "UNREAD IN PAGE", value: unreadCount.toString().padStart(2, '0'), icon: Bell, desc: "현재 페이지 미확인" }
+            {
+              label: "TOTAL MESSAGES",
+              value: totalCount.toString().padStart(2, "0"),
+              icon: FileText,
+              desc: "필터 기준 전체 알림 수",
+            },
+            {
+              label: "UNREAD ON PAGE",
+              value: unreadCount.toString().padStart(2, "0"),
+              icon: Bell,
+              desc: "이 페이지에만 표시된 미읽음 (전체 미읽음은 하단 플로팅 배지)",
+            },
           ].map((stat, i) => (
             <div key={i} className="group bg-white p-10 rounded-[2.5rem] border border-primary/5 shadow-2xl shadow-primary/5 hover:border-accent/30 transition-all">
               <div className="flex items-start justify-between mb-8">
@@ -128,20 +138,27 @@ export default async function NotificationsPage({ searchParams }: { searchParams
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-10 overflow-x-auto border-b border-primary/10 pb-8 mb-12">
+      <div className="mb-12 space-y-4 border-b border-primary/10 pb-8">
+        <p className="text-xs font-medium text-muted-foreground">
+          카드 왼쪽 강조선·<span className="font-semibold text-accent">미읽음</span> 뱃지가 있는 알림은 아직 확인하지 않은 메시지입니다. 탭을 눌러 목록을 좁힐 수 있습니다.
+        </p>
+        <div className="flex flex-wrap items-center gap-6 overflow-x-auto">
           {[
-            { label: "ALL", href: "/notifications", active: !isRead },
-            { label: "UNREAD", href: "/notifications?is_read=false", active: isRead === "false" },
-            { label: "READ", href: "/notifications?is_read=true", active: isRead === "true" }
+            { label: "전체", href: "/notifications", active: !isRead },
+            { label: "미읽음만", href: "/notifications?is_read=false", active: isRead === "false" },
+            { label: "읽음만", href: "/notifications?is_read=true", active: isRead === "true" },
           ].map((tab) => (
             <Link
               key={tab.label}
               href={tab.href}
-              className={`shrink-0 pb-2 text-[10px] font-black uppercase tracking-[0.3em] transition-all border-b-2 ${tab.active ? "text-accent border-accent" : "text-muted-foreground opacity-40 hover:opacity-100 border-transparent"}`}
+              className={`shrink-0 pb-2 text-xs font-black uppercase tracking-[0.2em] transition-all border-b-2 ${
+                tab.active ? "text-accent border-accent" : "text-muted-foreground opacity-50 hover:opacity-100 border-transparent"
+              }`}
             >
               {tab.label}
             </Link>
           ))}
+        </div>
       </div>
 
       {error && (

--- a/frontend/src/components/layout/NotificationSseClient.tsx
+++ b/frontend/src/components/layout/NotificationSseClient.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import { Bell } from "lucide-react";
 import { useAuthStore } from "@/store/useAuthStore";
+import { NOTIFICATIONS_UNREAD_INVALIDATE } from "@/lib/notifications-events";
 
 type NotificationEventPayload = {
   notificationId: number;
@@ -66,6 +67,11 @@ export default function NotificationSseClient() {
       void fetchUnreadCount();
     }, 60000);
 
+    const onUnreadInvalidate = () => {
+      void fetchUnreadCount();
+    };
+    window.addEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onUnreadInvalidate);
+
     const eventSource = new EventSource("/api/notifications/stream", { withCredentials: true });
 
     const onNotification = (event: MessageEvent) => {
@@ -96,6 +102,7 @@ export default function NotificationSseClient() {
 
     return () => {
       mounted = false;
+      window.removeEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onUnreadInvalidate);
       window.clearInterval(unreadResyncTimer);
       eventSource.removeEventListener("notification", onNotification as EventListener);
       eventSource.removeEventListener("connected", onConnected as EventListener);

--- a/frontend/src/lib/notifications-events.ts
+++ b/frontend/src/lib/notifications-events.ts
@@ -1,0 +1,7 @@
+/** 알림 배지 등에서 미읽음 개수를 다시 불러오도록 신호를 보냅니다. */
+export const NOTIFICATIONS_UNREAD_INVALIDATE = "cokkiri:notifications-unread-invalidate";
+
+export function invalidateNotificationsUnreadCount(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent(NOTIFICATIONS_UNREAD_INVALIDATE));
+}


### PR DESCRIPTION
## 요약

### 백엔드 / DB
- `notifications_reference_type_check` 유지보수 SQL (`COMMUNITY`, `PAYMENT` 등) — 운영 DB에 이미 적용한 경우 스킵.
- 댓글·알림 관련 저장/리스너 정리.
- `ContractApplyRequestDto`: `@JsonIgnoreProperties(ignoreUnknown = true)` (`termsAgreed` 등).

### 프론트 (알림)
- 읽음 PATCH 성공 시 커스텀 이벤트로 플로팅 배지 미읽음 수 **즉시 재조회**.
- 알림 목록: 미읽음/읽음 뱃지·왼쪽 강조선 등 가독성 개선, 필터/통계 문구 정리.

## 운영 DB (미적용 시)
```sql
ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (reference_type IS NULL OR reference_type IN ('CONTRACT','RESERVATION','VOC','COMMUNITY','PAYMENT'));