### PR TITLE
🐛 [USR] 로그인, 회원가입 페이지 디자인 다듬기

### DIFF
--- a/frontend/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/frontend/src/app/(auth)/login/_components/LoginForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { apiFetch, ApiError } from '@/lib/api';
 import { useAuthStore } from '@/store/useAuthStore';
+import { motion, AnimatePresence } from 'framer-motion';
 
 export default function LoginForm() {
   const router = useRouter();
@@ -12,6 +13,11 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const login = useAuthStore((state) => state.login);
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 30 },
+    visible: { opacity: 1, y: 0, transition: { duration: 0.8, ease: "easeOut" as const } }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -46,7 +52,7 @@ export default function LoginForm() {
         // which fulfills the prompt's requirement of not giving specific reasons.
         setError(err.message);
       } else {
-        setError('로그인 중 문제가 발생했습니다.');
+        setError('An error occurred during login.');
       }
     } finally {
       setIsLoading(false);
@@ -54,44 +60,56 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-6">
-      {error && (
-        <div className="bg-destructive/10 text-destructive text-sm font-medium p-4 rounded-xl border border-destructive/20">
-          {error}
-        </div>
-      )}
+    <form 
+      onSubmit={handleSubmit} 
+      className="mt-8 flex flex-col gap-6"
+    >
+      <AnimatePresence>
+        {error && (
+          <motion.div 
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            className="bg-destructive/10 text-destructive text-sm font-medium p-4 rounded-xl border border-destructive/20"
+          >
+            {error}
+          </motion.div>
+        )}
+      </AnimatePresence>
       
-      <div className="flex flex-col gap-2">
-        <label className="text-[10px] font-black uppercase tracking-[0.3em] text-muted">ID</label>
+      <motion.div variants={itemVariants} className="flex flex-col gap-2">
+        <label className="text-[10px] font-black uppercase tracking-[0.3em] text-primary/80">ID</label>
         <input
           type="text"
           value={loginId}
           onChange={(e) => setLoginId(e.target.value)}
           required
-          placeholder="아이디를 입력하세요"
-          className="h-12 w-full rounded-xl border border-secondary bg-transparent px-4 py-2 placeholder:text-muted focus:border-primary focus:outline-none"
+          placeholder="Enter your login ID"
+          className="h-12 w-full rounded-xl border border-secondary bg-transparent px-4 py-2 text-primary placeholder:text-primary/50 focus:border-primary focus:outline-none"
         />
-      </div>
+      </motion.div>
       
-      <div className="flex flex-col gap-2">
-        <label className="text-[10px] font-black uppercase tracking-[0.3em] text-muted">PASSWORD</label>
+      <motion.div variants={itemVariants} className="flex flex-col gap-2">
+        <label className="text-[10px] font-black uppercase tracking-[0.3em] text-primary/80">PASSWORD</label>
         <input
           type="password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          placeholder="비밀번호를 입력하세요"
-          className="h-12 w-full rounded-xl border border-secondary bg-transparent px-4 py-2 placeholder:text-muted focus:border-primary focus:outline-none"
+          placeholder="Enter your password"
+          className="h-12 w-full rounded-xl border border-secondary bg-transparent px-4 py-2 text-primary placeholder:text-primary/50 focus:border-primary focus:outline-none"
         />
-      </div>
+      </motion.div>
 
-      <button
-        type="submit"
-        disabled={isLoading}
-        className="mt-6 flex h-14 w-full items-center justify-center rounded-xl bg-primary text-background font-black uppercase tracking-tighter hover:scale-[1.02] transition-transform disabled:opacity-50"
-      >
-        {isLoading ? '로딩 중...' : '로그인'}
-      </button>
+      <motion.div variants={itemVariants} className="mt-6">
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="flex h-14 w-full items-center justify-center rounded-xl bg-primary text-background font-black uppercase tracking-[0.2em] hover:scale-[1.02] transition-transform disabled:opacity-50"
+        >
+          {isLoading ? 'Loading...' : 'Log In'}
+        </button>
+      </motion.div>
     </form>
   );
 }

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,29 +1,52 @@
+"use client";
+
 import Link from 'next/link';
 import LoginForm from './_components/LoginForm';
+import { motion } from 'framer-motion';
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, delayChildren: 0.1 }
+  }
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.8, ease: "easeOut" as const } }
+};
 
 export default function LoginPage() {
   return (
     <div className="py-24 md:py-32 px-6 md:px-12 lg:px-24 max-w-[1400px] mx-auto min-h-screen flex flex-col justify-center">
-      <div className="max-w-md w-full mx-auto">
-        <h1 className="text-[12vw] md:text-[8vw] lg:text-5xl font-black tracking-tighter uppercase leading-[0.85] text-primary">
-          <span className="underline underline-offset-[1vw] decoration-accent">로그인</span>
-        </h1>
-        <p className="mt-6 text-muted font-medium tracking-tight text-balance">
-          COKKIRI에 다시 오신 것을 환영합니다.
-        </p>
+      <motion.div 
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+        className="max-w-md w-full mx-auto"
+      >
+        <motion.div variants={itemVariants}>
+          <h1 className="text-4xl md:text-5xl font-black tracking-tighter uppercase text-primary mb-4">
+            Log In<span className="text-accent">.</span>
+          </h1>
+          <p className="text-base text-primary/80 font-medium tracking-tight">
+            Welcome back to COKKIRI.
+          </p>
+        </motion.div>
         
         <LoginForm />
         
-        <div className="mt-12 pt-6 border-t border-secondary/30 text-center">
-          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-muted mb-4">아직 계정이 없으신가요?</p>
+        <motion.div variants={itemVariants} className="mt-12 pt-6 border-t border-secondary/30 text-center">
+          <p className="text-[10px] font-black uppercase tracking-[0.3em] text-primary/80 mb-4">Not a member yet?</p>
           <Link 
             href="/register" 
-            className="inline-flex h-12 w-full items-center justify-center rounded-xl border border-primary text-primary font-black tracking-tighter hover:bg-primary/5 transition-colors"
+            className="inline-flex h-12 w-full items-center justify-center rounded-xl border border-primary text-primary font-black tracking-[0.1em] uppercase hover:bg-primary/5 transition-colors"
           >
-            회원가입
+            Create Account
           </Link>
-        </div>
-      </div>
+        </motion.div>
+      </motion.div>
     </div>
   );
 }

--- a/frontend/src/app/(auth)/register/_components/register-form.tsx
+++ b/frontend/src/app/(auth)/register/_components/register-form.tsx
@@ -169,16 +169,8 @@ export default function RegisterForm() {
   };
 
   const getInputClasses = (hasError: boolean) => 
-    `w-full border-b bg-transparent px-0 py-3 text-lg font-medium text-primary outline-none transition-colors placeholder:text-primary/30 ${hasError ? 'border-red-500 focus:border-red-500' : 'border-primary/20 focus:border-accent'}`;
-  const labelClasses = "block text-[10px] font-black uppercase tracking-[0.3em] text-primary/60 mb-1";
-
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: { staggerChildren: 0.1, delayChildren: 0.2 }
-    }
-  };
+    `w-full border-b bg-transparent px-0 py-3 text-lg font-medium text-primary outline-none transition-colors placeholder:text-primary/50 ${hasError ? 'border-red-500 focus:border-red-500' : 'border-primary/20 focus:border-accent'}`;
+  const labelClasses = "block text-[10px] font-black uppercase tracking-[0.3em] text-primary/80 mb-1";
 
   const itemVariants = {
     hidden: { opacity: 0, y: 30 },
@@ -203,10 +195,7 @@ export default function RegisterForm() {
   }
 
   return (
-    <motion.form 
-      variants={containerVariants}
-      initial="hidden"
-      animate="visible"
+    <form 
       onSubmit={handleSubmit} 
       className="flex flex-col gap-10"
       noValidate
@@ -247,7 +236,7 @@ export default function RegisterForm() {
             {fieldErrors.password ? (
               <p className="absolute top-full left-0 mt-1.5 text-red-500 text-xs font-medium leading-tight">{fieldErrors.password}</p>
             ) : (
-              <p className="absolute top-full left-0 mt-1.5 text-primary/40 text-[11px] font-medium tracking-tight">8자 이상, 영문+숫자+특수문자 조합</p>
+              <p className="absolute top-full left-0 mt-1.5 text-primary/60 text-[11px] font-medium tracking-tight">8자 이상, 영문+숫자+특수문자 조합</p>
             )}
           </div>
           <div className="relative">
@@ -291,7 +280,7 @@ export default function RegisterForm() {
                className={`${getInputClasses(false)} cursor-pointer flex justify-between items-center`}
              >
                <span>{formData.gender === 'MALE' ? 'MALE (남성)' : 'FEMALE (여성)'}</span>
-               <motion.span animate={{ rotate: isGenderOpen ? 180 : 0 }} className="text-[10px] text-primary/40">▼</motion.span>
+               <motion.span animate={{ rotate: isGenderOpen ? 180 : 0 }} className="text-[10px] text-primary/50">▼</motion.span>
              </div>
              
              <AnimatePresence>
@@ -309,7 +298,7 @@ export default function RegisterForm() {
                    >
                      {formData.gender === 'MALE' && <motion.div layoutId="gender-active" className="absolute left-0 top-0 bottom-0 w-1 bg-accent" />}
                      <span className="font-black tracking-tight text-primary group-hover:tracking-widest transition-all duration-300">MALE</span>
-                     <span className="text-[10px] text-primary/50 font-bold uppercase tracking-[0.2em]">남성</span>
+                     <span className="text-[10px] text-primary/60 font-bold uppercase tracking-[0.2em]">남성</span>
                    </div>
                    <div 
                      onClick={() => { setFormData(p => ({...p, gender: 'FEMALE'})); setIsGenderOpen(false); }}
@@ -317,7 +306,7 @@ export default function RegisterForm() {
                    >
                      {formData.gender === 'FEMALE' && <motion.div layoutId="gender-active" className="absolute left-0 top-0 bottom-0 w-1 bg-accent" />}
                      <span className="font-black tracking-tight text-primary group-hover:tracking-widest transition-all duration-300">FEMALE</span>
-                     <span className="text-[10px] text-primary/50 font-bold uppercase tracking-[0.2em]">여성</span>
+                     <span className="text-[10px] text-primary/60 font-bold uppercase tracking-[0.2em]">여성</span>
                    </div>
                  </motion.div>
                )}
@@ -333,7 +322,7 @@ export default function RegisterForm() {
               }}
               className={`${getInputClasses(!!fieldErrors.birthDate)} cursor-pointer flex items-center justify-between`}
             >
-               <span className={formData.birthDate ? 'text-primary' : 'text-primary/30'}>
+               <span className={formData.birthDate ? 'text-primary' : 'text-primary/50'}>
                  {formData.birthDate ? formData.birthDate : 'YYYY-MM-DD'}
                </span>
             </div>
@@ -408,6 +397,6 @@ export default function RegisterForm() {
           {loading ? 'Creating Account...' : 'Complete Registration'}
         </Button>
       </motion.div>
-    </motion.form>
+    </form>
   );
 }

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -1,22 +1,43 @@
+"use client";
+
 import Link from 'next/link';
 import RegisterForm from './_components/register-form';
+import { motion } from 'framer-motion';
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, delayChildren: 0.1 }
+  }
+};
+
+const itemVariants = {
+  hidden: { opacity: 0, y: 30 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.8, ease: "easeOut" as const } }
+};
 
 export default function RegisterPage() {
   return (
-    <div className="w-full">
-      <div className="mb-14">
+    <motion.div 
+      variants={containerVariants}
+      initial="hidden"
+      animate="visible"
+      className="w-full"
+    >
+      <motion.div variants={itemVariants} className="mb-14">
         <h2 className="text-4xl md:text-5xl font-black tracking-tighter uppercase text-primary mb-4">
           Create Account<span className="text-accent">.</span>
         </h2>
-        <p className="text-base text-primary/70 font-medium tracking-tight">
+        <p className="text-base text-primary/80 font-medium tracking-tight">
           Already a member?{' '}
           <Link href="/login" className="text-primary font-bold underline decoration-accent underline-offset-4 hover:text-accent transition-colors">
             Log in here
           </Link>
         </p>
-      </div>
+      </motion.div>
 
       <RegisterForm />
-    </div>
+    </motion.div>
   );
 }


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 로그인 및 회원가입 페이지의 시각적 일관성(에디토리얼 무드)을 확보하고 폼 가독성을 높이기 위해 텍스트 색상 대비와 타이포그래피를 전면 개선했습니다.
- 로그인/회원가입 페이지 진입 시 적용된 애니메이션(초기 로드 페이드 인)이 제대로 연계되지 않거나, 일부 버튼이 갑자기 튀어나와 부자연스럽게 보이던 문제(Stagger 충돌 및 일관성 누락)를 해결하여 사용자 경험(UX)을 크게 향상시켰습니다.

## 🔑 주요 변경 사항 (What)
- **UI 가독성 및 명암비 상향:** 
  - `text-muted`를 `text-primary/80`으로, 입력창 힌트(placeholder) 텍스트를 `text-primary/50`으로 조절하여 명시성을 높였습니다.
- **영문 타이포그래피 일치 (에디토리얼 컨셉):** 
  - 로그인 페이지의 한글 텍스트를 회원가입 페이지에 맞춰 모두 영문(`Log In.`, `Welcome back to COKKIRI.`, `Not a member yet?`, `Create Account` 등)으로 변환했습니다.
- **페이드 인(Stagger) 애니메이션 전체 흐름 제어(Orchestration):**
  - 두 Auth 페이지 모두 최상단([page.tsx](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28auth%29/login/page.tsx:0:0-0:0))에서 `containerVariants`를 선언해 제어권을 넘겨, 제목 텍스트부터 맨 아래 링크 버튼까지 한 번의 부드러운 릴레이(Stagger) 애니메이션으로 나타나도록 일원화했습니다.
- **애니메이션과 CSS 트랜지션 충돌 해결:**
  - 로그인 폼 제출 버튼에 걸린 `Framer Motion`의 Transform 속성과 `Tailwind` 고유의 `hover:scale` 속성이 겹쳐 렌더링이 튀는 현상을 막기 위해 `<motion.div>` 래퍼 계층을 분리 적용했습니다.
- **타입스크립트 오류 픽스:**
  - `ease: "easeOut"` 등 Framer Motion Variants에 필요한 `as const` 리터럴 단언을 추가하여 타입 오류를 정상적으로 픽스했습니다.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #274

## 💻 테스트 방법 (How to Test)
1. 프론트엔드 최상위 경로에서 `npm run dev` 실행 후 `http://localhost:3000/login` 경로로 진입합니다.
2. 페이지 접속 순간 타이틀부터 하단의 `Create Account` 링크까지 도미노처럼 부드럽게 위로 올라오는지(Stagger 애니메이션) 확인합니다.
3. `/register` 페이지로 전환하여 동일하게 깔끔한 화면 진입 효과가 끊김 없이 화면 전체에 적용되었는지 확인합니다.
4. 텍스트 라벨과 플레이스홀더 텍스트 색상이 이전에 비해 뚜렷하고 명확하게 잘 보이는지 검토합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- (리뷰어가 참고할 수 있도록 페이지가 차례대로 나타나는 GIF 영상 또는 텍스트 변경 전/후 스크린샷을 첨부해 주세요.)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- Framer Motion 애니메이션이 개별 컴포넌트(UI)에서 각각 따로 돌지 않도록, `Variants`를 가장 최상단 부모([page.tsx](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/frontend/src/app/%28auth%29/login/page.tsx:0:0-0:0))에서 일괄로 매니징하게 구성했습니다. 앞으로 다른 컴포넌트를 이 뷰 안에 추가할 때는 단순히 `variants={itemVariants}`만 넘겨주면 자연스럽게 흐름에 합류합니다!
- 프레임워크 애니메이션 툴을 쓸 때 Tailwind의 `hover:transform`과 충돌(Overriding)을 방지하기 위한 구조 래퍼(`motion.div` > `button`)를 적용했으니 유사 작업 시 참고해주세요 팀원들! 😊

Closes #274
