### PR TITLE
[CS/fix] 알림(DB·댓글)·인박스 읽음·RSC 갱신

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -27,7 +27,8 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
   const isRead = readLocally || item.isRead;
 
   const handleClick = async () => {
-    // 1. 읽음 처리 후 배지·인박스 갱신 신호 (이동 전에 완료)
+    // 1. 읽음 처리: router.refresh()는 "현재 URL"의 RSC만 갱신합니다.
+    //    invalidate만 지연 실행하면 그사이 router.push로 다른 페이지로 나가 알림 페이지는 갱신되지 않습니다.
     if (!isRead) {
       try {
         const res = await fetch(`/api/notifications/${item.notificationId}/read`, {
@@ -37,6 +38,9 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
         if (res.ok) {
           setReadLocally(true);
           invalidateNotificationsUnreadCount();
+          router.refresh();
+          // Flight/RSC 페이로드가 돌아올 때까지 잠깐 대기 후 이동 (refresh는 Promise를 반환하지 않음)
+          await new Promise((r) => setTimeout(r, 400));
         }
       } catch {
         /* ignore */

--- a/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationsInboxRefreshClient.tsx
@@ -2,12 +2,13 @@
 
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
-import { NOTIFICATIONS_UNREAD_INVALIDATE } from "@/lib/notifications-events";
 
 /**
- * - 읽음 PATCH 후: invalidate → 짧게 디바운스 후 RSC 갱신
- * - 다른 라우트에서 알림으로 재진입: 마운트 후 지연 refresh (GET이 PATCH보다 먼저 끝나는 레이스 완화)
- * - 탭 전환 복귀 / bfcache 복원: 동일 디바운스로 한 번만 서버 데이터 재요청
+ * 알림 페이지 RSC 캐시 보정 (재진입·탭·bfcache).
+ *
+ * 읽음 직후 갱신은 NotificationListItem에서 router.refresh() 후 이동 전 대기로 처리합니다.
+ * 여기서 invalidate에 묶인 지연 refresh는 이미 다른 라우트로 나간 뒤에는 "현재 URL"만 갱신되어
+ * 대시보드·목록이 영원히 옛날 데이터로 남는 버그가 됩니다.
  */
 export function NotificationsInboxRefreshClient() {
   const router = useRouter();
@@ -23,11 +24,7 @@ export function NotificationsInboxRefreshClient() {
       }, delayMs);
     };
 
-    // 클라이언트 네비게이션으로 알림 페이지에 올 때 캐시된 RSC 보정
     scheduleRefresh(450);
-
-    const onInvalidate = () => scheduleRefresh(250);
-    window.addEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
 
     const onVisible = () => {
       if (document.visibilityState === "visible") scheduleRefresh(320);
@@ -42,7 +39,6 @@ export function NotificationsInboxRefreshClient() {
 
     return () => {
       if (idle) clearTimeout(idle);
-      window.removeEventListener(NOTIFICATIONS_UNREAD_INVALIDATE, onInvalidate);
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("pageshow", onPageShow);
     };


### PR DESCRIPTION
## 요약

### 백엔드 / DB
- `notifications_reference_type_check` 유지보수 SQL, 댓글·알림, `ContractApplyRequestDto` JSON 등.

### 프론트 (알림)
- 플로팅 배지: 읽음 후 `invalidate`로 미읽음 재조회.
- **인박스/대시보드**: `router.refresh()`는 **현재 URL**만 갱신하므로, 이동(`push`) **전에** 알림 페이지에 있을 때 refresh + 짧은 대기 후 이동. `invalidate`만 지연 refresh하던 경로는 제거.
- 낙관적 `readLocally`, 재진입·탭·bfcache용 `NotificationsInboxRefreshClient`.

## 운영 DB (미적용 시)
```sql
ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_reference_type_check;
ALTER TABLE notifications ADD CONSTRAINT notifications_reference_type_check CHECK (reference_type IS NULL OR reference_type IN ('CONTRACT','RESERVATION','VOC','COMMUNITY','PAYMENT'));