### PR TITLE
[CS/fix] 알림 DB·댓글·인박스 UX(배지·RSC 갱신)

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { invalidateNotificationsUnreadCount } from "@/lib/notifications-events";
 
 type NotificationItem = {
@@ -19,19 +19,22 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
   const router = useRouter();
   const [isRead, setIsRead] = useState(item.isRead);
 
+  useEffect(() => {
+    setIsRead(item.isRead);
+  }, [item.isRead, item.notificationId]);
+
   const handleClick = async () => {
-    // 1. 읽음 처리 (비동기로 진행하되 페이지 이동을 막지 않음)
+    // 1. 읽음 처리 후 RSC·배지와 맞추기 (이동 전에 서버 반영·캐시 무효화)
     if (!isRead) {
-      fetch(`/api/notifications/${item.notificationId}/read`, { method: "PATCH" })
-        .then((res) => {
-          if (res.ok) {
-            setIsRead(true);
-            invalidateNotificationsUnreadCount();
-          }
-        })
-        .catch(() => {
-          /* ignore */
-        });
+      try {
+        const res = await fetch(`/api/notifications/${item.notificationId}/read`, { method: "PATCH" });
+        if (res.ok) {
+          setIsRead(true);
+          invalidateNotificationsUnreadCount();
+        }
+      } catch {
+        /* ignore */
+      }
     }
 
     // 2. 경로 설정로직 최적화 (대소문자 무관하게 체크)

--- a/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { NOTIFICATIONS_UNREAD_INVALIDATE } from "@/lib/notifications-events";
+
+/**
+ * 알림 인박스는 서버 컴포넌트로 그려집니다. 클라이언트 이동 후 복귀 시 RSC 페이로드가
+ * 오래된 상태로 남을 수 있어, 마운트·읽음 처리 시점에 서버 데이터를 다시 받아옵니다.
+ */
+export function NotificationsInboxRefreshClient() {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.refresh();
+  }, [router]);
+
+  useEffect(() => {
+    const onInvalidate = () => {
+      router.refresh();
+    };
+    window.addEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
+    return () => window.removeEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
+  }, [router]);
+
+  return null;
+}

--- a/frontend/src/app/(common)/notifications/page.tsx
+++ b/frontend/src/app/(common)/notifications/page.tsx
@@ -1,11 +1,11 @@
 import Link from "next/link";
-import { Bell, FileText, Layout, ArrowRight } from "lucide-react";
+import { Bell, FileText, ArrowRight } from "lucide-react";
 import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { LoginRequiredGate } from "@/components/shared/LoginRequiredGate";
 import { PaginationBar } from "@/app/(common)/community/_components/PaginationBar";
 import { bffGet } from "./_api/bff-server";
-import { MotionEnter } from "@/app/(common)/community/_components/MotionEnter";
 import { NotificationListItem } from "./_components/NotificationListItem";
+import { NotificationsInboxRefreshClient } from "./_components/NotificationsInboxRefreshClient";
 
 type ApiResponse<T> = {
   success: boolean;
@@ -38,6 +38,8 @@ type SearchParams = Promise<{ p?: string; s?: string; is_read?: string }>;
 export const metadata = {
   title: "알림 센터 | CoKkiri",
 };
+
+export const dynamic = "force-dynamic";
 
 export default async function NotificationsPage({ searchParams }: { searchParams: SearchParams }) {
   const sp = await searchParams;
@@ -78,6 +80,7 @@ export default async function NotificationsPage({ searchParams }: { searchParams
 
   return (
     <>
+      <NotificationsInboxRefreshClient />
       {/* Editorial Header */}
       <header className="mb-20">
         <div className="flex flex-col gap-6">


### PR DESCRIPTION
## 요약

### 백엔드 / DB
- `notifications_reference_type_check` 유지보수 SQL (COMMUNITY 등).
- 댓글·알림 저장/리스너 정리.
- `ContractApplyRequestDto`: unknown JSON 필드 허용.

### 프론트 (알림)
- 읽음 PATCH 후 `invalidate`로 플로팅 배지 즉시 재조회.
- **인박스**: `NotificationsInboxRefreshClient` + `force-dynamic`로 목록·대시보드 RSC 갱신, `await` 읽음 후 이동, `item.isRead`와 로컬 state 동기화.
- 목록 UI: 미읽음/읽음 구분 강화, 필터 문구.

## 운영 DB (미적용 시)
```sql
ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (reference_type IS NULL OR reference_type IN ('CONTRACT','RESERVATION','VOC','COMMUNITY','PAYMENT'));