### PR TITLE
✨ [USR] 회원 탈퇴 기능 추가

### DIFF
--- a/backend/src/main/java/com/coliving/common/profile/adapter/in/web/ProfileController.java
+++ b/backend/src/main/java/com/coliving/common/profile/adapter/in/web/ProfileController.java
@@ -9,18 +9,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import com.coliving.common.profile.adapter.in.web.dto.req.UpdatePasswordRequestDto;
+import com.coliving.common.profile.adapter.in.web.dto.req.WithdrawRequestDto;
 import com.coliving.common.profile.application.command.UpdatePasswordCommand;
+import com.coliving.common.profile.application.command.WithdrawCommand;
 import com.coliving.common.profile.application.port.in.UpdatePasswordUseCase;
+import com.coliving.common.profile.application.port.in.WithdrawUseCase;
 import com.coliving.common.auth.application.port.in.LogoutUseCase;
 import jakarta.validation.Valid;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users/me")
@@ -28,6 +31,7 @@ public class ProfileController {
 
     private final GetProfileUseCase getProfileUseCase;
     private final UpdatePasswordUseCase updatePasswordUseCase;
+    private final WithdrawUseCase withdrawUseCase;
     private final LogoutUseCase logoutUseCase;
 
     @GetMapping
@@ -70,5 +74,31 @@ public class ProfileController {
         }
 
         return ApiResponse.ok(null, "비밀번호가 성공적으로 변경되었습니다. 다시 로그인해주세요.");
+    }
+
+    @DeleteMapping
+    public ApiResponse<Void> withdrawUser(
+            @Valid @RequestBody WithdrawRequestDto request,
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        Long userId = Long.parseLong(authentication.getPrincipal().toString());
+
+        WithdrawCommand command = WithdrawCommand.builder()
+                .password(request.getPassword())
+                .build();
+
+        withdrawUseCase.withdraw(userId, command);
+
+        if (StringUtils.hasText(authorizationHeader) && authorizationHeader.startsWith("Bearer ")) {
+            String accessToken = authorizationHeader.substring(7);
+            logoutUseCase.logout(accessToken);
+        }
+
+        return ApiResponse.ok(null, "성공적으로 탈퇴 처리되었습니다. 그동안 이용해주셔서 감사합니다.");
     }
 }

--- a/backend/src/main/java/com/coliving/common/profile/adapter/in/web/dto/req/WithdrawRequestDto.java
+++ b/backend/src/main/java/com/coliving/common/profile/adapter/in/web/dto/req/WithdrawRequestDto.java
@@ -1,0 +1,14 @@
+package com.coliving.common.profile.adapter.in.web.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WithdrawRequestDto {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/backend/src/main/java/com/coliving/common/profile/adapter/out/persistence/ProfilePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/common/profile/adapter/out/persistence/ProfilePersistenceAdapter.java
@@ -35,6 +35,17 @@ public class ProfilePersistenceAdapter implements ProfileRepositoryPort {
         userJpaRepository.save(user);
     }
 
+    @Override
+    public void withdrawUser(Long userId) {
+        UserEntity user = userJpaRepository.findById(userId)
+                .orElseThrow(() -> new com.coliving.global.error.BusinessException(com.coliving.global.error.ErrorCode.ACCOUNT_NOT_FOUND));
+        
+        user.updateProfile("탈퇴한 사용자", "탈퇴한 사용자", "탈퇴한 사용자", null);
+        user.deactivate();
+        user.softDelete();
+        userJpaRepository.save(user);
+    }
+
     private ProfileResponseDto toResponseDto(UserEntity user) {
         return ProfileResponseDto.builder()
                 .id(user.getUserId())

--- a/backend/src/main/java/com/coliving/common/profile/application/command/WithdrawCommand.java
+++ b/backend/src/main/java/com/coliving/common/profile/application/command/WithdrawCommand.java
@@ -1,0 +1,10 @@
+package com.coliving.common.profile.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class WithdrawCommand {
+    private final String password;
+}

--- a/backend/src/main/java/com/coliving/common/profile/application/port/in/WithdrawUseCase.java
+++ b/backend/src/main/java/com/coliving/common/profile/application/port/in/WithdrawUseCase.java
@@ -1,0 +1,7 @@
+package com.coliving.common.profile.application.port.in;
+
+import com.coliving.common.profile.application.command.WithdrawCommand;
+
+public interface WithdrawUseCase {
+    void withdraw(Long userId, WithdrawCommand command);
+}

--- a/backend/src/main/java/com/coliving/common/profile/application/port/out/ProfileRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/common/profile/application/port/out/ProfileRepositoryPort.java
@@ -8,4 +8,6 @@ public interface ProfileRepositoryPort {
     
     String getPasswordHash(Long userId);
     void updatePassword(Long userId, String newPasswordHash);
+    
+    void withdrawUser(Long userId);
 }

--- a/backend/src/main/java/com/coliving/common/profile/application/service/ProfileService.java
+++ b/backend/src/main/java/com/coliving/common/profile/application/service/ProfileService.java
@@ -10,14 +10,23 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coliving.common.profile.application.command.UpdatePasswordCommand;
+import com.coliving.common.profile.application.command.WithdrawCommand;
 import com.coliving.common.profile.application.port.in.UpdatePasswordUseCase;
+import com.coliving.common.profile.application.port.in.WithdrawUseCase;
+import com.coliving.admin.payment.adapter.out.jpa.PaymentJpaRepository;
+import com.coliving.admin.payment.model.PaymentStatus;
+import com.coliving.user.contract.adapter.out.jpa.ContractJpaRepository;
+import com.coliving.user.contract.model.ContractStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class ProfileService implements GetProfileUseCase, UpdatePasswordUseCase {
+public class ProfileService implements GetProfileUseCase, UpdatePasswordUseCase, WithdrawUseCase {
 
     private final ProfileRepositoryPort profileRepositoryPort;
+    private final ContractJpaRepository contractJpaRepository;
+    private final PaymentJpaRepository paymentJpaRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Override
@@ -49,5 +58,24 @@ public class ProfileService implements GetProfileUseCase, UpdatePasswordUseCase 
         }
 
         profileRepositoryPort.updatePassword(userId, passwordEncoder.encode(command.getNewPassword()));
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(Long userId, WithdrawCommand command) {
+        String currentHash = profileRepositoryPort.getPasswordHash(userId);
+        if (!passwordEncoder.matches(command.getPassword(), currentHash)) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        if (!contractJpaRepository.findByUserIdAndStatus(userId, ContractStatus.ACTIVE).isEmpty()) {
+            throw new BusinessException(ErrorCode.ACTIVE_CONTRACT_EXISTS, "활성 계약이 존재하여 탈퇴할 수 없습니다.");
+        }
+
+        if (!paymentJpaRepository.findByUserIdAndStatus(userId, PaymentStatus.UNPAID).isEmpty()) {
+            throw new BusinessException(ErrorCode.UNPAID_PAYMENT_EXISTS, "미납된 결제가 존재하여 탈퇴할 수 없습니다.");
+        }
+
+        profileRepositoryPort.withdrawUser(userId);
     }
 }

--- a/frontend/src/app/(common)/profile/_components/profile-info.tsx
+++ b/frontend/src/app/(common)/profile/_components/profile-info.tsx
@@ -6,6 +6,7 @@ import { Profile } from "../_types/profile";
 import { UserRound } from "lucide-react";
 import { motion } from "framer-motion";
 import { PasswordChangeModal } from "./password-change-modal";
+import { WithdrawModal } from "./withdraw-modal";
 
 export default function ProfileInfo() {
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -13,6 +14,7 @@ export default function ProfileInfo() {
   const [error, setError] = useState<string | null>(null);
   
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false);
+  const [isWithdrawModalOpen, setIsWithdrawModalOpen] = useState(false);
 
   useEffect(() => {
     let isMounted = true;
@@ -149,12 +151,25 @@ export default function ProfileInfo() {
           >
             비밀번호 변경
           </motion.button>
+          <motion.button 
+            whileHover={{ scale: 1.02, y: -2 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={() => setIsWithdrawModalOpen(true)}
+            className="rounded-none border border-red-900/20 bg-transparent px-8 py-4 text-red-800 transition-colors hover:bg-red-900/5 hover:border-red-900/40 text-xs font-black uppercase tracking-[0.2em] ml-auto"
+          >
+            회원 탈퇴
+          </motion.button>
         </div>
       </div>
 
       <PasswordChangeModal 
         isOpen={isPasswordModalOpen} 
         onClose={() => setIsPasswordModalOpen(false)} 
+      />
+
+      <WithdrawModal
+        isOpen={isWithdrawModalOpen}
+        onClose={() => setIsWithdrawModalOpen(false)}
       />
     </motion.div>
   );

--- a/frontend/src/app/(common)/profile/_components/withdraw-modal.tsx
+++ b/frontend/src/app/(common)/profile/_components/withdraw-modal.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
+import { apiFetch, ApiError } from "@/lib/api";
+import { useAuthStore } from "@/store/useAuthStore";
+
+interface WithdrawModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
+  const logout = useAuthStore((state) => state.logout);
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setPassword("");
+      setError(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!password) {
+      setError("비밀번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsLoading(true);
+      const res = await apiFetch("/users/me", {
+        method: "DELETE",
+        body: JSON.stringify({ password }),
+      });
+      alert(res.message || "성공적으로 탈퇴 처리되었습니다. 그동안 이용해주셔서 감사합니다.");
+      onClose();
+      await logout();
+    } catch (err: any) {
+      setError(err instanceof ApiError ? err.message : "탈퇴 처리 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div className="fixed inset-0 z-[100] flex items-center justify-center p-6">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.5, ease: "easeInOut" }}
+            className="fixed inset-0 bg-primary/40 backdrop-blur-md"
+            onClick={isLoading ? undefined : onClose}
+          />
+          
+          <motion.div
+            initial={{ opacity: 0, y: 40, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 20, scale: 0.98 }}
+            transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+            className="relative w-full max-w-3xl overflow-hidden rounded-[2rem] bg-background shadow-2xl"
+          >
+            <button
+               onClick={onClose}
+               disabled={isLoading}
+               className="absolute right-8 top-8 z-10 text-primary/40 hover:text-primary transition-colors disabled:opacity-50"
+               aria-label="닫기"
+            >
+              <X className="h-8 w-8" strokeWidth={1} />
+            </button>
+            
+            <div className="flex flex-col md:flex-row h-full">
+              {/* Left visual column */}
+              <div className="hidden md:flex w-[40%] flex-col justify-between bg-primary p-12 text-background">
+                <div>
+                  <h3 className="text-[3vw] lg:text-[2.5rem] font-black uppercase tracking-tighter leading-[0.85] mb-6">
+                    FARE<br/>WELL.
+                  </h3>
+                  <div className="h-1 w-12 bg-accent/50" />
+                </div>
+                <p className="text-[10px] font-bold uppercase tracking-[0.3em] text-background/50 leading-loose">
+                  Data<br/>Anonymization<br/>Notice
+                </p>
+              </div>
+
+              {/* Right form column */}
+              <div className="w-full md:w-[60%] p-8 md:p-14 flex flex-col justify-center">
+                <div className="md:hidden mb-10">
+                  <h3 className="text-5xl font-black uppercase tracking-tighter leading-[0.85] text-primary mb-4">
+                    FARE<br/>WELL.
+                  </h3>
+                  <div className="h-1 w-12 bg-accent/50" />
+                </div>
+
+                <div className="mb-12">
+                  <h4 className="text-xl font-black uppercase tracking-tight text-primary mb-3 flex items-center gap-3">
+                    <span className="inline-block h-2 w-2 rounded-full bg-red-800"></span>
+                    Account Withdrawal
+                  </h4>
+                  <p className="text-sm font-medium text-primary/60 leading-relaxed text-balance">
+                    탈퇴 시 모든 정보가 익명화 처리되며 영구적으로 복구할 수 없습니다. 활성 계약이나 미납금이 있는 경우 탈퇴가 제한될 수 있습니다.
+                  </p>
+                </div>
+
+                <form onSubmit={handleSubmit} className="flex flex-col gap-10">
+                  <div className="relative">
+                    <label className="block text-[10px] font-black uppercase tracking-[0.3em] text-primary/60 mb-2">
+                      CURRENT PASSWORD
+                    </label>
+                    <input
+                      type="password"
+                      value={password}
+                      onChange={(e) => {
+                        setPassword(e.target.value);
+                        setError(null);
+                      }}
+                      disabled={isLoading}
+                      className={`w-full border-b bg-transparent px-0 py-3 text-lg font-medium text-primary outline-none transition-colors placeholder:text-primary/30 disabled:opacity-50 ${error ? 'border-red-800 focus:border-red-800' : 'border-primary/20 focus:border-accent'}`}
+                      placeholder="비밀번호를 입력하세요"
+                      required
+                    />
+                    
+                    <AnimatePresence>
+                      {error && (
+                        <motion.div
+                          initial={{ opacity: 0, y: -5 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          exit={{ opacity: 0, y: -5 }}
+                          className="absolute top-full left-0 mt-2"
+                        >
+                          <p className="text-xs font-bold text-red-800 tracking-tight">
+                            {error}
+                          </p>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
+
+                  <div className="mt-8 flex items-center justify-end gap-6">
+                    <button
+                      type="button"
+                      onClick={onClose}
+                      disabled={isLoading}
+                      className="text-xs font-black uppercase tracking-[0.2em] text-primary/40 transition-colors hover:text-primary disabled:opacity-50"
+                    >
+                      취소
+                    </button>
+                    <motion.button
+                      type="submit"
+                      disabled={isLoading}
+                      whileHover={!isLoading ? { scale: 1.02 } : {}}
+                      whileTap={!isLoading ? { scale: 0.98 } : {}}
+                      className="rounded-2xl bg-red-900 border border-red-900 px-8 py-5 text-xs font-black uppercase tracking-[0.2em] text-[#e8ebe6] transition-colors hover:bg-transparent hover:text-red-900 disabled:opacity-50"
+                    >
+                      {isLoading ? "PROCESSING..." : "탈퇴 확정"}
+                    </motion.button>
+                  </div>
+                </form>
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- **목적:** 사용자가 서비스 이용을 중단하고 탈퇴를 요청할 때, 안전하게 회원 데이터를 처리하는 회원 탈퇴 기능 도입.
- **해결 문제:** 회원 정보를 데이터베이스에서 영구 삭제(Hard Delete)할 경우, 해당 회원이 작성한 커뮤니티 게시글이나 예약 이력 등에서 Foreign Key 참조 에러 및 무결성 파괴가 발생합니다. 이를 방지하기 위해 **논리 삭제(Soft Delete)** 및 **민감정보 익명화 처리** 정책을 반영한 탈퇴 백엔드 및 모달 UI를 새롭게 추가했습니다.

## 🔑 주요 변경 사항 (What)
- **백엔드 (Backend)**
  - [ProfileService](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/profile/application/service/ProfileService.java:22:0-80:1): 회원 탈퇴 비즈니스 로직 추가 (`ACTIVE` 계약이나 `UNPAID` 미납금이 있을 시 `409 Conflict` 반환하여 탈퇴 차단 로직 포함).
  - [ProfilePersistenceAdapter](cci:2://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/common/profile/adapter/out/persistence/ProfilePersistenceAdapter.java:11:0-63:1): 회원 데이터를 "탈퇴한 사용자"로 일괄 익명화 처리한 뒤, `user.deactivate()` 처리를 통해 접속 상태(`UserStatus`) 제한.
  - `@SQLDelete` 가 붙은 엔티티의 `softDelete()` 메서드를 호출해 `deleted_at` 필드 기반 논리 삭제 진행.
  - `DELETE /api/users/me` 엔드포인트 구현 및 기존 발급된 Token 즉시 파기 연동(`LogoutUseCase`).
- **프론트엔드 (Frontend)**
  - [profile-info.tsx](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28common%29/profile/_components/profile-info.tsx:0:0-0:0): 현재 "내 정보" 계정 관리 화면 내에 회원 탈퇴 트리거 버튼 삽입.
  - [withdraw-modal.tsx](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28common%29/profile/_components/withdraw-modal.tsx:0:0-0:0): 파괴적인 동작에 걸맞게 "Moss & Aloe" 에디토리얼 가이드라인을 새롭게 해석한 모달 뷰 추가 (대담한 `FAREWELL` 타이포그래피, Framer Motion 라우팅, 딥 버건디 버튼).
  - `Zustand(useAuthStore)`: 탈퇴 성공 시 자동으로 클라이언트 단에서 로그아웃 처리를 수행하고 사용자를 홈 화면으로 전환.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #54 

## 💻 테스트 방법 (How to Test)
1. 클라이언트를 띄우고 로그인한 후, **"내 정보(`/profile`)"** 페이지로 진입합니다.
2. 우측 하단의 `회원 탈퇴` 버튼을 클릭하여 탈퇴 모달을 엽니다.
3. 현재 사용할 비밀번호를 틀리게 입력하여 `401 Unauthorized` 에러 메시지가 인풋폼 아래 정상 노출되는지 확인합니다.
4. **(예외 핸들링 테스트):** 할당된 활성 계약이 있거나 미납금이 있는 유저라면, 올바른 비밀번호를 입력해도 `409 Conflict` (예: "활성 중인 계약이 있어 탈퇴할 수 없습니다.")가 방어되는지 확인합니다.
5. 올바른 비밀번호를 입력 후 **[탈퇴 확정]** 버튼을 누릅니다. 
6. 성공 얼럿과 함께 모달 애니메이션이 닫히며 즉시 로그아웃 되어 **홈 화면으로 이동**하는지 검증합니다.
7. 방금 탈퇴한 계정으로 다시 로그인을 시도했을 때, 로그인 거부(`ACCOUNT_DEACTIVATED` / 401 오류) 처리가 되는지 검사합니다.
8. 데이터베이스 `users` 테이블에서 해당 유저의 `deleted_at` 컬럼에 날짜가 기입되고, 이름/이메일/번호가 모두 *"탈퇴한 사용자"* 로 익명화되었는지 최종 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
*(여기에 띄워놓으신 브라우저의 회원 탈퇴 모달 화면 스크린샷을 첨부해 주세요!)*

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- Hard Delete 방지를 위해 데이터 파기 대신 `Soft Delete` 전략과 민감정보 익명화(`전화번호`, `이메일`, `이름`을 "탈퇴한 사용자"로 덮어쓰기)를 적용했습니다. 향후 커뮤니티 조회 시, 해당 탈퇴 유저의 작성글에서 이름이 "탈퇴한 사용자"로 N+1 이슈 없이 부드럽게 노출되는지 한 번 더 확인 바랍니다.
- 탈퇴 UI 모달은 이번에 팀 내 UI/UX 디자인 가이드라인(Moss & Aloe Editorial)을 보다 파격적이고 다크하게 응용하여 짠 것이니 애니메이션 및 시각 요소들이 잘 렌더링 되는지도 확인해주세요!

Closes #54