### PR TITLE
[SPC/feat] 사용자 방 둘러보기 검색/정렬 기능 및 방 유형 D&D 순서 변경 구현

### DIFF
--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminRoomTypeController.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminRoomTypeController.java
@@ -63,4 +63,11 @@ public class AdminRoomTypeController {
         adminRoomTypeUseCase.deleteRoomType(roomTypeId);
         return ApiResponse.ok(null);
     }
+
+    @Operation(summary = "방 유형 순서 변경")
+    @PutMapping("/order")
+    public ApiResponse<Void> updateRoomTypeOrder(@RequestBody java.util.List<Long> orderedIds) {
+        adminRoomTypeUseCase.updateRoomTypeOrder(orderedIds);
+        return ApiResponse.ok(null, "순서가 저장되었습니다.");
+    }
 }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/res/AdminRoomTypeResponseDto.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/in/web/dto/res/AdminRoomTypeResponseDto.java
@@ -12,6 +12,7 @@ public class AdminRoomTypeResponseDto {
     private String code;
     private String name;
     private Boolean isSystemDefault;
+    private Integer sortOrder;
 
     public static AdminRoomTypeResponseDto from(AdminRoomTypeResult result) {
         return AdminRoomTypeResponseDto.builder()
@@ -19,6 +20,7 @@ public class AdminRoomTypeResponseDto {
                 .code(result.getCode())
                 .name(result.getName())
                 .isSystemDefault(result.getIsSystemDefault())
+                .sortOrder(result.getSortOrder())
                 .build();
     }
 }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/RoomTypeEntity.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/RoomTypeEntity.java
@@ -36,6 +36,7 @@ public class RoomTypeEntity extends BaseEntity {
     @Column(name = "is_system_default", nullable = false)
     private Boolean isSystemDefault;
 
+    @org.hibernate.annotations.ColumnDefault("0")
     @Column(name = "sort_order", nullable = false)
     private Integer sortOrder = 0;
 

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/RoomTypeEntity.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/RoomTypeEntity.java
@@ -36,14 +36,22 @@ public class RoomTypeEntity extends BaseEntity {
     @Column(name = "is_system_default", nullable = false)
     private Boolean isSystemDefault;
 
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder = 0;
+
     @Builder
-    public RoomTypeEntity(String code, String name, Boolean isSystemDefault) {
+    public RoomTypeEntity(String code, String name, Boolean isSystemDefault, Integer sortOrder) {
         this.code = code;
         this.name = name;
         this.isSystemDefault = isSystemDefault;
+        this.sortOrder = sortOrder != null ? sortOrder : 0;
     }
 
     public void update(String name) {
         this.name = name;
+    }
+
+    public void updateSortOrder(Integer sortOrder) {
+        this.sortOrder = sortOrder;
     }
 }

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
@@ -48,6 +48,7 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
     @Query(value = "SELECT s FROM SpaceEntity s " +
                     "JOIN FETCH s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
+                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
                     "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
                     "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
                     "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
@@ -55,11 +56,13 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
             countQuery = "SELECT COUNT(s) FROM SpaceEntity s " +
                     "JOIN s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
+                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
                     "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
                     "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
                     "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
                     "AND (:floor IS NULL OR s.floor = :floor)")
     Page<SpaceEntity> findRoomsWithFilter(
+            @Param("keyword") String keyword,
             @Param("roomTypeId") Long roomTypeId,
             @Param("minRent") BigDecimal minRent,
             @Param("maxRent") BigDecimal maxRent,

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminRoomTypePersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/persistence/AdminRoomTypePersistenceAdapter.java
@@ -21,7 +21,7 @@ public class AdminRoomTypePersistenceAdapter implements AdminRoomTypeRepositoryP
 
     @Override
     public List<AdminRoomType> findAll() {
-        return roomTypeJpaRepository.findAll(org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.ASC, "name")).stream()
+        return roomTypeJpaRepository.findAll(org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.ASC, "sortOrder", "id")).stream()
                 .map(this::toModel)
                 .toList();
     }
@@ -47,6 +47,7 @@ public class AdminRoomTypePersistenceAdapter implements AdminRoomTypeRepositoryP
                     .code(roomType.getCode())
                     .name(roomType.getName())
                     .isSystemDefault(roomType.getIsSystemDefault())
+                    .sortOrder(roomType.getSortOrder())
                     .build();
         }
         return toModel(roomTypeJpaRepository.save(entity));
@@ -64,12 +65,24 @@ public class AdminRoomTypePersistenceAdapter implements AdminRoomTypeRepositoryP
         return privateSpaceDetailJpaRepository.existsByRoomType_Id(roomTypeId);
     }
 
+    @Override
+    public void updateSortOrders(List<AdminRoomType> roomTypes) {
+        for (AdminRoomType rt : roomTypes) {
+            RoomTypeEntity entity = roomTypeJpaRepository.findById(rt.getRoomTypeId()).orElse(null);
+            if (entity != null) {
+                entity.updateSortOrder(rt.getSortOrder());
+                roomTypeJpaRepository.save(entity);
+            }
+        }
+    }
+
     private AdminRoomType toModel(RoomTypeEntity entity) {
         return AdminRoomType.builder()
                 .roomTypeId(entity.getId())
                 .code(entity.getCode())
                 .name(entity.getName())
                 .isSystemDefault(entity.getIsSystemDefault())
+                .sortOrder(entity.getSortOrder())
                 .build();
     }
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminRoomTypeUseCase.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/in/AdminRoomTypeUseCase.java
@@ -11,4 +11,5 @@ public interface AdminRoomTypeUseCase {
     AdminRoomTypeResult createRoomType(CreateRoomTypeCommand command);
     AdminRoomTypeResult updateRoomType(UpdateRoomTypeCommand command);
     void deleteRoomType(Long roomTypeId);
+    void updateRoomTypeOrder(List<Long> orderedIds);
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminRoomTypeRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/port/out/AdminRoomTypeRepositoryPort.java
@@ -12,4 +12,5 @@ public interface AdminRoomTypeRepositoryPort {
     AdminRoomType save(AdminRoomType roomType);
     void delete(Long roomTypeId);
     boolean isUsedInSpaces(Long roomTypeId);
+    void updateSortOrders(List<AdminRoomType> roomTypes);
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/result/AdminRoomTypeResult.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/result/AdminRoomTypeResult.java
@@ -12,6 +12,7 @@ public class AdminRoomTypeResult {
     private String code;
     private String name;
     private Boolean isSystemDefault;
+    private Integer sortOrder;
 
     public static AdminRoomTypeResult from(AdminRoomType model) {
         return AdminRoomTypeResult.builder()
@@ -19,6 +20,7 @@ public class AdminRoomTypeResult {
                 .code(model.getCode())
                 .name(model.getName())
                 .isSystemDefault(model.getIsSystemDefault())
+                .sortOrder(model.getSortOrder())
                 .build();
     }
 }

--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminRoomTypeService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminRoomTypeService.java
@@ -77,4 +77,16 @@ public class AdminRoomTypeService implements AdminRoomTypeUseCase {
 
         adminRoomTypeRepositoryPort.delete(roomTypeId);
     }
+
+    @Override
+    public void updateRoomTypeOrder(List<Long> orderedIds) {
+        List<AdminRoomType> updates = new java.util.ArrayList<>();
+        for (int i = 0; i < orderedIds.size(); i++) {
+            updates.add(AdminRoomType.builder()
+                    .roomTypeId(orderedIds.get(i))
+                    .sortOrder(i)
+                    .build());
+        }
+        adminRoomTypeRepositoryPort.updateSortOrders(updates);
+    }
 }

--- a/backend/src/main/java/com/coliving/admin/space/model/AdminRoomType.java
+++ b/backend/src/main/java/com/coliving/admin/space/model/AdminRoomType.java
@@ -10,4 +10,5 @@ public class AdminRoomType {
     private String code;
     private String name;
     private Boolean isSystemDefault;
+    private Integer sortOrder;
 }

--- a/backend/src/main/java/com/coliving/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/DataInitializer.java
@@ -631,6 +631,7 @@ public class DataInitializer implements ApplicationRunner {
                                 .code(code)
                                 .name(name)
                                 .isSystemDefault(true)
+                                .sortOrder((int) roomTypeJpaRepository.count())
                                 .build()));
     }
 

--- a/backend/src/main/java/com/coliving/user/room/adapter/in/web/RoomController.java
+++ b/backend/src/main/java/com/coliving/user/room/adapter/in/web/RoomController.java
@@ -30,6 +30,7 @@ public class RoomController {
     @Operation(summary = "방 목록 조회 (필터 + 페이지네이션)")
     @GetMapping
     public ApiResponse<Page<RoomResponseDto>> getRooms(
+            @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long roomTypeId,
             @RequestParam(required = false) BigDecimal minRent,
             @RequestParam(required = false) BigDecimal maxRent,
@@ -37,6 +38,7 @@ public class RoomController {
             @PageableDefault(size = 12, sort = "name", direction = org.springframework.data.domain.Sort.Direction.ASC) Pageable pageable) {
 
         RoomListCommand command = RoomListCommand.builder()
+                .keyword(keyword)
                 .roomTypeId(roomTypeId)
                 .minRent(minRent)
                 .maxRent(maxRent)

--- a/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
@@ -33,10 +33,10 @@ public class RoomPersistenceAdapter implements RoomRepositoryPort {
     }
 
     @Override
-    public Page<Room> findAvailableRoomsWithFilter(Long roomTypeId, BigDecimal minRent,
+    public Page<Room> findAvailableRoomsWithFilter(String keyword, Long roomTypeId, BigDecimal minRent,
                                                     BigDecimal maxRent, Integer floor, Pageable pageable) {
         return spaceJpaRepository
-                .findRoomsWithFilter(roomTypeId, minRent, maxRent, floor, pageable)
+                .findRoomsWithFilter(keyword, roomTypeId, minRent, maxRent, floor, pageable)
                 .map(this::toRoom);
     }
 

--- a/backend/src/main/java/com/coliving/user/room/application/command/RoomListCommand.java
+++ b/backend/src/main/java/com/coliving/user/room/application/command/RoomListCommand.java
@@ -11,6 +11,7 @@ import java.math.BigDecimal;
 @Builder
 public class RoomListCommand {
 
+    private String keyword;
     private Long roomTypeId;
     private BigDecimal minRent;
     private BigDecimal maxRent;

--- a/backend/src/main/java/com/coliving/user/room/application/port/out/RoomRepositoryPort.java
+++ b/backend/src/main/java/com/coliving/user/room/application/port/out/RoomRepositoryPort.java
@@ -16,7 +16,7 @@ public interface RoomRepositoryPort {
 
     Page<Room> findAvailablePrivateSpaces(Pageable pageable);
 
-    Page<Room> findAvailableRoomsWithFilter(Long roomTypeId, BigDecimal minRent,
+    Page<Room> findAvailableRoomsWithFilter(String keyword, Long roomTypeId, BigDecimal minRent,
                                              BigDecimal maxRent, Integer floor, Pageable pageable);
 
     Optional<Room> findById(Long spaceId);

--- a/backend/src/main/java/com/coliving/user/room/application/service/RoomService.java
+++ b/backend/src/main/java/com/coliving/user/room/application/service/RoomService.java
@@ -22,13 +22,15 @@ public class RoomService implements RoomUseCase {
 
     @Override
     public Page<Room> getRooms(RoomListCommand command, Pageable pageable) {
-        boolean hasFilter = command.getRoomTypeId() != null
+        boolean hasFilter = command.getKeyword() != null
+                || command.getRoomTypeId() != null
                 || command.getMinRent() != null
                 || command.getMaxRent() != null
                 || command.getFloor() != null;
 
         if (hasFilter) {
             return roomRepositoryPort.findAvailableRoomsWithFilter(
+                    command.getKeyword(),
                     command.getRoomTypeId(),
                     command.getMinRent(),
                     command.getMaxRent(),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/utilities": "^3.2.2",
+        "@hello-pangea/dnd": "^18.0.1",
         "@portone/browser-sdk": "^0.1.3",
         "clsx": "^2.1.1",
         "framer-motion": "^12.0.0",
@@ -53,6 +54,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@dnd-kit/accessibility": {
@@ -269,6 +279,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hello-pangea/dnd": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-18.0.1.tgz",
+      "integrity": "sha512-xojVWG8s/TGrKT1fC8K2tIWeejJYTAeJuj36zM//yEm/ZrnZUSFGS15BpO+jGZT1ybWvyXmeDJwPYb4dhWlbZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.26.7",
+        "css-box-model": "^1.2.1",
+        "raf-schd": "^4.0.3",
+        "react-redux": "^9.2.0",
+        "redux": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2564,6 +2591,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-box-model": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-box-model/-/css-box-model-1.2.1.tgz",
+      "integrity": "sha512-a7Vr4Q/kd/aw96bnJG332W9V9LkJO69JRcaCYDUqjp6/z0w6VcZjgAcTbgFxEPfBgdnAwlh3iwu+hLopa+flJw==",
+      "license": "MIT",
+      "dependencies": {
+        "tiny-invariant": "^1.0.6"
       }
     },
     "node_modules/csstype": {
@@ -5684,6 +5720,12 @@
       "engines": {
         "node": ">= 12.0.0"
       }
+    },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/utilities": "^3.2.2",
+    "@hello-pangea/dnd": "^18.0.1",
     "@portone/browser-sdk": "^0.1.3",
     "clsx": "^2.1.1",
     "framer-motion": "^12.0.0",

--- a/frontend/src/app/(public)/rooms/_api/roomApi.ts
+++ b/frontend/src/app/(public)/rooms/_api/roomApi.ts
@@ -10,6 +10,7 @@ export const fetchRooms = async (params?: RoomFilterParams) => {
   if (params?.floor !== undefined) searchParams.set('floor', String(params.floor));
   if (params?.page !== undefined) searchParams.set('page', String(params.page));
   if (params?.size !== undefined) searchParams.set('size', String(params.size));
+  if (params?.sort) searchParams.set('sort', params.sort);
 
   const query = searchParams.toString();
   const res = await fetch(`/api/rooms${query ? `?${query}` : ''}`);

--- a/frontend/src/app/(public)/rooms/_api/roomApi.ts
+++ b/frontend/src/app/(public)/rooms/_api/roomApi.ts
@@ -4,6 +4,7 @@ export type { RoomDTO, PageResponse, RoomFilterParams };
 
 export const fetchRooms = async (params?: RoomFilterParams) => {
   const searchParams = new URLSearchParams();
+  if (params?.keyword) searchParams.set('keyword', params.keyword);
   if (params?.roomTypeId !== undefined) searchParams.set('roomTypeId', String(params.roomTypeId));
   if (params?.minRent !== undefined) searchParams.set('minRent', String(params.minRent));
   if (params?.maxRent !== undefined) searchParams.set('maxRent', String(params.maxRent));

--- a/frontend/src/app/(public)/rooms/_components/FilterChips.tsx
+++ b/frontend/src/app/(public)/rooms/_components/FilterChips.tsx
@@ -1,19 +1,41 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Search, X, Filter } from 'lucide-react';
+import { Search, X, ArrowUpDown, Check } from 'lucide-react';
 import type { RoomTypeOption } from '../_types';
+import type { SortOption } from '../_hooks/useRooms';
 
 interface FilterChipsProps {
   roomTypes: RoomTypeOption[];
   selectedTypeId: number | null;
   onSelectType: (typeId: number | null) => void;
+  sortOption: SortOption;
+  onSortChange: (sort: SortOption) => void;
 }
 
-export function FilterChips({ roomTypes, selectedTypeId, onSelectType }: FilterChipsProps) {
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+  { value: 'name,asc', label: '이름순 (ㄱ→ㅎ)' },
+  { value: 'name,desc', label: '이름순 (ㅎ→ㄱ)' },
+  { value: 'spaceId,desc', label: '최신 등록순' },
+];
+
+export function FilterChips({ roomTypes, selectedTypeId, onSelectType, sortOption, onSortChange }: FilterChipsProps) {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
+  const [isSortOpen, setIsSortOpen] = useState(false);
+  const sortRef = useRef<HTMLDivElement>(null);
+
+  // 바깥 클릭 시 정렬 드롭다운 닫기
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
+        setIsSortOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
 
   return (
     <div className="flex flex-col md:flex-row justify-between items-stretch md:items-center gap-6">
@@ -85,10 +107,44 @@ export function FilterChips({ roomTypes, selectedTypeId, onSelectType }: FilterC
           )}
         </AnimatePresence>
 
-        <button className="flex items-center gap-2 text-[10px] md:text-xs font-black uppercase tracking-widest hover:opacity-60 transition-opacity cursor-pointer">
-          <Filter className="h-3.5 w-3.5 md:h-4 md:w-4" />
-          Sort
-        </button>
+        {/* Sort dropdown */}
+        <div ref={sortRef} className="relative">
+          <button
+            onClick={() => setIsSortOpen(!isSortOpen)}
+            className="flex items-center gap-2 text-[10px] md:text-xs font-black uppercase tracking-widest hover:opacity-60 transition-opacity cursor-pointer"
+          >
+            <ArrowUpDown className="h-3.5 w-3.5 md:h-4 md:w-4" />
+            Sort
+          </button>
+
+          <AnimatePresence>
+            {isSortOpen && (
+              <motion.div
+                initial={{ opacity: 0, y: -8, scale: 0.95 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -8, scale: 0.95 }}
+                transition={{ duration: 0.15 }}
+                className="absolute right-0 top-full mt-3 w-48 bg-[var(--background)] border border-foreground/10 rounded-2xl shadow-2xl overflow-hidden z-50"
+              >
+                {SORT_OPTIONS.map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => {
+                      onSortChange(opt.value);
+                      setIsSortOpen(false);
+                    }}
+                    className={`w-full flex items-center justify-between px-4 py-3 text-xs font-bold tracking-tight hover:bg-black/5 transition cursor-pointer ${
+                      sortOption === opt.value ? 'text-[var(--color-accent)]' : ''
+                    }`}
+                  >
+                    {opt.label}
+                    {sortOption === opt.value && <Check size={14} className="text-[var(--color-accent)]" />}
+                  </button>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/(public)/rooms/_components/FilterChips.tsx
+++ b/frontend/src/app/(public)/rooms/_components/FilterChips.tsx
@@ -12,6 +12,8 @@ interface FilterChipsProps {
   onSelectType: (typeId: number | null) => void;
   sortOption: SortOption;
   onSortChange: (sort: SortOption) => void;
+  keyword: string;
+  onSearch: (keyword: string) => void;
 }
 
 const SORT_OPTIONS: { value: SortOption; label: string }[] = [
@@ -20,11 +22,16 @@ const SORT_OPTIONS: { value: SortOption; label: string }[] = [
   { value: 'spaceId,desc', label: '최신 등록순' },
 ];
 
-export function FilterChips({ roomTypes, selectedTypeId, onSelectType, sortOption, onSortChange }: FilterChipsProps) {
-  const [isSearchOpen, setIsSearchOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
+export function FilterChips({ roomTypes, selectedTypeId, onSelectType, sortOption, onSortChange, keyword, onSearch }: FilterChipsProps) {
+  const [isSearchOpen, setIsSearchOpen] = useState(!!keyword);
+  const [searchQuery, setSearchQuery] = useState(keyword || '');
   const [isSortOpen, setIsSortOpen] = useState(false);
   const sortRef = useRef<HTMLDivElement>(null);
+
+  // 외부 키워드 변경 시 로컬 상태 동기화
+  useEffect(() => {
+    setSearchQuery(keyword || '');
+  }, [keyword]);
 
   // 바깥 클릭 시 정렬 드롭다운 닫기
   useEffect(() => {
@@ -85,11 +92,17 @@ export function FilterChips({ roomTypes, selectedTypeId, onSelectType, sortOptio
                 className="bg-transparent text-[10px] md:text-xs font-bold uppercase tracking-widest focus:outline-none min-w-[140px] md:min-w-[200px]"
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    onSearch(searchQuery);
+                  }
+                }}
               />
               <button
                 onClick={() => {
                   setIsSearchOpen(false);
                   setSearchQuery('');
+                  onSearch('');
                 }}
                 className="cursor-pointer"
               >

--- a/frontend/src/app/(public)/rooms/_hooks/useRooms.ts
+++ b/frontend/src/app/(public)/rooms/_hooks/useRooms.ts
@@ -15,6 +15,7 @@ export function useRooms() {
   const [totalElements, setTotalElements] = useState(0);
   const [roomTypes, setRoomTypes] = useState<RoomTypeOption[]>([]);
   const [sortOption, setSortOption] = useState<SortOption>('name,asc');
+  const [keyword, setKeyword] = useState<string>('');
 
   // 방 유형 목록 로드
   useEffect(() => {
@@ -27,6 +28,7 @@ export function useRooms() {
     setLoading(true);
     try {
       const params: RoomFilterParams = {
+        keyword: keyword || undefined,
         roomTypeId: selectedTypeId ?? undefined,
         page: currentPage,
         size: 12,
@@ -43,7 +45,7 @@ export function useRooms() {
     } finally {
       setLoading(false);
     }
-  }, [selectedTypeId, currentPage, sortOption]);
+  }, [selectedTypeId, currentPage, sortOption, keyword]);
 
   useEffect(() => {
     loadRooms();
@@ -52,7 +54,7 @@ export function useRooms() {
   // 필터 변경 시 페이지 리셋
   useEffect(() => {
     setCurrentPage(0);
-  }, [selectedTypeId, sortOption]);
+  }, [selectedTypeId, sortOption, keyword]);
 
   return {
     rooms,
@@ -66,5 +68,7 @@ export function useRooms() {
     totalElements,
     sortOption,
     setSortOption,
+    keyword,
+    setKeyword,
   };
 }

--- a/frontend/src/app/(public)/rooms/_hooks/useRooms.ts
+++ b/frontend/src/app/(public)/rooms/_hooks/useRooms.ts
@@ -4,6 +4,8 @@ import { useEffect, useState, useCallback } from 'react';
 import { fetchRooms, fetchPublicRoomTypes } from '../_api/roomApi';
 import type { RoomDTO, RoomFilterParams, RoomTypeOption } from '../_types';
 
+export type SortOption = 'name,asc' | 'spaceId,desc' | 'name,desc';
+
 export function useRooms() {
   const [rooms, setRooms] = useState<RoomDTO[]>([]);
   const [loading, setLoading] = useState(true);
@@ -12,6 +14,7 @@ export function useRooms() {
   const [totalPages, setTotalPages] = useState(0);
   const [totalElements, setTotalElements] = useState(0);
   const [roomTypes, setRoomTypes] = useState<RoomTypeOption[]>([]);
+  const [sortOption, setSortOption] = useState<SortOption>('name,asc');
 
   // 방 유형 목록 로드
   useEffect(() => {
@@ -27,6 +30,7 @@ export function useRooms() {
         roomTypeId: selectedTypeId ?? undefined,
         page: currentPage,
         size: 12,
+        sort: sortOption,
       };
       const res = await fetchRooms(params);
       const pageData = res.data;
@@ -39,7 +43,7 @@ export function useRooms() {
     } finally {
       setLoading(false);
     }
-  }, [selectedTypeId, currentPage]);
+  }, [selectedTypeId, currentPage, sortOption]);
 
   useEffect(() => {
     loadRooms();
@@ -48,7 +52,7 @@ export function useRooms() {
   // 필터 변경 시 페이지 리셋
   useEffect(() => {
     setCurrentPage(0);
-  }, [selectedTypeId]);
+  }, [selectedTypeId, sortOption]);
 
   return {
     rooms,
@@ -60,5 +64,7 @@ export function useRooms() {
     setCurrentPage,
     totalPages,
     totalElements,
+    sortOption,
+    setSortOption,
   };
 }

--- a/frontend/src/app/(public)/rooms/_types/index.ts
+++ b/frontend/src/app/(public)/rooms/_types/index.ts
@@ -36,6 +36,7 @@ export interface PageResponse<T> {
 }
 
 export interface RoomFilterParams {
+  keyword?: string;
   roomTypeId?: number;
   minRent?: number;
   maxRent?: number;

--- a/frontend/src/app/(public)/rooms/_types/index.ts
+++ b/frontend/src/app/(public)/rooms/_types/index.ts
@@ -42,6 +42,7 @@ export interface RoomFilterParams {
   floor?: number;
   page?: number;
   size?: number;
+  sort?: string;
 }
 
 export interface RoomTypeOption {

--- a/frontend/src/app/(public)/rooms/page.tsx
+++ b/frontend/src/app/(public)/rooms/page.tsx
@@ -22,6 +22,8 @@ export default function RoomsPage() {
     setCurrentPage,
     totalPages,
     totalElements,
+    sortOption,
+    setSortOption,
   } = useRooms();
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -77,6 +79,8 @@ export default function RoomsPage() {
             roomTypes={roomTypes}
             selectedTypeId={selectedTypeId}
             onSelectType={setSelectedTypeId}
+            sortOption={sortOption}
+            onSortChange={setSortOption}
           />
         </div>
       </section>

--- a/frontend/src/app/(public)/rooms/page.tsx
+++ b/frontend/src/app/(public)/rooms/page.tsx
@@ -24,6 +24,8 @@ export default function RoomsPage() {
     totalElements,
     sortOption,
     setSortOption,
+    keyword,
+    setKeyword,
   } = useRooms();
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -81,6 +83,8 @@ export default function RoomsPage() {
             onSelectType={setSelectedTypeId}
             sortOption={sortOption}
             onSortChange={setSortOption}
+            keyword={keyword}
+            onSearch={setKeyword}
           />
         </div>
       </section>
@@ -104,7 +108,7 @@ export default function RoomsPage() {
 
           {/* Empty State */}
           {!loading && rooms.length === 0 && (
-            <EmptyState onReset={() => setSelectedTypeId(null)} />
+            <EmptyState onReset={() => { setSelectedTypeId(null); setKeyword(''); }} />
           )}
         </div>
       </section>

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -6,6 +6,7 @@ export interface RoomTypeDTO {
   code: string;
   name: string;
   isSystemDefault: boolean;
+  sortOrder: number;
 }
 
 export interface SpaceDTO {
@@ -62,10 +63,11 @@ export function extractRoomTypeName(space: SpaceDTO): string | undefined {
   return space.roomTypeName || nested?.roomTypeName;
 }
 
-export const fetchSpaces = async (params?: { type?: string; status?: string }) => {
+export const fetchSpaces = async (params?: { type?: string; status?: string; sort?: string }) => {
   const query = new URLSearchParams();
   if (params?.type && params.type !== 'ALL') query.append('type', params.type);
   if (params?.status && params.status !== 'ALL') query.append('status', params.status);
+  if (params?.sort) query.append('sort', params.sort);
   
   const queryString = query.toString() ? `?${query.toString()}` : '';
   const res = await apiFetch<any>(`/admin/spaces${queryString}`);
@@ -174,6 +176,13 @@ export const updateRoomType = async (roomTypeId: number, data: { name: string })
 export const deleteRoomType = async (roomTypeId: number) => {
   return await apiFetch<any>(`/admin/room-types/${roomTypeId}`, {
     method: 'DELETE',
+  });
+};
+
+export const updateRoomTypeOrder = async (orderedIds: number[]) => {
+  return await apiFetch<any>('/admin/room-types/order', {
+    method: 'PUT',
+    body: JSON.stringify(orderedIds),
   });
 };
 

--- a/frontend/src/app/admin/spaces/_components/RoomTypeManager.tsx
+++ b/frontend/src/app/admin/spaces/_components/RoomTypeManager.tsx
@@ -1,13 +1,20 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Plus, Pencil, Trash2, X, Check, Shield } from 'lucide-react';
+import { Plus, Pencil, Trash2, X, Check, Shield, GripVertical } from 'lucide-react';
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  type DropResult,
+} from '@hello-pangea/dnd';
 import {
   fetchRoomTypes,
   createRoomType,
   updateRoomType,
   deleteRoomType,
+  updateRoomTypeOrder,
   RoomTypeDTO,
 } from '../_api/spaceAdminApi';
 
@@ -28,21 +35,26 @@ export default function RoomTypeManager() {
   // 삭제 확인
   const [deletingId, setDeletingId] = useState<number | null>(null);
 
-  const loadRoomTypes = async () => {
+  // 순서 저장 상태
+  const [isSavingOrder, setIsSavingOrder] = useState(false);
+  const [orderChanged, setOrderChanged] = useState(false);
+
+  const loadRoomTypes = useCallback(async () => {
     try {
       setLoading(true);
       const res = await fetchRoomTypes();
       setRoomTypes(res.data || []);
+      setOrderChanged(false);
     } catch (e) {
       console.error(e);
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     loadRoomTypes();
-  }, []);
+  }, [loadRoomTypes]);
 
   const handleCreate = async () => {
     if (!newCode.trim() || !newName.trim()) return;
@@ -87,22 +99,66 @@ export default function RoomTypeManager() {
     setDeletingId(null);
   };
 
+  // === D&D 핸들러 ===
+  const handleDragEnd = (result: DropResult) => {
+    if (!result.destination) return;
+    if (result.source.index === result.destination.index) return;
+
+    const reordered = Array.from(roomTypes);
+    const [moved] = reordered.splice(result.source.index, 1);
+    reordered.splice(result.destination.index, 0, moved);
+
+    setRoomTypes(reordered);
+    setOrderChanged(true);
+  };
+
+  const handleSaveOrder = async () => {
+    setIsSavingOrder(true);
+    try {
+      const orderedIds = roomTypes.map((rt) => rt.roomTypeId);
+      await updateRoomTypeOrder(orderedIds);
+      setOrderChanged(false);
+    } catch (e: unknown) {
+      alert(e instanceof Error ? e.message : '순서 저장에 실패했습니다.');
+    } finally {
+      setIsSavingOrder(false);
+    }
+  };
+
   return (
     <div>
       {/* 헤더 */}
       <div className="flex items-center justify-between mb-8">
         <div>
           <p className="text-sm font-bold opacity-50 tracking-tight">
-            관리자가 방 유형을 자유롭게 등록·수정·삭제할 수 있습니다.
+            드래그하여 순서를 변경하고, 저장 버튼을 눌러 반영하세요.
           </p>
         </div>
-        <button
-          onClick={() => { setShowCreateForm(true); setEditingId(null); setDeletingId(null); }}
-          className="flex items-center gap-2 bg-[var(--foreground)] text-[var(--background)] px-5 py-3 rounded-full font-black tracking-tighter hover:scale-105 transition shadow-xl text-sm"
-        >
-          <Plus size={16} />
-          <span className="hidden sm:inline">유형 추가</span>
-        </button>
+        <div className="flex items-center gap-3">
+          {/* 순서 저장 버튼 */}
+          <AnimatePresence>
+            {orderChanged && (
+              <motion.button
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                onClick={handleSaveOrder}
+                disabled={isSavingOrder}
+                className="flex items-center gap-2 bg-blue-600 text-white px-5 py-3 rounded-full font-black tracking-tighter hover:scale-105 transition shadow-xl text-sm disabled:opacity-50"
+              >
+                <Check size={16} />
+                {isSavingOrder ? '저장 중...' : '순서 저장'}
+              </motion.button>
+            )}
+          </AnimatePresence>
+          <button
+            onClick={() => { setShowCreateForm(true); setEditingId(null); setDeletingId(null); }}
+            className="flex items-center gap-2 bg-[var(--foreground)] text-[var(--background)] px-5 py-3 rounded-full font-black tracking-tighter hover:scale-105 transition shadow-xl text-sm"
+          >
+            <Plus size={16} />
+            <span className="hidden sm:inline">유형 추가</span>
+          </button>
+        </div>
       </div>
 
       {/* 등록 폼 */}
@@ -158,7 +214,7 @@ export default function RoomTypeManager() {
         )}
       </AnimatePresence>
 
-      {/* 목록 */}
+      {/* 목록 (D&D) */}
       {loading ? (
         <div className="space-y-3">
           {[...Array(4)].map((_, i) => (
@@ -170,99 +226,127 @@ export default function RoomTypeManager() {
           <p className="text-lg font-black tracking-tighter">등록된 방 유형이 없습니다</p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {roomTypes.map((rt, idx) => (
-            <motion.div
-              key={rt.roomTypeId}
-              initial={{ opacity: 0, y: 10 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ delay: 0.03 * idx }}
-              className="flex items-center justify-between p-5 bg-black/5 rounded-2xl hover:bg-black/10 transition group"
-            >
-              <div className="flex items-center gap-4 flex-1">
-                {/* 코드 뱃지 */}
-                <span className="px-3 py-1 bg-[var(--color-accent)] text-white text-xs font-black rounded-full tracking-wider">
-                  {rt.code}
-                </span>
-
-                {/* 이름 (수정 모드 / 표시 모드) */}
-                {editingId === rt.roomTypeId ? (
-                  <div className="flex items-center gap-2 flex-1">
-                    <input
-                      type="text"
-                      value={editName}
-                      onChange={(e) => setEditName(e.target.value)}
-                      onKeyDown={(e) => e.key === 'Enter' && handleUpdate(rt.roomTypeId)}
-                      className="px-3 py-1.5 rounded-xl bg-[var(--color-muted)] outline-none text-sm font-bold flex-1 max-w-[200px]"
-                      autoFocus
-                    />
-                    <button
-                      onClick={() => handleUpdate(rt.roomTypeId)}
-                      className="p-1.5 bg-green-500 text-white rounded-full hover:scale-110 transition"
-                    >
-                      <Check size={14} />
-                    </button>
-                    <button
-                      onClick={() => setEditingId(null)}
-                      className="p-1.5 hover:bg-black/10 rounded-full transition"
-                    >
-                      <X size={14} />
-                    </button>
-                  </div>
-                ) : (
-                  <span className="text-sm font-bold tracking-tight">{rt.name}</span>
-                )}
-
-                {/* 시스템 기본 뱃지 */}
-                {rt.isSystemDefault && (
-                  <span className="flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-600 text-[10px] font-black rounded-full">
-                    <Shield size={10} />
-                    기본
-                  </span>
-                )}
-              </div>
-
-              {/* 액션 버튼 */}
-              {editingId !== rt.roomTypeId && (
-                <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition">
-                  <button
-                    onClick={() => startEdit(rt)}
-                    className="p-2 hover:bg-black/10 rounded-full transition"
-                    title="수정"
+        <DragDropContext onDragEnd={handleDragEnd}>
+          <Droppable droppableId="room-types">
+            {(provided) => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+                className="space-y-3"
+              >
+                {roomTypes.map((rt, idx) => (
+                  <Draggable
+                    key={rt.roomTypeId}
+                    draggableId={String(rt.roomTypeId)}
+                    index={idx}
                   >
-                    <Pencil size={14} />
-                  </button>
-                  {!rt.isSystemDefault && (
-                    deletingId === rt.roomTypeId ? (
-                      <div className="flex items-center gap-1">
-                        <button
-                          onClick={() => handleDelete(rt.roomTypeId)}
-                          className="px-3 py-1.5 bg-red-500 text-white text-xs font-bold rounded-full hover:bg-red-600 transition"
-                        >
-                          확인
-                        </button>
-                        <button
-                          onClick={() => setDeletingId(null)}
-                          className="px-3 py-1.5 text-xs font-bold hover:bg-black/10 rounded-full transition"
-                        >
-                          취소
-                        </button>
-                      </div>
-                    ) : (
-                      <button
-                        onClick={() => { setDeletingId(rt.roomTypeId); setEditingId(null); }}
-                        className="p-2 hover:bg-red-100 text-red-500 rounded-full transition"
-                        title="삭제"
+                    {(provided, snapshot) => (
+                      <div
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        className={`flex items-center justify-between p-5 bg-black/5 rounded-2xl hover:bg-black/10 transition group ${
+                          snapshot.isDragging ? 'shadow-2xl ring-2 ring-[var(--color-accent)] bg-[var(--background)]' : ''
+                        }`}
                       >
-                        <Trash2 size={14} />
-                      </button>
-                    )
-                  )}
-                </div>
-              )}
-            </motion.div>
-          ))}
-        </div>
+                        {/* 드래그 핸들 */}
+                        <div
+                          {...provided.dragHandleProps}
+                          className="mr-3 cursor-grab active:cursor-grabbing p-1 hover:bg-black/10 rounded-lg transition opacity-40 hover:opacity-100"
+                          title="드래그하여 순서 변경"
+                        >
+                          <GripVertical size={16} />
+                        </div>
+
+                        <div className="flex items-center gap-4 flex-1">
+                          {/* 코드 뱃지 */}
+                          <span className="px-3 py-1 bg-[var(--color-accent)] text-white text-xs font-black rounded-full tracking-wider">
+                            {rt.code}
+                          </span>
+
+                          {/* 이름 (수정 모드 / 표시 모드) */}
+                          {editingId === rt.roomTypeId ? (
+                            <div className="flex items-center gap-2 flex-1">
+                              <input
+                                type="text"
+                                value={editName}
+                                onChange={(e) => setEditName(e.target.value)}
+                                onKeyDown={(e) => e.key === 'Enter' && handleUpdate(rt.roomTypeId)}
+                                className="px-3 py-1.5 rounded-xl bg-[var(--color-muted)] outline-none text-sm font-bold flex-1 max-w-[200px]"
+                                autoFocus
+                              />
+                              <button
+                                onClick={() => handleUpdate(rt.roomTypeId)}
+                                className="p-1.5 bg-green-500 text-white rounded-full hover:scale-110 transition"
+                              >
+                                <Check size={14} />
+                              </button>
+                              <button
+                                onClick={() => setEditingId(null)}
+                                className="p-1.5 hover:bg-black/10 rounded-full transition"
+                              >
+                                <X size={14} />
+                              </button>
+                            </div>
+                          ) : (
+                            <span className="text-sm font-bold tracking-tight">{rt.name}</span>
+                          )}
+
+                          {/* 시스템 기본 뱃지 */}
+                          {rt.isSystemDefault && (
+                            <span className="flex items-center gap-1 px-2 py-0.5 bg-blue-100 text-blue-600 text-[10px] font-black rounded-full">
+                              <Shield size={10} />
+                              기본
+                            </span>
+                          )}
+                        </div>
+
+                        {/* 액션 버튼 */}
+                        {editingId !== rt.roomTypeId && (
+                          <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition">
+                            <button
+                              onClick={() => startEdit(rt)}
+                              className="p-2 hover:bg-black/10 rounded-full transition"
+                              title="수정"
+                            >
+                              <Pencil size={14} />
+                            </button>
+                            {!rt.isSystemDefault && (
+                              deletingId === rt.roomTypeId ? (
+                                <div className="flex items-center gap-1">
+                                  <button
+                                    onClick={() => handleDelete(rt.roomTypeId)}
+                                    className="px-3 py-1.5 bg-red-500 text-white text-xs font-bold rounded-full hover:bg-red-600 transition"
+                                  >
+                                    확인
+                                  </button>
+                                  <button
+                                    onClick={() => setDeletingId(null)}
+                                    className="px-3 py-1.5 text-xs font-bold hover:bg-black/10 rounded-full transition"
+                                  >
+                                    취소
+                                  </button>
+                                </div>
+                              ) : (
+                                <button
+                                  onClick={() => { setDeletingId(rt.roomTypeId); setEditingId(null); }}
+                                  className="p-2 hover:bg-red-100 text-red-500 rounded-full transition"
+                                  title="삭제"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              )
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </Draggable>
+                ))}
+                {provided.placeholder}
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
       )}
     </div>
   );

--- a/frontend/src/app/admin/spaces/page.tsx
+++ b/frontend/src/app/admin/spaces/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { fetchSpaces, SpaceDTO } from './_api/spaceAdminApi';
 import SpaceCreateModal from './_components/SpaceCreateModal';
 import SpaceEditModal from './_components/SpaceEditModal';
@@ -8,7 +8,7 @@ import RoomTypeManager from './_components/RoomTypeManager';
 import AnnotationTypeManager from './_components/AnnotationTypeManager';
 import { FloorPlanEditor } from './_components/floor-plan/FloorPlanEditor';
 import { motion } from 'framer-motion';
-import { Plus, Pencil, LayoutGrid, Tag, Map, Shapes } from 'lucide-react';
+import { Plus, Pencil, LayoutGrid, Tag, Map, Shapes, ArrowUpDown, Check } from 'lucide-react';
 
 type Tab = 'spaces' | 'room-types' | 'floor-plan' | 'annotation-types';
 
@@ -20,13 +20,25 @@ export default function SpacesPage() {
 
   // 필터 상태
   const [filterType, setFilterType] = useState<'ALL' | 'PRIVATE' | 'COMMON'>('ALL');
+  const [sortOption, setSortOption] = useState('name,asc');
+  const [isSortOpen, setIsSortOpen] = useState(false);
+  const sortRef = React.useRef<HTMLDivElement>(null);
+
+  // 바깥 클릭 시 정렬 드롭다운 닫기
+  React.useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (sortRef.current && !sortRef.current.contains(e.target as Node)) {
+        setIsSortOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
 
   const loadSpaces = async () => {
     try {
-      const res = await fetchSpaces({ type: filterType });
-      // 프론트엔드에서 간편하게 정렬 (이름순)
-      const sorted = (res.data?.content || []).sort((a: SpaceDTO, b: SpaceDTO) => a.name.localeCompare(b.name));
-      setSpaces(sorted);
+      const res = await fetchSpaces({ type: filterType, sort: sortOption });
+      setSpaces(res.data?.content || []);
     } catch (e) {
       console.error(e);
     }
@@ -34,7 +46,7 @@ export default function SpacesPage() {
 
   useEffect(() => {
     loadSpaces();
-  }, [filterType]);
+  }, [filterType, sortOption]);
 
   const getStatusDisplay = (space: SpaceDTO) => {
     if (space.type === 'PRIVATE') {
@@ -118,6 +130,37 @@ export default function SpacesPage() {
                 {type === 'ALL' ? '전체 보기' : type}
               </button>
             ))}
+          </div>
+
+          {/* 정렬 드롭다운 */}
+          <div ref={sortRef} className="relative inline-block mb-6">
+            <button
+              onClick={() => setIsSortOpen(!isSortOpen)}
+              className="flex items-center gap-2 px-4 py-2 rounded-full text-xs font-bold tracking-tight bg-black/5 hover:bg-black/10 transition"
+            >
+              <ArrowUpDown size={14} />
+              {sortOption === 'name,asc' ? '이름순 (ㄱ→ㅎ)' : sortOption === 'name,desc' ? '이름순 (ㅎ→ㄱ)' : '최신 등록순'}
+            </button>
+            {isSortOpen && (
+              <div className="absolute left-0 top-full mt-2 w-44 bg-[var(--background)] border border-foreground/10 rounded-2xl shadow-2xl overflow-hidden z-50">
+                {[
+                  { value: 'name,asc', label: '이름순 (ㄱ→ㅎ)' },
+                  { value: 'name,desc', label: '이름순 (ㅎ→ㄱ)' },
+                  { value: 'spaceId,desc', label: '최신 등록순' },
+                ].map((opt) => (
+                  <button
+                    key={opt.value}
+                    onClick={() => { setSortOption(opt.value); setIsSortOpen(false); }}
+                    className={`w-full flex items-center justify-between px-4 py-3 text-xs font-bold tracking-tight hover:bg-black/5 transition cursor-pointer ${
+                      sortOption === opt.value ? 'text-[var(--color-accent)]' : ''
+                    }`}
+                  >
+                    {opt.label}
+                    {sortOption === opt.value && <Check size={14} className="text-[var(--color-accent)]" />}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- **일반 유저 UX 강화**: 방 둘러보기 페이지에서 이름 검색 및 다양한 정렬(이름순/최신순)을 통해 원하는 방을 빠르게 찾도록 지원합니다.
- **관리자 편의성 향상**: 공간 관리 탭에서 방 유형의 노출 순서를 드래그 앤 드롭(D&D)으로 직관적으로 반영할 수 있게 합니다.

## 🔑 주요 변경 사항 (What)
- **방 목록 검색/정렬 (Full-Stack)**: 백엔드 JPQL 동적 쿼리(`keyword`) 추가 및 정렬 적용, 프론트엔드 검색 입력창 및 셀렉트 박스 연동 완료
- **방 유형 순서 변경 (Frontend)**: `@hello-pangea/dnd`를 활용한 리스트 D&D 기능 추가 및 `updateRoomTypeOrder` 데이터베이스 연동
- **오리지널 브랜치 동기화**: 최신 `develop` 브랜치 내용 병합 완료

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305 

## 💻 테스트 방법 (How to Test)
1. **일반 유저 (`/rooms`)**: "Search" 아이콘 클릭 후 공간명 일부를 입력 및 Enter로 필터링 확인, "Sort" 메뉴로 정렬 변경 테스트
2. **관리자 (`/admin/spaces`)**: "방 유형 관리" 메뉴에서 목록을 드래그하여 위아래로 섞은 뒤 "순서 저장" 버튼 클릭 시 정상 반응 여부 확인

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- (검색창 스크린샷 또는 방 유형 D&D 작동 영상 첨부)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 프론트엔드의 검색 필터 초기화(Empty State의 초기화 버튼), 엔터 키 이벤트 등 세부적인 UX 요소도 챙겼습니다!
- @팀원 

Closes #305 