### PR TITLE
fix: 관리자 등록 방 이미지 열람 불가 현상 해결 및 필터링 500 에러 교정

### DIFF
--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
@@ -69,19 +69,19 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
     @Query(value = "SELECT s FROM SpaceEntity s " +
                     "JOIN FETCH s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
-                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-                    "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
-                    "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
-                    "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
-                    "AND (:floor IS NULL OR s.floor = :floor)",
+                    "AND (CAST(:keyword AS text) IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+                    "AND (CAST(:roomTypeId AS bigint) IS NULL OR pd.roomType.id = :roomTypeId) " +
+                    "AND (CAST(:minRent AS numeric) IS NULL OR pd.monthlyRent >= :minRent) " +
+                    "AND (CAST(:maxRent AS numeric) IS NULL OR pd.monthlyRent <= :maxRent) " +
+                    "AND (CAST(:floor AS integer) IS NULL OR s.floor = :floor)",
             countQuery = "SELECT COUNT(s) FROM SpaceEntity s " +
                     "JOIN s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
-                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-                    "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
-                    "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
-                    "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
-                    "AND (:floor IS NULL OR s.floor = :floor)")
+                    "AND (CAST(:keyword AS text) IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+                    "AND (CAST(:roomTypeId AS bigint) IS NULL OR pd.roomType.id = :roomTypeId) " +
+                    "AND (CAST(:minRent AS numeric) IS NULL OR pd.monthlyRent >= :minRent) " +
+                    "AND (CAST(:maxRent AS numeric) IS NULL OR pd.monthlyRent <= :maxRent) " +
+                    "AND (CAST(:floor AS integer) IS NULL OR s.floor = :floor)")
     Page<SpaceEntity> findRoomsWithFilter(
             @Param("keyword") String keyword,
             @Param("roomTypeId") Long roomTypeId,

--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
@@ -172,8 +172,8 @@ public class AdminSpaceService implements AdminSpaceUseCase {
 
         String savedFileName = fileStoragePort.storeFile(spaceId, file);
 
-        // 프론트엔드가 자체 프록시(/api/bff/...)를 통해 컨트롤러 엔드포인트를 타도록 경로 합성
-        String imageUrl = "/api/admin/spaces/" + spaceId + "/images/serve/" + savedFileName;
+        // 프론트엔드가 권한 없이 접근 가능한 정적 리소스 경로 사용
+        String imageUrl = "/api/uploads/spaces/" + spaceId + "/" + savedFileName;
 
         AdminSpace.SpaceImage newImage = AdminSpace.SpaceImage.builder()
                 .imageUrl(imageUrl)

--- a/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
@@ -54,7 +54,10 @@ public class RoomPersistenceAdapter implements RoomRepositoryPort {
                 .filter(img -> Boolean.TRUE.equals(img.getIsThumbnail()))
                 .map(SpaceImageEntity::getImageUrl)
                 .findFirst()
-                .orElse(null);
+                .orElseGet(() -> entity.getImages().stream()
+                        .findFirst()
+                        .map(SpaceImageEntity::getImageUrl)
+                        .orElse(null));
 
         Room.RoomBuilder builder = Room.builder()
                 .spaceId(entity.getSpaceId())


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- **비회원/일반 유저의 화면에서 관리자가 등록한 방 이미지가 표시되지 않는 문제**를 해결하기 위해 작성되었습니다. (시드 데이터는 작동하나, CRUD로 생성한 데이터만 이미지가 보이지 않음)
- **방 목록 페이지에서 특정 방 유형(필터) 클릭 시 목록 렌더링이 먹통이 되는(500 에러) 현상**을 해결하기 위해 작성되었습니다.

## 🔑 주요 변경 사항 (What)
- **이미지 URL 정적 리소스 경로 우회 적용 ([AdminSpaceService.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java:0:0-0:0))**
  - 원인: 생성된 이미지 URL에 `/admin/`이 포함되어 프론트엔드([middleware.ts](cci:7://file:///c:/team1_cokkiri/frontend/src/middleware.ts:0:0-0:0))가 비회원 접근 시 403 에러로 취급하여 차단함.
  - 해결: 이미지 저장 반환 URL을 [WebConfig.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/WebConfig.java:0:0-0:0)에 정의된 정적 리소스 경로인 `/api/uploads/spaces/...`로 변경하여 프론트엔드 URL 권한 필터를 자연스럽게 통과하도록 수정.
- **방 썸네일 폴백(Fallback) 로직 추가 ([RoomPersistenceAdapter.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java:0:0-0:0))**
  - 원인: 관리자가 이미지 업로드 시 `isThumbnail` 체크를 누락하면 방 목록에서 불러올 썸네일 사진이 없어 기본(Placeholder) 이미지를 노출함.
  - 해결: `isThumbnail=true`인 이미지가 없을 경우 리스트의 가장 첫 번째 사진([findFirst()](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/DataInitializer.java:181:4-185:5))을 썸네일로 띄우도록 폴백 로직 추가.
- **방 필터링 쿼리 파라미터 타입 캐스팅 명시 ([SpaceJpaRepository.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java:0:0-0:0))**
  - 원인: PostgreSQL 쿼리에 필터링 빈 값(`null`)이 하나라도 들어오면, 엄격한 타입 검사 탓에 타입을 결정하지 못해 예외 트리거 발생.
  - 해결: 필터 쿼리에 [(CAST(:roomTypeId AS bigint) IS NULL OR ...)](cci:1://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/DataInitializer.java:106:4-128:5) 형태로 명시적 타입 캐스팅(`CAST`)을 추가하여 파라미터가 비어 들어와도 안정적으로 무시되도록 처리.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305

## 💻 테스트 방법 (How to Test)
1. **관리자 이미지 등록 테스트**
   - 관리자 페이지에 접속하여 [공간 관리]에서 새로운 방 데이터와 이미지를 임의로 등록합니다. (썸네일 체크 안 해도 됨)
   - 로그아웃 후 비회원 상태로 [방 둘러보기] 페이지에 접근하여 해당 방 사진이 정상적으로 렌더링되는지 확인합니다.
2. **방 필터링 응답 테스트**
   - 사용자 방 목록 화면 상단의 필터 칩(예: `1인가구` 등)을 누릅니다.
   - 백엔드 500 에러 없이, 조건에 부합하는 리스트가 즉시 정상적으로 응답 및 렌더링되는지 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- 백엔드 비즈니스/로직 픽스이므로 별도 UI 변경 캡처본 없음

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까? (`./gradlew classes` 통과)
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 프론트엔드의 [middleware.ts](cci:7://file:///c:/team1_cokkiri/frontend/src/middleware.ts:0:0-0:0) 룰이나 권한을 비틀지 않고, 오직 백엔드 `space` 도메인 로직 교정만으로 URL 라우팅 보안 우회 및 접근 에러를 복구했습니다. 
- 필터 조건인 [SpaceJpaRepository](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java:16:0-100:1)에서 빈 값(`null`)이 포함될 때 DB가 뻗지 않도록 `CAST`를 일괄 적용해 두었으니 쿼리 부분을 눈여겨봐 주세요.

Closes #305 