### PR TITLE
[CMN/fix] 날짜/시간 Asia/Seoul(KST) 명시 적용

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/JacksonConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/JacksonConfig.java
@@ -69,6 +69,8 @@ public class JacksonConfig {
         return new ObjectMapper()
                 .registerModule(javaTimeModule)
                 // LocalDate 등을 [2026,5,1] 배열이 아닌 "2026-05-01" 문자열로 직렬화
-                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                // 모든 날짜/시간 직렬화·역직렬화 시 Asia/Seoul(KST) 기준
+                .setTimeZone(java.util.TimeZone.getTimeZone("Asia/Seoul"));
     }
 }

--- a/backend/src/main/java/com/coliving/global/config/JpaConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/JpaConfig.java
@@ -6,14 +6,17 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 @Configuration
 @EnableJpaAuditing(dateTimeProviderRef = "offsetDateTimeProvider")
 public class JpaConfig {
 
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
     @Bean
     public DateTimeProvider offsetDateTimeProvider() {
-        return () -> Optional.of(OffsetDateTime.now());
+        return () -> Optional.of(OffsetDateTime.now(SEOUL));
     }
 }

--- a/backend/src/main/java/com/coliving/global/entity/BaseEntity.java
+++ b/backend/src/main/java/com/coliving/global/entity/BaseEntity.java
@@ -9,11 +9,14 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
@@ -27,10 +30,11 @@ public abstract class BaseEntity {
     private OffsetDateTime deletedAt;
 
     public void softDelete() {
-        this.deletedAt = OffsetDateTime.now();
+        this.deletedAt = OffsetDateTime.now(SEOUL);
     }
 
     public boolean isDeleted() {
         return this.deletedAt != null;
     }
 }
+


### PR DESCRIPTION
## 📌 개요

알림 시스템 버그 수정, 도메인별 접근 권한 정비, 미구현 알림 시나리오 추가, 403 사용자 안내 팝업 구현, 날짜/시간 시간대(KST) 정합성 확보를 포함합니다.

---

## 🐛 버그 수정

### 1. 알림 읽음 상태 미반영
- **증상**: 알림 클릭 → 읽음 전환 → 페이지 재진입 시 미읽음으로 되돌아감
- **원인**: Lombok `boolean isRead` + Jackson 직렬화 충돌 (`"read"` 키로 직렬화)
- **수정**: 3개 DTO에 `@JsonProperty("isRead")` 추가

### 2. React Hydration Error #418
- **증상**: `Minified React error #418` 발생
- **원인**: `toLocaleDateString()` / `toLocaleTimeString()`의 SSR/CSR 불일치
- **수정**: `NotificationListItem.tsx`에서 결정론적 날짜 포맷으로 변경

### 3. 날짜/시간 시간대 어긋남 (KST)
- **증상**: community, comment, voc, notification의 시간이 실제 서울 시간과 불일치
- **원인**: `JpaConfig`의 `DateTimeProvider`가 `OffsetDateTime.now()`로 JVM 기본 시간대(UTC) 사용
- **수정**:

| 파일 | 변경 |
|------|------|
| `JpaConfig.java` | `OffsetDateTime.now()` → `OffsetDateTime.now(ZoneId.of("Asia/Seoul"))` |
| `BaseEntity.java` | `softDelete()`에 KST 명시 |
| `JacksonConfig.java` | `ObjectMapper.setTimeZone("Asia/Seoul")` 추가 |

---

## 🔒 권한(Authorization) 정비

### SecurityConfig 변경

게시판·댓글·민원 CUD를 **RESIDENT + ADMIN만** 허용하도록 제한:

```java
private static final String[] RESIDENT_ADMIN_ROLES = {"RESIDENT", "ADMIN"};
