### PR TITLE
[CS/fix] 알림 읽음 상태 미반영 및 React Hydration 에러 수정

### DIFF
--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationItemResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationItemResponseDto.java
@@ -1,5 +1,6 @@
 package com.coliving.common.notification.adapter.in.web.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -14,6 +15,7 @@ public class NotificationItemResponseDto {
     private final String message;
     private final String referenceType;
     private final Long referenceId;
+    @JsonProperty("isRead")
     private final boolean isRead;
     private final OffsetDateTime createdAt;
 }

--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationReadResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationReadResponseDto.java
@@ -1,5 +1,6 @@
 package com.coliving.common.notification.adapter.in.web.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,5 +8,6 @@ import lombok.Getter;
 @Builder
 public class NotificationReadResponseDto {
     private final Long notificationId;
+    @JsonProperty("isRead")
     private final boolean isRead;
 }

--- a/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationSseEventResponseDto.java
+++ b/backend/src/main/java/com/coliving/common/notification/adapter/in/web/dto/res/NotificationSseEventResponseDto.java
@@ -1,5 +1,6 @@
 package com.coliving.common.notification.adapter.in.web.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,6 +16,7 @@ public class NotificationSseEventResponseDto {
     private String message;
     private String referenceType;
     private Long referenceId;
+    @JsonProperty("isRead")
     private boolean isRead;
     private OffsetDateTime createdAt;
 }

--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -132,13 +132,16 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
         </div>
         <div className="shrink-0 flex flex-col items-end gap-2 text-right">
           <span className="text-[10px] font-black uppercase tracking-widest text-muted-foreground">
-            {new Date(item.createdAt).toLocaleDateString()}
+            {(() => {
+              const d = new Date(item.createdAt);
+              return `${d.getFullYear()}. ${d.getMonth() + 1}. ${d.getDate()}.`;
+            })()}
           </span>
           <span className="text-[10px] font-black uppercase tracking-widest opacity-20">
-            {new Date(item.createdAt).toLocaleTimeString([], {
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
+            {(() => {
+              const d = new Date(item.createdAt);
+              return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+            })()}
           </span>
         </div>
       </div>


### PR DESCRIPTION
## 🐛 문제

1. **알림 목록에서 클릭 시 "읽음"으로 바뀌지만, 페이지를 다시 방문하면 "미읽음"으로 되돌아감**
2. **React Minified Error #418 (Hydration Mismatch)** 콘솔 에러 발생
3. 플로팅 배지(unread count)도 읽음 처리 후 갱신되지 않음

## 🔍 원인

### 1. Lombok `boolean isRead` + Jackson 직렬화 충돌

Java DTO에서 `boolean isRead` + Lombok `@Getter` 조합 시, Lombok은 `isRead()` getter를 생성하지만 **Jackson이 `is` 프리픽스를 제거하여 JSON 키를 `"read"`로 직렬화**합니다.

| 계층 | 코드 | 결과 |
|------|------|------|
| Java DTO | `boolean isRead` + `@Getter` | Lombok → `isRead()` |
| Jackson | `isRead()` → | JSON: `"read": true` |
| Frontend | `item.isRead` | **`undefined`** (항상 미읽음) |

### 2. React Hydration Error #418

`NotificationListItem.tsx`에서 `toLocaleDateString()` / `toLocaleTimeString()` 사용 → 서버(Node.js)와 클라이언트(브라우저)의 로케일·타임존 차이로 SSR HTML 불일치 발생

## ✅ 수정 내용

### Backend — `@JsonProperty("isRead")` 추가
- `NotificationItemResponseDto.java`
- `NotificationReadResponseDto.java`
- `NotificationSseEventResponseDto.java`

### Frontend — 날짜 포맷 결정론적 방식으로 변경
- `NotificationListItem.tsx`: `toLocaleDateString()` → `getFullYear()/getMonth()/getDate()` 조합

## 📁 변경 파일

| 파일 | 변경 |
|------|------|
| `NotificationItemResponseDto.java` | `@JsonProperty("isRead")` 추가 |
| `NotificationReadResponseDto.java` | `@JsonProperty("isRead")` 추가 |
| `NotificationSseEventResponseDto.java` | `@JsonProperty("isRead")` 추가 |
| `NotificationListItem.tsx` | 날짜 포맷 hydration mismatch 수정 |

## 🧪 테스트 방법

1. 백엔드 재빌드 후 배포
2. 알림 목록 진입 → 미읽음 알림 클릭
3. 뒤로가기 또는 재진입 시 **읽음 상태 유지 확인**
4. 브라우저 콘솔에서 React Error #418 사라졌는지 확인
