### PR TITLE
[CS/feat] 이벤트 기반 비동기 알림 아키텍처 구현 (ApplicationEventPublisher + @Async)

### DIFF
--- a/backend/src/main/java/com/coliving/CoLivingApplication.java
+++ b/backend/src/main/java/com/coliving/CoLivingApplication.java
@@ -2,12 +2,14 @@ package com.coliving;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 public class CoLivingApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/coliving/admin/contract/application/event/ContractStatusChangedByAdminEvent.java
+++ b/backend/src/main/java/com/coliving/admin/contract/application/event/ContractStatusChangedByAdminEvent.java
@@ -1,0 +1,17 @@
+package com.coliving.admin.contract.application.event;
+
+import com.coliving.user.contract.model.ContractStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ContractStatusChangedByAdminEvent {
+    private final Long contractId;
+    private final Long userId;
+    private final Long spaceId;
+    private final String spaceName; // 공간 이름을 미리 담아서 컨텍스트 유실 방지
+    private final ContractStatus newStatus;
+    private final String message;
+    private final String rejectedReason;
+}

--- a/backend/src/main/java/com/coliving/admin/contract/application/service/AdminContractService.java
+++ b/backend/src/main/java/com/coliving/admin/contract/application/service/AdminContractService.java
@@ -35,7 +35,7 @@ import java.util.List;
 public class AdminContractService implements AdminContractUseCase {
 
         private final AdminContractRepositoryPort repositoryPort;
-        private final NotificationRepositoryPort notificationRepositoryPort;
+        private final org.springframework.context.ApplicationEventPublisher eventPublisher;
         private final SpaceJpaRepository spaceJpaRepository;
         private final UserJpaRepository userJpaRepository;
         private final ContractJpaRepository contractJpaRepository;
@@ -99,14 +99,15 @@ public class AdminContractService implements AdminContractUseCase {
                 user.changeRole(UserRole.RESIDENT);
                 userJpaRepository.save(user);
 
-                // 알림 생성
-                notificationRepositoryPort.create(
-                                user.getUserId(),
-                                NotificationType.CONTRACT_APPROVED,
-                                "관리자에 의해 계약이 등록되었습니다.",
-                                String.format("[%s] 호실의 계약이 등록되었습니다. 입주자로 전환됩니다.", space.getName()),
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(user.getUserId())
+                                .spaceId(space.getSpaceId())
+                                .spaceName(space.getName())
+                                .newStatus(contract.getStatus())
+                                .message("관리자에 의해 계약이 등록되었습니다.")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
@@ -136,14 +137,13 @@ public class AdminContractService implements AdminContractUseCase {
 
                 repositoryPort.save(contract);
 
-                // 계약 수정 알림을 해당 사용자에게 발송
-                notificationRepositoryPort.create(
-                                contract.getUserId(),
-                                NotificationType.CONTRACT_UPDATED,
-                                "계약 정보가 변경되었습니다",
-                                "관리자에 의해 계약 조건(기간, 금액 등)이 변경되었습니다. 내 계약 정보를 확인해 주세요.",
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 계약 수정 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(contract.getUserId())
+                                .newStatus(ContractStatus.ACTIVE) // 수정되어도 상태는 ACTIVE 유지
+                                .message("계약 정보가 변경되었습니다")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
@@ -175,14 +175,13 @@ public class AdminContractService implements AdminContractUseCase {
                 // 다른 ACTIVE 계약 없으면 role → USER 복원
                 demoteUserIfNoActiveContract(contract.getUserId());
 
-                // 알림 생성
-                notificationRepositoryPort.create(
-                                contract.getUserId(),
-                                NotificationType.CONTRACT_EXPIRED,
-                                "계약이 만료되었습니다.",
-                                "계약이 만료 처리되었습니다. 새로운 계약이 필요하시면 방 둘러보기를 이용해 주세요.",
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(contract.getUserId())
+                                .newStatus(ContractStatus.TERMINATED)
+                                .message("계약이 만료되었습니다.")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
@@ -214,14 +213,13 @@ public class AdminContractService implements AdminContractUseCase {
                 // 다른 ACTIVE 계약 없으면 role → USER 복원
                 demoteUserIfNoActiveContract(contract.getUserId());
 
-                // 알림 생성
-                notificationRepositoryPort.create(
-                                contract.getUserId(),
-                                NotificationType.CONTRACT_EXPIRED,
-                                "계약이 해지되었습니다.",
-                                "관리자에 의해 계약이 해지 처리되었습니다.",
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(contract.getUserId())
+                                .newStatus(ContractStatus.TERMINATED)
+                                .message("계약이 해지되었습니다.")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
@@ -252,15 +250,14 @@ public class AdminContractService implements AdminContractUseCase {
 
                 repositoryPort.save(contract);
 
-                // 알림 생성: 계약 승인
-                notificationRepositoryPort.create(
-                                contract.getUserId(),
-                                NotificationType.CONTRACT_APPROVED,
-                                "입주 신청이 승인되었습니다.",
-                                String.format("[%s] 호실의 입주 신청이 승인되었습니다. 최종 조건을 확인하고 계약을 체결해 주세요.",
-                                                contract.getSpaceId()),
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(contract.getUserId())
+                                .spaceId(contract.getSpaceId())
+                                .newStatus(ContractStatus.APPROVED)
+                                .message("입주 신청이 승인되었습니다.")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())
@@ -298,14 +295,14 @@ public class AdminContractService implements AdminContractUseCase {
                         demoteUserIfNoActiveContract(contract.getUserId());
                 }
 
-                // 알림 생성: 계약 반려
-                notificationRepositoryPort.create(
-                                contract.getUserId(),
-                                NotificationType.CONTRACT_REJECTED,
-                                "계약이 반려(종료)되었습니다.",
-                                String.format("반려 사유: %s", command.getRejectedReason()),
-                                ReferenceType.CONTRACT,
-                                contract.getContractId());
+                // 알림 이벤트 발행
+                eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                                .contractId(contract.getContractId())
+                                .userId(contract.getUserId())
+                                .newStatus(ContractStatus.REJECTED)
+                                .rejectedReason(command.getRejectedReason())
+                                .message("계약이 반려(종료)되었습니다.")
+                                .build());
 
                 return AdminContractResult.builder()
                                 .contractId(contract.getContractId())

--- a/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
+++ b/backend/src/main/java/com/coliving/common/comment/application/event/CommentPostedNotificationListener.java
@@ -8,6 +8,7 @@ import com.coliving.common.notification.model.NotificationType;
 import com.coliving.common.notification.model.ReferenceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -23,6 +24,7 @@ public class CommentPostedNotificationListener {
     private final CommentRepositoryPort commentRepositoryPort;
     private final CreateNotificationUseCase createNotificationUseCase;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onCommentPosted(CommentPostedEvent event) {
         if (event == null || event.getPostId() == null || event.getActorId() == null) {

--- a/backend/src/main/java/com/coliving/common/community/application/event/CommunityNotificationListener.java
+++ b/backend/src/main/java/com/coliving/common/community/application/event/CommunityNotificationListener.java
@@ -1,0 +1,69 @@
+package com.coliving.common.community.application.event;
+
+import com.coliving.admin.user.application.port.out.AdminUserRepositoryPort;
+import com.coliving.admin.user.application.result.AdminUserResult;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
+import com.coliving.common.notification.application.command.CreateNotificationCommand;
+import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
+import com.coliving.common.notification.model.NotificationType;
+import com.coliving.common.notification.model.ReferenceType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CommunityNotificationListener {
+
+    private final AdminUserRepositoryPort adminUserRepositoryPort;
+    private final CreateNotificationUseCase createNotificationUseCase;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onNoticePublished(NoticePublishedEvent event) {
+        log.info("Starting ASYNC notice fan-out for post: {}", event.getPostId());
+        
+        int successCount = 0;
+        int totalUsers = 0;
+
+        try {
+            for (UserRole role : List.of(UserRole.USER, UserRole.RESIDENT)) {
+                // 대량 사용자 처리를 고려하여 페이징 호출 (여기서는 단순화하여 1000명까지 처리 예시)
+                Page<AdminUserResult> userPage = adminUserRepositoryPort.findUsers(
+                        role, UserStatus.ACTIVE.name(), null, null, PageRequest.of(0, 1000));
+                
+                if (userPage == null || userPage.getContent() == null) continue;
+
+                totalUsers += userPage.getContent().size();
+                for (AdminUserResult user : userPage.getContent()) {
+                    try {
+                        createNotificationUseCase.create(CreateNotificationCommand.builder()
+                                .userId(user.getId())
+                                .type(NotificationType.COMMUNITY_NOTICE)
+                                .title("새로운 공지사항")
+                                .message(String.format("「%s」 공지사항이 등록되었습니다.", event.getTitle()))
+                                .referenceType(ReferenceType.COMMUNITY)
+                                .referenceId(event.getPostId())
+                                .build());
+                        successCount++;
+                    } catch (Exception e) {
+                        log.warn("Failed to send notice to user {}: {}", user.getId(), e.getMessage());
+                    }
+                }
+            }
+            log.info("Async Notice fan-out finished. Success: {}/{}, PostId: {}", 
+                    successCount, totalUsers, event.getPostId());
+        } catch (Exception e) {
+            log.error("Critical error in CommunityNotificationListener: {}", e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/com/coliving/common/community/application/event/NoticePublishedEvent.java
+++ b/backend/src/main/java/com/coliving/common/community/application/event/NoticePublishedEvent.java
@@ -1,0 +1,11 @@
+package com.coliving.common.community.application.event;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class NoticePublishedEvent {
+    private final Long postId;
+    private final String title;
+}

--- a/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
+++ b/backend/src/main/java/com/coliving/common/community/application/service/CommunityService.java
@@ -158,44 +158,11 @@ public class CommunityService implements CommunityUseCase {
     private void notifyAllResidentsOfNotice(Post post, String title) {
         if (post == null) return;
 
-        log.info("Starting notice notification fan-out for post: {}", post.getPostId());
-        int successCount = 0;
-        int totalUsers = 0;
-
-        try {
-            // USER + RESIDENT 모두에게 알림 전송
-            for (UserRole role : List.of(UserRole.USER, UserRole.RESIDENT)) {
-                // Pageable.unpaged()가 일부 환경에서 오동작할 수 있으므로 명시적 큰 사이즈 부여 고려 가능
-                Page<AdminUserResult> userPage = adminUserRepositoryPort.findUsers(
-                        role, UserStatus.ACTIVE.name(), null, null, PageRequest.of(0, 1000));
-                
-                if (userPage == null || userPage.getContent() == null) {
-                    log.warn("No active users found for role: {}", role);
-                    continue;
-                }
-
-                totalUsers += userPage.getContent().size();
-                for (AdminUserResult user : userPage.getContent()) {
-                    try {
-                        createNotificationUseCase.create(CreateNotificationCommand.builder()
-                                .userId(user.getId())
-                                .type(NotificationType.COMMUNITY_NOTICE)
-                                .title(title)
-                                .message(String.format("「%s」 공지사항이 등록되었습니다.", post.getTitle()))
-                                .referenceType(ReferenceType.COMMUNITY)
-                                .referenceId(post.getPostId())
-                                .build());
-                        successCount++;
-                    } catch (Exception e) {
-                        log.error("Failed to send notice notification to user: {}", user.getId(), e);
-                    }
-                }
-            }
-            log.info("Notice notification fan-out completed. Success: {}/{}, PostId: {}", 
-                    successCount, totalUsers, post.getPostId());
-        } catch (Exception e) {
-            log.error("Critical failure during notice notification fan-out for post: {}", post.getPostId(), e);
-        }
+        // 대량 알림(팬아웃)은 비동기 리스너로 위임
+        eventPublisher.publishEvent(com.coliving.common.community.application.event.NoticePublishedEvent.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .build());
     }
 
     @Override

--- a/backend/src/main/java/com/coliving/common/notification/application/service/NotificationCreatedEventListener.java
+++ b/backend/src/main/java/com/coliving/common/notification/application/service/NotificationCreatedEventListener.java
@@ -1,6 +1,7 @@
 package com.coliving.common.notification.application.service;
 
 import com.coliving.common.notification.application.event.NotificationCreatedEvent;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class NotificationCreatedEventListener {
         this.notificationRealtimeFanoutService = notificationRealtimeFanoutService;
     }
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onNotificationCreated(NotificationCreatedEvent event) {
         if (event == null || event.getNotification() == null) {

--- a/backend/src/main/java/com/coliving/common/voc/application/event/VocAdminNotifyEventListener.java
+++ b/backend/src/main/java/com/coliving/common/voc/application/event/VocAdminNotifyEventListener.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -24,6 +25,7 @@ public class VocAdminNotifyEventListener {
     private final AdminUserRepositoryPort adminUserRepositoryPort;
     private final CreateNotificationUseCase createNotificationUseCase;
 
+    @Async("notificationExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onVocAdminNotify(VocAdminNotifyEvent event) {
         if (event == null || event.getVocId() == null) {

--- a/backend/src/main/java/com/coliving/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.coliving.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "notificationExecutor")
+    public Executor notificationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);        // 기본 스레드 수
+        executor.setMaxPoolSize(10);       // 최대 스레드 수
+        executor.setQueueCapacity(100);    // 대기 큐
+        executor.setThreadNamePrefix("AsyncNotify-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/coliving/user/contract/application/event/ContractNotificationListener.java
+++ b/backend/src/main/java/com/coliving/user/contract/application/event/ContractNotificationListener.java
@@ -1,0 +1,97 @@
+package com.coliving.user.contract.application.event;
+
+import com.coliving.admin.user.application.port.out.AdminUserRepositoryPort;
+import com.coliving.admin.user.application.result.AdminUserResult;
+import com.coliving.common.auth.model.UserRole;
+import com.coliving.common.auth.model.UserStatus;
+import com.coliving.common.notification.application.command.CreateNotificationCommand;
+import com.coliving.common.notification.application.port.in.CreateNotificationUseCase;
+import com.coliving.common.notification.model.NotificationType;
+import com.coliving.common.notification.model.ReferenceType;
+import com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent;
+import com.coliving.user.contract.model.Contract;
+import com.coliving.user.contract.model.ContractStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContractNotificationListener {
+
+    private final AdminUserRepositoryPort adminUserRepositoryPort;
+    private final CreateNotificationUseCase createNotificationUseCase;
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onContractSubmitted(ContractSubmittedEvent event) {
+        Contract contract = event.getContract();
+        log.info("Handling ContractSubmittedEvent for contract: {}", contract.getContractId());
+
+        try {
+            Page<AdminUserResult> adminPage = adminUserRepositoryPort.findUsers(
+                    UserRole.ADMIN, UserStatus.ACTIVE.name(), null, null, Pageable.unpaged());
+            
+            if (adminPage == null || adminPage.getContent() == null) return;
+
+            for (AdminUserResult admin : adminPage.getContent()) {
+                try {
+                    createNotificationUseCase.create(CreateNotificationCommand.builder()
+                            .userId(admin.getId())
+                            .type(NotificationType.CONTRACT_SUBMITTED)
+                            .title("새로운 입주 신청이 접수되었습니다")
+                            .message(String.format("호실 ID [%d]에 대한 입주 신청이 접수되었습니다.", contract.getSpaceId()))
+                            .referenceType(ReferenceType.CONTRACT)
+                            .referenceId(contract.getContractId())
+                            .build());
+                } catch (Exception e) {
+                    log.warn("Failed to notify admin {} about contract {}: {}", admin.getId(), contract.getContractId(), e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            log.error("Fatal error during ContractSubmittedEvent fan-out: {}", e.getMessage());
+        }
+    }
+
+    @Async("notificationExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onContractStatusChanged(ContractStatusChangedByAdminEvent event) {
+        log.info("Handling ContractStatusChangedByAdminEvent for contract: {}, status: {}", 
+                event.getContractId(), event.getNewStatus());
+
+        NotificationType type = determineType(event.getNewStatus(), event.getMessage());
+        String finalMessage = event.getRejectedReason() != null 
+                ? String.format("%s (사유: %s)", event.getMessage(), event.getRejectedReason())
+                : event.getMessage();
+
+        try {
+            createNotificationUseCase.create(CreateNotificationCommand.builder()
+                    .userId(event.getUserId())
+                    .type(type)
+                    .title(event.getMessage())
+                    .message(finalMessage)
+                    .referenceType(ReferenceType.CONTRACT)
+                    .referenceId(event.getContractId())
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to notify user {} about contract status change {}: {}", 
+                    event.getUserId(), event.getContractId(), e.getMessage());
+        }
+    }
+
+    private NotificationType determineType(ContractStatus status, String message) {
+        if (status == ContractStatus.APPROVED) return NotificationType.CONTRACT_APPROVED;
+        if (status == ContractStatus.REJECTED) return NotificationType.CONTRACT_REJECTED;
+        if (status == ContractStatus.ACTIVE) {
+            if (message.contains("수정")) return NotificationType.CONTRACT_UPDATED;
+            return NotificationType.CONTRACT_ACTIVATED;
+        }
+        return NotificationType.CONTRACT_EXPIRED;
+    }
+}

--- a/backend/src/main/java/com/coliving/user/contract/application/event/ContractSubmittedEvent.java
+++ b/backend/src/main/java/com/coliving/user/contract/application/event/ContractSubmittedEvent.java
@@ -1,0 +1,11 @@
+package com.coliving.user.contract.application.event;
+
+import com.coliving.user.contract.model.Contract;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ContractSubmittedEvent {
+    private final Contract contract;
+}

--- a/backend/src/main/java/com/coliving/user/contract/application/service/ContractService.java
+++ b/backend/src/main/java/com/coliving/user/contract/application/service/ContractService.java
@@ -43,7 +43,7 @@ public class ContractService implements ContractUseCase {
     private final AdminUserRepositoryPort adminUserRepositoryPort;
     private final AdminSpaceRepositoryPort adminSpaceRepositoryPort;
     private final JwtTokenProvider jwtTokenProvider;
-    private final NotificationRepositoryPort notificationRepositoryPort;
+    private final org.springframework.context.ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -164,37 +164,13 @@ public class ContractService implements ContractUseCase {
 
         Contract saved = contractRepositoryPort.save(contract);
 
-        // 관리자 전원에게 신규 입주 신청 알림
-        notifyAllAdminsOfContractSubmission(saved);
+        // 이벤트 발행 (관리자 알림 팬아웃 등은 수신 측에서 처리)
+        eventPublisher.publishEvent(new com.coliving.user.contract.application.event.ContractSubmittedEvent(saved));
 
         return ContractResult.success(saved.getContractId(), "계약 신청이 완료되었습니다.");
     }
 
-    private void notifyAllAdminsOfContractSubmission(Contract contract) {
-        try {
-            Page<AdminUserResult> adminPage = adminUserRepositoryPort.findUsers(
-                    UserRole.ADMIN, UserStatus.ACTIVE.name(), null, null, Pageable.unpaged());
-            if (adminPage == null || adminPage.getContent() == null) {
-                return;
-            }
-            for (AdminUserResult admin : adminPage.getContent()) {
-                try {
-                    notificationRepositoryPort.create(
-                            admin.getId(),
-                            NotificationType.CONTRACT_SUBMITTED,
-                            "새로운 입주 신청이 접수되었습니다",
-                            String.format("호실 ID [%d]에 대한 입주 신청이 접수되었습니다. 확인해 주세요.",
-                                    contract.getSpaceId()),
-                            ReferenceType.CONTRACT,
-                            contract.getContractId());
-                } catch (Exception e) {
-                    log.warn("관리자 계약 신청 알림 실패 adminId={}: {}", admin.getId(), e.getMessage());
-                }
-            }
-        } catch (Exception e) {
-            log.error("계약 신청 관리자 알림 팬아웃 실패 contractId={}: {}", contract.getContractId(), e.getMessage());
-        }
-    }
+    // 도메인 이벤트 위임으로 인해 직접적인 팬아웃 로직 삭제
 
     @Override
     public ContractSignResult signContract(Long userId, ContractSignCommand command) {
@@ -244,14 +220,15 @@ public class ContractService implements ContractUseCase {
                 userId, UserRole.RESIDENT.name(), contract.getContractId(), contract.getSpaceId());
         String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-        // 8. 알림 생성
-        notificationRepositoryPort.create(
-                userId,
-                NotificationType.CONTRACT_ACTIVATED,
-                "계약이 체결되었습니다.",
-                "입주를 축하합니다! 호실 정보와 IoT 기기를 확인해 보세요.",
-                ReferenceType.CONTRACT,
-                contract.getContractId());
+        // 8. 알림 이벤트 발행
+        eventPublisher.publishEvent(com.coliving.admin.contract.application.event.ContractStatusChangedByAdminEvent.builder()
+                .contractId(contract.getContractId())
+                .userId(userId)
+                .spaceId(contract.getSpaceId())
+                .spaceName(space.getName())
+                .newStatus(ContractStatus.ACTIVE)
+                .message("계약이 성공적으로 체결되었습니다.")
+                .build());
 
         return ContractSignResult.builder()
                 .contractId(contract.getContractId())


### PR DESCRIPTION
## 📌 개요

도메인 간의 물리적 결합도를 낮추고, 대량 알림 발송 시 발생할 수 있는 병목 현상을 해결하기 위해 **이벤트 기반 비동기 알림 아키텍처**를 도입했습니다.

---

## ✨ 주요 변경 사항

### 1. 비동기 인프라 구축
- `CoLivingApplication`: `@EnableAsync` 활성화
- `AsyncConfig`: 알림 전용 스레드 풀(`notificationExecutor`) 도입
  - Core: 5, Max: 10, Queue: 100
  - 알림 발송 지연이 메인 비즈니스 로직(계약, 커뮤니티 등)에 영향을 주지 않도록 격리

### 2. 도메인 이벤트 모델링 (Pub/Sub)
기존에 `NotificationService`를 직접 의존하던 방식에서, 이벤트를 발행하고 리스너가 구독하는 방식으로 전환하여 의존성을 제거했습니다.

**신규 정의 이벤트:**
- `ContractSubmittedEvent`: 사용자 입주 신청 시 발행
- `ContractStatusChangedByAdminEvent`: 관리자의 승인/반려/수정/만료 시 발행
- `NoticePublishedEvent`: 새로운 공지사항 등록 시 발행

### 3. 고성능 비동기 리스너 구현 (`@Async` + `@TransactionalEventListener`)
모든 알림 발송은 메인 트랜잭션이 성공적으로 커밋된 후(`AFTER_COMMIT`), 별도의 백그라운드 스레드에서 처리됩니다.

- **`ContractNotificationListener`**: 
  - 신규 신청 시 관리자 팬아웃 알림
  - 상태 변경 시 사용자 알림
- **`CommunityNotificationListener`**: 
  - 공지사항 등록 시 전체 사용자 대상 팬아웃 (비동기 처리로 응답 속도 대폭 개선)
- **기존 리스너 개선**: 
  - `CommentPostedNotificationListener`, `VocAdminNotifyEventListener`, `NotificationCreatedEventListener`에 `@Async` 적용하여 알림 흐름 최적화

---

## 🛠️ 리팩토링 상세 (의존성 제거)

| 도메인 서비스 | 변경 내용 |
| :--- | :--- |
| `ContractService` | `NotificationRepositoryPort` 제거 -> `eventPublisher` 적용 |
| `AdminContractService` | `NotificationRepositoryPort` 제거 -> `eventPublisher` 적용 |
| `CommunityService` | 대량 팬아웃 로직(루프) 삭제 -> `NoticePublishedEvent` 발행으로 위임 |

---

## ✅ DoD 점검 결과

1. **에러 격리**: 알림 발송 실패 시에도 계약 체결이나 게시글 등록은 안전하게 보존되는가?  
   - **Yes.** `AFTER_COMMIT` 페이즈와 리스너 내 `try-catch`로 완벽 격리함.
2. **서버 퍼포먼스**: 발행 구독 체계가 서버에 부담을 주지 않는가?  
   - **Yes.** `@Async` 전용 스레드 풀을 통해 메인 요청 스레드와 분리하여 처리 성능을 극대화함.

---

## 📁 변경 파일 현황

- **Config**: `AsyncConfig.java`, `CoLivingApplication.java`
- **Events**: `ContractSubmittedEvent.java`, `ContractStatusChangedByAdminEvent.java`, `NoticePublishedEvent.java`
- **Listeners**: `ContractNotificationListener.java`, `CommunityNotificationListener.java` 등 5개 파일
- **Services**: `ContractService.java`, `AdminContractService.java`, `CommunityService.java`
