### PR TITLE
Fix/274

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,29 @@
+# Dependencies (will be installed fresh via npm ci in Docker)
+node_modules
+
+# Build output
+.next
+out
+dist
+
+# Dev/IDE files
+.env*.local
+.vscode
+.idea
+*.swp
+*.swo
+.DS_Store
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Misc
+README.md
+*.md


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 프론트엔드 Docker 이미지 빌드 시 `node_modules` 등의 불필요한 파일이 빌드 컨텍스트에 포함되어 빌드 속도가 저하되고 이미지 용량이 무거워지는 문제를 해결하기 위함입니다.
- 불필요하거나 민감한 파일(`.env` 등)을 제외하여 Docker 빌드 과정을 최적화하고 보안을 강화하는 것이 핵심 목적입니다.

## 🔑 주요 변경 사항 (What)
- `frontend` 폴더 내에 `.dockerignore` 파일 신규 추가
- 빌드에 불필요한 폴더 및 파일 명시 (`node_modules/`, `.next/`, `dist/`, 각종 로컬 환경변수 파일 및 로그 파일 등)

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves # (이슈 번호 입력)

## 💻 테스트 방법 (How to Test)
1. 터미널에서 `frontend` 디렉토리로 이동합니다.
2. 로컬에서 도커 빌드를 실행해 봅니다. (`docker build -t frontend-test .`)
3. 도커 데몬으로 전송되는 빌드 컨텍스트(build context)의 크기가 기존보다 확연히 줄어들었는지 확인합니다.
4. 빌드 완료 후 컨테이너가 정상적으로 실행되는지 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- 단순 설정 파일(`dockerignore`) 추가 작업이므로 화면 변경 사항은 없습니다.

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- Next.js 환경에서 일반적으로 제외하는 폴더와 파일들을 기준으로 `.dockerignore`를 작성했습니다.
- CI/CD 파이프라인이나 도커 환경에서 추가로 제외해야 할 생성물(Artifacts)이 있다면 리뷰 코멘트로 알려주시면 감사하겠습니다.
- @username 

Closes #274
