### PR TITLE
[CS/fix] 알림 DB·인박스·읽음 UX

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -17,19 +17,25 @@ type NotificationItem = {
 
 export function NotificationListItem({ item }: { item: NotificationItem }) {
   const router = useRouter();
-  const [isRead, setIsRead] = useState(item.isRead);
+  /** 서버가 잠깐 늦게 따라올 때 로컬 읽음을 덮어쓰지 않도록 낙관적 플래그만 사용 */
+  const [readLocally, setReadLocally] = useState(false);
 
   useEffect(() => {
-    setIsRead(item.isRead);
-  }, [item.isRead, item.notificationId]);
+    setReadLocally(false);
+  }, [item.notificationId]);
+
+  const isRead = readLocally || item.isRead;
 
   const handleClick = async () => {
-    // 1. 읽음 처리 후 RSC·배지와 맞추기 (이동 전에 서버 반영·캐시 무효화)
+    // 1. 읽음 처리 후 배지·인박스 갱신 신호 (이동 전에 완료)
     if (!isRead) {
       try {
-        const res = await fetch(`/api/notifications/${item.notificationId}/read`, { method: "PATCH" });
+        const res = await fetch(`/api/notifications/${item.notificationId}/read`, {
+          method: "PATCH",
+          credentials: "include",
+        });
         if (res.ok) {
-          setIsRead(true);
+          setReadLocally(true);
           invalidateNotificationsUnreadCount();
         }
       } catch {

--- a/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
@@ -5,22 +5,47 @@ import { useEffect } from "react";
 import { NOTIFICATIONS_UNREAD_INVALIDATE } from "@/lib/notifications-events";
 
 /**
- * 알림 인박스는 서버 컴포넌트로 그려집니다. 클라이언트 이동 후 복귀 시 RSC 페이로드가
- * 오래된 상태로 남을 수 있어, 마운트·읽음 처리 시점에 서버 데이터를 다시 받아옵니다.
+ * - 읽음 PATCH 후: invalidate → 짧게 디바운스 후 RSC 갱신
+ * - 다른 라우트에서 알림으로 재진입: 마운트 후 지연 refresh (GET이 PATCH보다 먼저 끝나는 레이스 완화)
+ * - 탭 전환 복귀 / bfcache 복원: 동일 디바운스로 한 번만 서버 데이터 재요청
  */
 export function NotificationsInboxRefreshClient() {
   const router = useRouter();
 
   useEffect(() => {
-    router.refresh();
-  }, [router]);
+    let idle: ReturnType<typeof setTimeout> | undefined;
 
-  useEffect(() => {
-    const onInvalidate = () => {
-      router.refresh();
+    const scheduleRefresh = (delayMs: number) => {
+      if (idle) clearTimeout(idle);
+      idle = setTimeout(() => {
+        idle = undefined;
+        router.refresh();
+      }, delayMs);
     };
+
+    // 클라이언트 네비게이션으로 알림 페이지에 올 때 캐시된 RSC 보정
+    scheduleRefresh(450);
+
+    const onInvalidate = () => scheduleRefresh(250);
     window.addEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
-    return () => window.removeEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible") scheduleRefresh(320);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    const onPageShow = (e: Event) => {
+      const pe = e as PageTransitionEvent;
+      if (pe.persisted) scheduleRefresh(120);
+    };
+    window.addEventListener("pageshow", onPageShow);
+
+    return () => {
+      if (idle) clearTimeout(idle);
+      window.removeEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("pageshow", onPageShow);
+    };
   }, [router]);
 
   return null;


### PR DESCRIPTION
## 요약

### 백엔드 / DB
- `notifications_reference_type_check` 유지보수 SQL, 댓글·알림 처리, `ContractApplyRequestDto` JSON 등 (기존 커밋).

### 프론트 (알림)
- 플로팅 배지: 읽음 후 `invalidate`로 즉시 미읽음 재조회.
- **읽음 안정화**: `readLocally || item.isRead` — RSC가 PATCH보다 빨리 오면 미읽음으로 되돌아가지 않음.
- **인박스 자동 갱신**: 읽음 후 디바운스 `router.refresh`; 페이지 재진입·탭 복귀·bfcache 복원 시에도 지연 refresh.

## 운영 DB (미적용 시)
```sql
ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (reference_type IS NULL OR reference_type IN ('CONTRACT','RESERVATION','VOC','COMMUNITY','PAYMENT'));