### PR TITLE
[RSV] Facilities 페이지 헤더/카드 탭 스타일 정리

### DIFF
--- a/frontend/src/app/(resident-app)/facilities/_components/FacilitiesContent.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/FacilitiesContent.tsx
@@ -54,15 +54,15 @@ export default function FacilitiesContent() {
       <motion.header
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        className="space-y-2"
+        className="space-y-6"
       >
-        <p className="font-black text-xs uppercase tracking-[0.3em] text-muted-foreground">
+        <p className="text-xs md:text-sm font-black uppercase tracking-[0.3em] text-muted-foreground opacity-60">
           Facilities
         </p>
-        <h1 className="text-3xl font-black tracking-tighter text-primary md:text-4xl">
+        <h1 className="text-6xl md:text-8xl lg:text-[10rem] font-black tracking-tighter leading-[0.85] text-primary break-keep">
           공용시설 예약
         </h1>
-        <p className="text-sm font-medium tracking-tight text-muted-foreground text-balance">
+        <p className="text-sm md:text-2xl leading-tight font-medium tracking-tight text-muted-foreground opacity-70 text-balance">
           시설을 선택하고 원하는 시간대를 예약하세요.
         </p>
       </motion.header>

--- a/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/FacilityCard.tsx
@@ -14,21 +14,18 @@ import {
 } from "lucide-react";
 import type { Facility } from "../_types";
 
-const STATUS_MAP: Record<string, { label: string; dot: string; border: string }> = {
+const STATUS_MAP: Record<string, { label: string; dot: string }> = {
   AVAILABLE: {
     label: "이용 가능",
     dot: "bg-green-500",
-    border: "border-green-400/30 bg-green-50/50",
   },
   OCCUPIED: {
     label: "사용 중",
     dot: "bg-accent",
-    border: "border-accent/30 bg-accent/5",
   },
   MAINTENANCE: {
     label: "점검 중",
     dot: "bg-muted-foreground",
-    border: "border-border bg-muted/20 opacity-60",
   },
 };
 
@@ -69,7 +66,7 @@ export function FacilityCard({ facility, selected, onSelect, index }: FacilityCa
       className={`relative w-full rounded-[2rem] border p-5 text-left transition-all duration-200
         ${selected
           ? "border-primary/60 bg-primary text-primary-foreground shadow-lg shadow-primary/20"
-          : `${status.border} hover:shadow-md hover:border-primary/30`
+          : "bg-primary/5 border-foreground/10 hover:bg-primary/10 hover:shadow-md hover:border-foreground/20"
         }`}
     >
       {/* 상태 점 */}


### PR DESCRIPTION
- /facilities 페이지 헤더를 Experience 톤에 맞게 타이포/간격 조정
- 시설 카드(카테고리 탭) 미선택 상태 배경을 중립 톤으로 통일하고 연두색 테두리 제거