### PR TITLE
[CMN/style] UI 통일, 네비게이션/로딩 개선 및 시드 데이터 기본 활성화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
         # 소스 코드가 바뀌면 컨테이너 내부로 파일만 즉시 동기화 (Hot Reloading 적용)
         - action: sync
           path: ./frontend/src
-          target: /app/src  # ⚠️ 프론트엔드 Dockerfile의 WORKDIR 경로에 맞춰 수정하세요 (보통 /app)
+          target: /app/src # ⚠️ 프론트엔드 Dockerfile의 WORKDIR 경로에 맞춰 수정하세요 (보통 /app)
         - action: sync
           path: ./frontend/public
           target: /app/public
@@ -49,7 +49,7 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - MOCK_IOT_URL=${MOCK_IOT_URL:-http://mock-iot:8000}
       - APP_UPLOAD_DIR=${APP_UPLOAD_DIR:-/var/lib/cokkiri/uploads}
-      - APP_DEMO_DATA_ENABLED=${APP_DEMO_DATA_ENABLED:-false}
+      - APP_DEMO_DATA_ENABLED=${APP_DEMO_DATA_ENABLED:-true}
     volumes:
       - uploads-data:/var/lib/cokkiri/uploads
     depends_on:
@@ -61,7 +61,7 @@ services:
         # Java 코드가 바뀌면 파일을 동기화하고 컨테이너를 빠르게 재시작
         - action: sync+restart
           path: ./backend/src
-          target: /app/src  # ⚠️ 백엔드 Dockerfile의 WORKDIR 경로에 맞춰 수정하세요 (예: /app, /workspace)
+          target: /app/src # ⚠️ 백엔드 Dockerfile의 WORKDIR 경로에 맞춰 수정하세요 (예: /app, /workspace)
         # 의존성이 변경되면 이미지를 다시 빌드
         - action: rebuild
           path: ./backend/build.gradle # Maven을 사용한다면 pom.xml로 변경하세요

--- a/frontend/src/components/shared/Header.tsx
+++ b/frontend/src/components/shared/Header.tsx
@@ -25,9 +25,9 @@ const navItems: NavItem[] = [
   {
     name: "Space",
     children: [
-      { name: "일상의 집", path: "/rooms" },
-      { name: "느낌의 여정", path: "/experience" },
-      { name: "쉼의 자리", path: "/facilities" },
+      { name: "룸 둘러보기", path: "/rooms" },
+      { name: "시설 둘러보기", path: "/experience" },
+      { name: "층별 안내", path: "/floor" },
     ],
   },
   { name: "Community", path: "/community" },
@@ -36,20 +36,20 @@ const navItems: NavItem[] = [
     children: [
       { name: "프로필", path: "/profile" },
       {
-        name: "나의 히스토리",
+        name: "히스토리",
         children: [
           { name: "계약 내역", path: "/my-contracts" },
           { name: "예약 내역", path: "/my-history/reservation" },
         ],
       },
       {
-        name: "나의 커뮤니티",
+        name: "커뮤니티",
         children: [
           { name: "나의 민원", path: "/vocs" },
           { name: "나의 게시글", path: "/my-posts" },
         ],
       },
-      { name: "나의 기기", path: "/my-devices" },
+      { name: "스마트홈 기기", path: "/my-devices" },
       { name: "알림", path: "/notifications" },
       { name: "로그아웃", path: "#" },
     ],


### PR DESCRIPTION
## 📌 개요
프론트엔드 전반의 UI 일관성 확보, 네비게이션/로딩 UX 개선 및 서버 재시작 시 시드 데이터 미적재 버그 수정

## ✅ 주요 변경 사항

### 🎨 디자인 시스템 통일
- 커뮤니티, 알림, VOC 페이지에 'Moss & Aloe' 디자인 시스템 일관 적용
- `SearchAndSort`, `CategoryFilter` 등 공통 필터 컴포넌트 개선
- `NotificationCategoryFilter`, `NotificationSearchAndSort` 신규 추가

### 🔀 네비게이션 개선
- Header 네비게이션 서브메뉴 구조 개편 (My 메뉴 하위 그룹화)
- Header Space 메뉴 라벨 변경 (룸 둘러보기, 시설 둘러보기, 층별 안내)
- Footer 브랜딩/연락처 정보 업데이트
- VOC 라우트 `/profile/vocs` → `/vocs` 통합 (리디렉트 제거)

### ⏳ 로딩 UX
- `BrandLoading` 공통 컴포넌트 생성
- 전체 라우트에 `loading.tsx` 추가/통일
- rooms/[id] 로딩 스켈레톤 간소화

### 📝 커뮤니티 기능 보강
- 게시글 수정 페이지 분리 (`[postId]/edit/`)
- `EditPostForm`, `NewPostForm` 리팩토링
- 입주민 전용 `my-posts` 페이지 신규 추가

### 🐛 버그 수정
- `profile/vocs/page.tsx` 머지 충돌 해결 — `MyVocTabLinks` 컴포넌트 복구 및 `VocAccessDeniedState` import 경로 수정
- **`APP_DEMO_DATA_ENABLED` 기본값 `false` → `true`로 변경** — 서버 재시작 시 시드 데이터가 적재되지 않던 문제 해결

## 📁 변경 파일
- 약 50개 파일 변경

## 🔗 관련 이슈
- #288
