### PR TITLE
[CS/fix] 알림 버그 수정 + 권한 제한 + 누락 알림 구현

### DIFF
--- a/backend/src/main/java/com/coliving/admin/contract/application/service/AdminContractService.java
+++ b/backend/src/main/java/com/coliving/admin/contract/application/service/AdminContractService.java
@@ -136,6 +136,15 @@ public class AdminContractService implements AdminContractUseCase {
 
                 repositoryPort.save(contract);
 
+                // 계약 수정 알림을 해당 사용자에게 발송
+                notificationRepositoryPort.create(
+                                contract.getUserId(),
+                                NotificationType.CONTRACT_UPDATED,
+                                "계약 정보가 변경되었습니다",
+                                "관리자에 의해 계약 조건(기간, 금액 등)이 변경되었습니다. 내 계약 정보를 확인해 주세요.",
+                                ReferenceType.CONTRACT,
+                                contract.getContractId());
+
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
                                 .message("계약 정보가 수정되었습니다.")

--- a/backend/src/main/java/com/coliving/admin/payment/application/service/AdminPaymentService.java
+++ b/backend/src/main/java/com/coliving/admin/payment/application/service/AdminPaymentService.java
@@ -6,20 +6,27 @@ import com.coliving.admin.payment.application.port.in.ViewPaymentListUseCase;
 import com.coliving.admin.payment.application.port.out.PaymentRepositoryPort;
 import com.coliving.admin.payment.model.Payment;
 import com.coliving.admin.payment.model.PaymentStatus;
+import com.coliving.common.notification.application.command.CreateNotificationCommand;
+import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
+import com.coliving.common.notification.model.NotificationType;
+import com.coliving.common.notification.model.ReferenceType;
 import com.coliving.global.error.BusinessException;
 import com.coliving.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminPaymentService implements ApprovePaymentUseCase, ViewPaymentListUseCase {
 
     private final PaymentRepositoryPort paymentRepositoryPort;
+    private final CreateNotificationUseCase createNotificationUseCase;
 
     @Override
     @Transactional
@@ -35,7 +42,25 @@ public class AdminPaymentService implements ApprovePaymentUseCase, ViewPaymentLi
         payment.setPaymentMethod(command.getPaymentMethod());
         payment.setPaidDate(command.getPaidDate());
 
-        return paymentRepositoryPort.save(payment);
+        Payment saved = paymentRepositoryPort.save(payment);
+
+        // 결제 승인 알림을 해당 사용자에게 발송
+        try {
+            createNotificationUseCase.create(CreateNotificationCommand.builder()
+                    .userId(saved.getUserId())
+                    .type(NotificationType.PAYMENT_SUCCESS)
+                    .title("결제가 승인되었습니다")
+                    .message(String.format("%s 납부가 관리자에 의해 승인 처리되었습니다. (%s원)",
+                            saved.getType(), saved.getAmount().toPlainString()))
+                    .referenceType(ReferenceType.PAYMENT)
+                    .referenceId(saved.getPaymentId())
+                    .build());
+        } catch (Exception e) {
+            log.error("결제 승인 알림 발송 실패 paymentId={}, userId={}: {}",
+                    saved.getPaymentId(), saved.getUserId(), e.getMessage());
+        }
+
+        return saved;
     }
 
     @Override
@@ -48,3 +73,4 @@ public class AdminPaymentService implements ApprovePaymentUseCase, ViewPaymentLi
         return paymentRepositoryPort.findByUserId(userId);
     }
 }
+

--- a/backend/src/main/java/com/coliving/common/notification/model/NotificationType.java
+++ b/backend/src/main/java/com/coliving/common/notification/model/NotificationType.java
@@ -1,10 +1,12 @@
 package com.coliving.common.notification.model;
 
 public enum NotificationType {
+    CONTRACT_SUBMITTED,
     CONTRACT_APPROVED,
     CONTRACT_REJECTED,
     CONTRACT_ACTIVATED,
     CONTRACT_EXPIRED,
+    CONTRACT_UPDATED,
     RESERVATION_APPROVED,
     RESERVATION_PENDING,
     RESERVATION_REJECTED,

--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -28,6 +28,9 @@ public class SecurityConfig {
     /** 일반 회원·입주자·관리자 공통 (JWT role 클레임과 동일) */
     private static final String[] MEMBER_ROLES = {"USER", "RESIDENT", "ADMIN"};
 
+    /** 입주자·관리자만 (게시판·민원·댓글 CUD) */
+    private static final String[] RESIDENT_ADMIN_ROLES = {"RESIDENT", "ADMIN"};
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -69,19 +72,19 @@ public class SecurityConfig {
                                 "/api/reservations/**", "/api/control-logs/**")
                         .hasAnyRole("RESIDENT", "ADMIN")
 
-                        // --- VOC: 로그인 회원만 (본인 민원만 서비스 레이어에서 제한) ---
-                        .requestMatchers("/api/vocs/**").hasAnyRole(MEMBER_ROLES)
-                        // VOC 본문 이미지·첨부 파일 (회원 전용)
-                        .requestMatchers(HttpMethod.GET, "/api/files/voc/**").hasAnyRole(MEMBER_ROLES)
+                        // --- VOC: 입주자·관리자만 (본인 민원만 서비스 레이어에서 추가 제한) ---
+                        .requestMatchers("/api/vocs/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
+                        // VOC 본문 이미지·첨부 파일 (입주자·관리자만)
+                        .requestMatchers(HttpMethod.GET, "/api/files/voc/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
 
-                        // --- 알림: 로그인 회원만 ---
+                        // --- 알림: 로그인 회원 전체 (USER 포함) ---
                         .requestMatchers("/api/notifications/**").hasAnyRole(MEMBER_ROLES)
 
-                        // --- 댓글: /api/comments/** (게시글 댓글 등록은 아래 /api/posts/** 규칙에 포함) ---
-                        .requestMatchers("/api/comments/**").hasAnyRole(MEMBER_ROLES)
+                        // --- 댓글: 입주자·관리자만 ---
+                        .requestMatchers("/api/comments/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
 
                         // --- 커뮤니티: 글 작성·수정·삭제, 좋아요, 에디터 이미지 업로드 (GET은 위에서 이미 permitAll) ---
-                        .requestMatchers("/api/posts/**").hasAnyRole(MEMBER_ROLES)
+                        .requestMatchers("/api/posts/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
 
                         // --- 그 외 API ---
                         .anyRequest().authenticated())

--- a/backend/src/main/java/com/coliving/user/contract/application/service/ContractService.java
+++ b/backend/src/main/java/com/coliving/user/contract/application/service/ContractService.java
@@ -3,7 +3,9 @@ package com.coliving.user.contract.application.service;
 import com.coliving.admin.space.application.port.out.AdminSpaceRepositoryPort;
 import com.coliving.admin.space.model.AdminSpace;
 import com.coliving.admin.user.application.port.out.AdminUserRepositoryPort;
+import com.coliving.admin.user.application.result.AdminUserResult;
 import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
 import com.coliving.common.notification.application.port.out.NotificationRepositoryPort;
 import com.coliving.common.notification.model.NotificationType;
 import com.coliving.common.notification.model.ReferenceType;
@@ -22,12 +24,16 @@ import com.coliving.user.contract.model.ContractOrigin;
 import com.coliving.user.contract.model.ContractStatus;
 import com.coliving.admin.space.model.SpaceStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -157,7 +163,37 @@ public class ContractService implements ContractUseCase {
         }
 
         Contract saved = contractRepositoryPort.save(contract);
+
+        // 관리자 전원에게 신규 입주 신청 알림
+        notifyAllAdminsOfContractSubmission(saved);
+
         return ContractResult.success(saved.getContractId(), "계약 신청이 완료되었습니다.");
+    }
+
+    private void notifyAllAdminsOfContractSubmission(Contract contract) {
+        try {
+            Page<AdminUserResult> adminPage = adminUserRepositoryPort.findUsers(
+                    UserRole.ADMIN, UserStatus.ACTIVE.name(), null, null, Pageable.unpaged());
+            if (adminPage == null || adminPage.getContent() == null) {
+                return;
+            }
+            for (AdminUserResult admin : adminPage.getContent()) {
+                try {
+                    notificationRepositoryPort.create(
+                            admin.getId(),
+                            NotificationType.CONTRACT_SUBMITTED,
+                            "새로운 입주 신청이 접수되었습니다",
+                            String.format("호실 ID [%d]에 대한 입주 신청이 접수되었습니다. 확인해 주세요.",
+                                    contract.getSpaceId()),
+                            ReferenceType.CONTRACT,
+                            contract.getContractId());
+                } catch (Exception e) {
+                    log.warn("관리자 계약 신청 알림 실패 adminId={}: {}", admin.getId(), e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("계약 신청 관리자 알림 팬아웃 실패 contractId={}: {}", contract.getContractId(), e.getMessage());
+        }
     }
 
     @Override


### PR DESCRIPTION
## 📌 개요

알림 시스템의 핵심 버그 수정, 도메인별 권한 규칙 정비, 미구현 알림 시나리오 추가를 포함합니다.

---

## 🐛 버그 수정

### 1. 알림 읽음 상태 미반영
- **증상**: 알림 클릭 → 읽음 전환 → 페이지 재진입 시 미읽음으로 되돌아감
- **원인**: Lombok `boolean isRead` + Jackson 직렬화 충돌 (`"read"` 키로 직렬화되어 프론트엔드에서 `undefined`)
- **수정**: 3개 DTO에 `@JsonProperty("isRead")` 추가

| DTO | 파일 |
|-----|------|
| `NotificationItemResponseDto` | 목록 조회 |
| `NotificationReadResponseDto` | 읽음 처리 응답 |
| `NotificationSseEventResponseDto` | SSE 실시간 이벤트 |

### 2. React Hydration Error #418
- **증상**: 콘솔에 `Minified React error #418` 발생
- **원인**: `toLocaleDateString()` / `toLocaleTimeString()`이 SSR/CSR 간 다른 결과 생성
- **수정**: `NotificationListItem.tsx`에서 결정론적 날짜 포맷(`YYYY. MM. DD.` / `HH:MM`)으로 변경

---

## 🔒 권한(Authorization) 정비

### SecurityConfig 변경

게시판·댓글·민원 CUD를 **RESIDENT + ADMIN만** 허용하도록 제한:

```java
private static final String[] RESIDENT_ADMIN_ROLES = {"RESIDENT", "ADMIN"};
