### PR TITLE
[USR/test] 사용자 권한 통합 테스트

### DIFF
--- a/backend/src/test/java/com/coliving/global/config/SecurityRoleCoverageTest.java
+++ b/backend/src/test/java/com/coliving/global/config/SecurityRoleCoverageTest.java
@@ -1,0 +1,151 @@
+package com.coliving.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityRoleCoverageTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // 편의를 위한 Custom Matcher: 인증/인가 성공을 나타내는 상태 (2xx, 400, 404, 405 등 401/403이 아닌 상태)
+    private ResultMatcher isAllowed() {
+        return result -> {
+            int status = result.getResponse().getStatus();
+            if (status == 401 || status == 403) {
+                throw new AssertionError("기대 상태: 허용(2xx, 404 등), 실제 상태: " + status);
+            }
+        };
+    }
+
+    @Test
+    @DisplayName("Public API - 권한과 무관하게 접근 허용")
+    void testPublicApi() throws Exception {
+        // 공개 공간 조회 -> 허용 확인
+        mockMvc.perform(get("/api/rooms/mock_not_exists"))
+                .andExpect(isAllowed());
+        // 로그인 API
+        mockMvc.perform(post("/api/auth/login"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @DisplayName("Admin API - 권한별 접근 테스트 (ADMIN만 허용)")
+    void testAdminApiUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/admin/mock_not_exists"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testAdminApiUser() throws Exception {
+        mockMvc.perform(get("/api/admin/mock_not_exists"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "RESIDENT")
+    void testAdminApiResident() throws Exception {
+        mockMvc.perform(get("/api/admin/mock_not_exists"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testAdminApiAdmin() throws Exception {
+        mockMvc.perform(get("/api/admin/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @DisplayName("Device API - 권한별 접근 테스트 (RESIDENT, ADMIN 허용)")
+    void testDeviceApiUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/devices/mock_not_exists"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testDeviceApiUser() throws Exception {
+        mockMvc.perform(get("/api/devices/mock_not_exists"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles = "RESIDENT")
+    void testDeviceApiResident() throws Exception {
+        mockMvc.perform(get("/api/devices/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDeviceApiAdmin() throws Exception {
+        mockMvc.perform(get("/api/devices/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @DisplayName("VOC API - 권한별 접근 테스트 (MEMBER_ROLES 허용)")
+    void testVocApiUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/vocs/mock_not_exists"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testVocApiUser() throws Exception {
+        mockMvc.perform(get("/api/vocs/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @WithMockUser(roles = "RESIDENT")
+    void testVocApiResident() throws Exception {
+        mockMvc.perform(get("/api/vocs/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testVocApiAdmin() throws Exception {
+        mockMvc.perform(get("/api/vocs/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @DisplayName("알림 API - 권한별 접근 테스트 (MEMBER_ROLES 허용)")
+    @WithMockUser(roles = "USER")
+    void testNotificationApiUser() throws Exception {
+        mockMvc.perform(get("/api/notifications/mock_not_exists"))
+                .andExpect(isAllowed());
+    }
+
+    @Test
+    @DisplayName("방어 지점 테스트 - 존재하지 않는 그 외 API는 모두 인증 필터 작용")
+    void testAnyRequestUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/unknown"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testAnyRequestAuthenticated() throws Exception {
+        mockMvc.perform(get("/api/unknown"))
+                .andExpect(isAllowed());
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- **사용자 역할 및 권한 커버리지 검증:** Spring Security([SecurityConfig.java](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/main/java/com/coliving/global/config/SecurityConfig.java:0:0-0:0))의 URL 경로 설정과 역할(Unauthenticated/USER/RESIDENT/ADMIN) 기반 접근 제어 필터가 명세대로 잘 동작하는지 검증하기 위해 작성되었습니다.
- **치명적인 권한 우회/탈취 해킹 방지:** 명시되지 않은 엔드포인트 우회 접근이나, 하위 권한 스위칭 등 인증 및 인가 실패 엣지케이스를 자동화 테스트로 철저히 차단합니다.

## 🔑 주요 변경 사항 (What)
- **`MockMvc` 기반 단위/통합 테스트 세팅 추가 ([SecurityRoleCoverageTest.java](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/backend/src/test/java/com/coliving/global/config/SecurityRoleCoverageTest.java:0:0-0:0)):** `@WithMockUser`를 활용한 다중 권한 셋업
- **도메인별(Admin, Device, Voc, Noti 등) 권한 통과 시나리오 16종 구축:** 
  - 미인증, `USER`, `RESIDENT`, `ADMIN`을 번갈아 주입해 `401 Unauthorized` 또는 `403 Forbidden` 발생 여부를 교차 검증
  - 필터 방어선 외 임의의 URL(`/api/unknown` 등)을 찔러 모든 기본 접근에 대한 인증 방어가 뚫려있지 않은지 검사
- **비즈니스 에러와 Security 필터 로직의 분리 검증:** 실제 Controller 핸들러에서 나는 가짜 에러를 배제하기 위해 의도적으로 존재하지 않는 엔드포인트(`mock_not_exists`)를 찔르고, 필터 통과(`404` 등 허용 상태)와 차단(`401/403`)만을 순수하게 분리하여 테스트

## 🔗 연관된 이슈 (Issue / Ticket)
- 관련 이슈 번호를 입력해주세요. (예: Resolves #55)

## 💻 테스트 방법 (How to Test)
1. 백엔드 디렉토리(`backend`) 터미널 환경에 진입합니다.
2. 다음 명령어를 입력하여 Security 커버리지 테스트 전용 실행을 진행합니다.
   ```bash
   ./gradlew test --tests "com.coliving.global.config.SecurityRoleCoverageTest"