### PR TITLE
[CS/fix] 알림 시스템 안정성 강화 및 서비스 권한(입주민 전용) 제한 적용

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -79,10 +79,10 @@ public class SecurityConfig {
                                 "/api/reservations/**", "/api/control-logs/**")
                         .hasAnyRole("RESIDENT", "ADMIN")
 
-                        // --- VOC: 입주자·관리자·일반회원 (본인 민원만 서비스 레이어에서 추가 제한) ---
-                        .requestMatchers("/api/vocs/**").hasAnyRole(MEMBER_ROLES)
+                        // --- VOC: 입주자·관리자 전용 ---
+                        .requestMatchers("/api/vocs/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
                         // VOC 본문 이미지·첨부 파일
-                        .requestMatchers(HttpMethod.GET, "/api/files/voc/**").hasAnyRole(MEMBER_ROLES)
+                        .requestMatchers(HttpMethod.GET, "/api/files/voc/**").hasAnyRole(RESIDENT_ADMIN_ROLES)
 
                         // --- 알림: 로그인 회원 전체 (USER 포함) ---
                         .requestMatchers("/api/notifications/**").hasAnyRole(MEMBER_ROLES)

--- a/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
+++ b/frontend/src/app/(common)/comment/_components/CommentThreadSection.tsx
@@ -152,39 +152,46 @@ export function CommentThreadSection({
                     답글
                   </button>
                   {openReply ? (
-                    <form
-                      onSubmit={(e) => {
-                        e.preventDefault();
-                        addComment(node.commentId, replyDraft);
-                      }}
-                      className="rounded-2xl border border-primary/10 bg-background p-4 shadow-sm"
-                    >
-                      <textarea
-                        value={replyDraft}
-                        onChange={(e) => setReplyDraftById((prev) => ({ ...prev, [node.commentId]: e.target.value }))}
-                        rows={2}
-                        placeholder="답글을 입력하세요"
-                        className="w-full resize-y rounded-xl border border-input bg-surface px-3 py-2 text-sm font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                      />
-                      <div className="mt-2 flex justify-end gap-2">
-                        <button
-                          type="button"
-                          onClick={() => setOpenReplyForId(null)}
-                          className="rounded-full border border-border px-4 py-1.5 text-[11px] font-black uppercase tracking-[0.24em] text-foreground"
-                        >
-                          취소
-                        </button>
-                        <motion.button
-                          type="submit"
-                          disabled={pending || !replyDraft.trim()}
-                          whileHover={{ scale: 1.02 }}
-                          whileTap={{ scale: 0.98 }}
-                          className="rounded-full bg-primary px-4 py-1.5 text-[11px] font-black uppercase tracking-[0.24em] text-primary-foreground disabled:opacity-50"
-                        >
-                          등록
-                        </motion.button>
+                    currentUser?.role === "USER" ? (
+                      <div className="rounded-2xl border border-dashed border-primary/20 bg-primary/5 p-6 text-center">
+                        <p className="font-bold text-[11px] text-primary tracking-tight">입주민 전용 기능입니다</p>
+                        <p className="mt-1 text-[9px] font-medium text-muted-foreground opacity-60">답글 작성 권한이 없습니다.</p>
                       </div>
-                    </form>
+                    ) : (
+                      <form
+                        onSubmit={(e) => {
+                          e.preventDefault();
+                          addComment(node.commentId, replyDraft);
+                        }}
+                        className="rounded-2xl border border-primary/10 bg-background p-4 shadow-sm"
+                      >
+                        <textarea
+                          value={replyDraft}
+                          onChange={(e) => setReplyDraftById((prev) => ({ ...prev, [node.commentId]: e.target.value }))}
+                          rows={2}
+                          placeholder="답글을 입력하세요"
+                          className="w-full resize-y rounded-xl border border-input bg-surface px-3 py-2 text-sm font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        />
+                        <div className="mt-2 flex justify-end gap-2">
+                          <button
+                            type="button"
+                            onClick={() => setOpenReplyForId(null)}
+                            className="rounded-full border border-border px-4 py-1.5 text-[11px] font-black uppercase tracking-[0.24em] text-foreground"
+                          >
+                            취소
+                          </button>
+                          <motion.button
+                            type="submit"
+                            disabled={pending || !replyDraft.trim()}
+                            whileHover={{ scale: 1.02 }}
+                            whileTap={{ scale: 0.98 }}
+                            className="rounded-full bg-primary px-4 py-1.5 text-[11px] font-black uppercase tracking-[0.24em] text-primary-foreground disabled:opacity-50"
+                          >
+                            등록
+                          </motion.button>
+                        </div>
+                      </form>
+                    )
                   ) : null}
                 </div>
               }
@@ -224,36 +231,46 @@ export function CommentThreadSection({
         </p>
       ) : null}
 
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          addComment(null, rootDraft);
-        }}
-        className="mt-8 rounded-[2rem] border border-primary/10 bg-background p-6 shadow-2xl shadow-primary/5 md:p-8"
-      >
-        <label htmlFor={`comment-root-${postId}`} className="sr-only">
-          댓글 작성
-        </label>
-        <textarea
-          id={`comment-root-${postId}`}
-          value={rootDraft}
-          onChange={(e) => setRootDraft(e.target.value)}
-          rows={3}
-          placeholder="댓글을 입력하세요"
-          className="w-full resize-y rounded-xl border border-input bg-surface px-4 py-3 font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-        />
-        <div className="mt-4 flex justify-end">
-          <motion.button
-            type="submit"
-            disabled={pending || !rootDraft.trim()}
-            whileHover={{ scale: 1.02 }}
-            whileTap={{ scale: 0.98 }}
-            className="rounded-full bg-primary px-5 py-2.5 text-xs font-black uppercase tracking-[0.24em] text-primary-foreground disabled:opacity-50"
-          >
-            등록
-          </motion.button>
+      {currentUser?.role === "USER" ? (
+        <div className="mt-8 rounded-[2rem] border border-dashed border-primary/20 bg-primary/5 p-12 text-center">
+          <p className="font-black text-xs uppercase tracking-[0.4em] text-destructive mb-3">Resident Only</p>
+          <p className="font-bold text-primary tracking-tight">입주민 전용 기능입니다</p>
+          <p className="mt-2 text-[10px] font-medium text-muted-foreground opacity-60">
+            댓글 작성을 위해선 실제 입주가 확인된 거주민 권한이 필요합니다.
+          </p>
         </div>
-      </form>
+      ) : (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            addComment(null, rootDraft);
+          }}
+          className="mt-8 rounded-[2rem] border border-primary/10 bg-background p-6 shadow-2xl shadow-primary/5 md:p-8"
+        >
+          <label htmlFor={`comment-root-${postId}`} className="sr-only">
+            댓글 작성
+          </label>
+          <textarea
+            id={`comment-root-${postId}`}
+            value={rootDraft}
+            onChange={(e) => setRootDraft(e.target.value)}
+            rows={3}
+            placeholder="댓글을 입력하세요"
+            className="w-full resize-y rounded-xl border border-input bg-surface px-4 py-3 font-medium tracking-tight text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+          <div className="mt-4 flex justify-end">
+            <motion.button
+              type="submit"
+              disabled={pending || !rootDraft.trim()}
+              whileHover={{ scale: 1.02 }}
+              whileTap={{ scale: 0.98 }}
+              className="rounded-full bg-primary px-5 py-2.5 text-xs font-black uppercase tracking-[0.24em] text-primary-foreground disabled:opacity-50"
+            >
+              등록
+            </motion.button>
+          </div>
+        </form>
+      )}
     </section>
   );
 }

--- a/frontend/src/app/(common)/profile/vocs/page.tsx
+++ b/frontend/src/app/(common)/profile/vocs/page.tsx
@@ -10,6 +10,7 @@ import { VocCard } from "@/app/(common)/vocs/_components/VocCard";
 import { PaginationBar } from "@/app/(common)/community/_components/PaginationBar";
 import { NewVocForm } from "@/app/(common)/vocs/new/_components/NewVocForm";
 import { MyVocTabLinks } from "./_components/MyVocTabLinks";
+import { VocAccessDeniedState } from "./_components/VocAccessDeniedState";
 
 type SearchParams = Promise<{ tab?: string; p?: string; s?: string }>;
 
@@ -31,23 +32,33 @@ export default async function ProfileVocsPage({ searchParams }: { searchParams: 
   let list: VocListData | null = null;
   let listError: string | null = null;
   let authError: string | null = null;
+  let isNotResident = false;
 
-  const res = await bffGet(`vocs/my?${qs.toString()}`);
-  if (res.status === 401) {
+  // 1. 현재 사용자 정보 로드 (Role 체크)
+  const meRes = await bffGet("users/me");
+  if (meRes.status === 401) {
     authError = LOGIN_REQUIRED_MESSAGE;
-  } else if (res.status === 403) {
-    const meRes = await bffGet("users/me");
-    if (meRes.status === 401 || meRes.status === 403) {
-      authError = LOGIN_REQUIRED_MESSAGE;
-    } else if (showList) {
-      listError = "목록을 불러오지 못했습니다.";
+  } else if (meRes.ok) {
+    const meBody = await meRes.json();
+    if (meBody.success && meBody.data?.role === "USER") {
+      isNotResident = true;
     }
-  } else if (showList && !res.ok) {
-    listError = "목록을 불러오지 못했습니다.";
-  } else if (showList) {
-    const body = (await res.json()) as ApiResponse<VocListData>;
-    if (body.success && body.data) list = body.data;
-    else listError = body.message ?? "목록을 불러오지 못했습니다.";
+  }
+
+  // 2. 민원 목록 로드 (Resident인 경우만)
+  if (!isNotResident && !authError) {
+    const res = await bffGet(`vocs/my?${qs.toString()}`);
+    if (res.status === 401) {
+      authError = LOGIN_REQUIRED_MESSAGE;
+    } else if (res.status === 403) {
+      listError = "권한이 없습니다.";
+    } else if (showList && !res.ok) {
+      listError = "목록을 불러오지 못했습니다.";
+    } else if (showList) {
+      const body = (await res.json()) as ApiResponse<VocListData>;
+      if (body.success && body.data) list = body.data;
+      else listError = body.message ?? "목록을 불러오지 못했습니다.";
+    }
   }
 
   const listBaseQuery = "tab=list";
@@ -78,7 +89,9 @@ export default async function ProfileVocsPage({ searchParams }: { searchParams: 
 
       {authError === LOGIN_REQUIRED_MESSAGE ? <LoginRequiredGate /> : null}
 
-      {!showList ? (
+      {isNotResident ? (
+        <VocAccessDeniedState />
+      ) : !showList ? (
         <div className="mx-auto max-w-4xl space-y-12">
           <div className="bg-white p-12 rounded-[3rem] border border-primary/5 shadow-2xl shadow-primary/5">
              <div className="mb-12 space-y-2">


### PR DESCRIPTION
## 📌 개요
알림 스트림의 안정성을 높이고, 민원(VOC) 및 댓글 기능을 실제 입주민으로 제한하여 서비스의 보안과 데이터 정합성을 강화했습니다.

---

## ✨ 주요 변경 사항

### 1. 알림 시스템(SSE) 및 UI 안정성 개선
- **SSE 디버깅 강화**: `onopen`, `onerror` 로그를 추가하여 네트워크 연결 상태 추적을 용이하게 했습니다.
- **실시간 목록 동기화**: 새 알림 수신 시 전역 이벤트(`NOTIFICATIONS_UNREAD_INVALIDATE`)를 통해 **알림 센터 목록이 즉시 새로고침**되도록 연동했습니다.
- **메모리 누수 방지**: Admin Dashboard 및 커뮤니티 섹션에 `mounted` 플래그 보호 로직을 적용하여 컴포넌트 이탈 시 발생하던 예기치 않은 오류를 차단했습니다.

### 2. 서비스 권한 제한 (입주민 전용 강화)
- **백엔드 보안 정책 상향**: `SecurityConfig`에서 민원 API(`/api/vocs/**`) 접근 권한을 `USER`에서 `RESIDENT`, `ADMIN`으로 제한했습니다.
- **민원(VOC) 센터**: 일반 회원이 접근 시 `VocAccessDeniedState` 가이드 화면을 출력하고 API 호출을 원천 차단했습니다.
- **커뮤니티 댓글**: 입주 절차가 완료되지 않은 일반 사용자에게는 댓글/답글 양식 대신 **"입주민 전용 가이드"** 섹션을 노출하여 접근을 제어했습니다.

---

## 🛠️ 기술적 세부 사항
- **Frontend**: `useTransition`과 `router.refresh()`를 조합한 실시간 서버 컴포넌트 갱신 로직 적용.
- **Backend**: Spring Security의 `hasAnyRole`을 활용한 세밀한 API 권한 필터링.
- **UI/UX**: 입주민 권한이 필요한 기능에 대해 명확한 피드백(Guide UI)을 제공하여 사용자 혼선 방지.

---

## ✅ 테스트 결과
- [x] 일반 유저(USER) 로그인 시 민원 등록 및 댓글 작성 불가 확인
- [x] 입주민(RESIDENT) 로그인 시 정상 기능 작동 확인
- [x] SSE 연결 유실 시 자동 재접속 및 에러 로그 기록 확인
- [x] 컴포넌트 전환 시 메모리 누수 경고 미발생 확인
