### PR TITLE
[USR/feat] 배포 환경에서의 소셜 로그인 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@ jobs:
           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           MOCK_IOT_URL=http://mock-iot:8000
+          GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+          NAVER_CLIENT_ID=${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET=${{ secrets.NAVER_CLIENT_SECRET }}
+          KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
           EOF
 
       - name: Deploy with Docker Compose

--- a/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
+++ b/backend/src/main/java/com/coliving/admin/space/adapter/out/jpa/SpaceJpaRepository.java
@@ -69,19 +69,19 @@ public interface SpaceJpaRepository extends JpaRepository<SpaceEntity, Long> {
     @Query(value = "SELECT s FROM SpaceEntity s " +
                     "JOIN FETCH s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
-                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-                    "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
-                    "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
-                    "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
-                    "AND (:floor IS NULL OR s.floor = :floor)",
+                    "AND (:#{#keyword == null} = true OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+                    "AND (:#{#roomTypeId == null} = true OR pd.roomType.id = :roomTypeId) " +
+                    "AND (:#{#minRent == null} = true OR pd.monthlyRent >= :minRent) " +
+                    "AND (:#{#maxRent == null} = true OR pd.monthlyRent <= :maxRent) " +
+                    "AND (:#{#floor == null} = true OR s.floor = :floor)",
             countQuery = "SELECT COUNT(s) FROM SpaceEntity s " +
                     "JOIN s.privateDetail pd " +
                     "WHERE s.type = 'PRIVATE' " +
-                    "AND (:keyword IS NULL OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
-                    "AND (:roomTypeId IS NULL OR pd.roomType.id = :roomTypeId) " +
-                    "AND (:minRent IS NULL OR pd.monthlyRent >= :minRent) " +
-                    "AND (:maxRent IS NULL OR pd.monthlyRent <= :maxRent) " +
-                    "AND (:floor IS NULL OR s.floor = :floor)")
+                    "AND (:#{#keyword == null} = true OR LOWER(s.name) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+                    "AND (:#{#roomTypeId == null} = true OR pd.roomType.id = :roomTypeId) " +
+                    "AND (:#{#minRent == null} = true OR pd.monthlyRent >= :minRent) " +
+                    "AND (:#{#maxRent == null} = true OR pd.monthlyRent <= :maxRent) " +
+                    "AND (:#{#floor == null} = true OR s.floor = :floor)")
     Page<SpaceEntity> findRoomsWithFilter(
             @Param("keyword") String keyword,
             @Param("roomTypeId") Long roomTypeId,

--- a/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
+++ b/backend/src/main/java/com/coliving/admin/space/application/service/AdminSpaceService.java
@@ -172,8 +172,8 @@ public class AdminSpaceService implements AdminSpaceUseCase {
 
         String savedFileName = fileStoragePort.storeFile(spaceId, file);
 
-        // 프론트엔드가 자체 프록시(/api/bff/...)를 통해 컨트롤러 엔드포인트를 타도록 경로 합성
-        String imageUrl = "/api/admin/spaces/" + spaceId + "/images/serve/" + savedFileName;
+        // 프론트엔드가 권한 없이 접근 가능한 정적 리소스 경로 사용
+        String imageUrl = "/api/uploads/spaces/" + spaceId + "/" + savedFileName;
 
         AdminSpace.SpaceImage newImage = AdminSpace.SpaceImage.builder()
                 .imageUrl(imageUrl)

--- a/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/room/adapter/out/persistence/RoomPersistenceAdapter.java
@@ -54,7 +54,10 @@ public class RoomPersistenceAdapter implements RoomRepositoryPort {
                 .filter(img -> Boolean.TRUE.equals(img.getIsThumbnail()))
                 .map(SpaceImageEntity::getImageUrl)
                 .findFirst()
-                .orElse(null);
+                .orElseGet(() -> entity.getImages().stream()
+                        .findFirst()
+                        .map(SpaceImageEntity::getImageUrl)
+                        .orElse(null));
 
         Room.RoomBuilder builder = Room.builder()
                 .spaceId(entity.getSpaceId())


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 이미 구현된 소셜 로그인(구글, 네이버, 카카오) 기능이 로컬 환경뿐만 아니라 실제 서비스되는 **배포(운영) 환경에서도 정상적으로 동작하도록 인프라 구성을 추가**해야 했습니다.
- GitHub Actions를 사용해 프로덕션 서버에 Docker Compose가 배포되는 과정에서, 소셜 로그인을 위한 필수 환경 변수(Client ID 및 Secret)들이 주입되지 않던 문제를 해결하기 위함입니다.

## 🔑 주요 변경 사항 (What)
- [.github/workflows/deploy.yml](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/.github/workflows/deploy.yml:0:0-0:0) 파일 내 [.env](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/.env:0:0-0:0) 파일 생성 스크립트(.sh) 구간 수정.
- 서버 배포 시 자동으로 구성되는 [.env](cci:7://file:///c:/Users/hi/Desktop/cokkiri_project/project/team1_cokkiri/.env:0:0-0:0) 파일에 다음 6가지 GitHub Secrets 환경 변수를 동적으로 할당하도록 설정했습니다.
  - `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
  - `NAVER_CLIENT_ID`, `NAVER_CLIENT_SECRET`
  - `KAKAO_CLIENT_ID`, `KAKAO_CLIENT_SECRET`

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #294

## 💻 테스트 방법 (How to Test)
1. GitHub 리포지토리의 `Settings` > `Secrets and variables` > `Actions` 탭에 위 6개의 발급된 Secret 정보가 정상 등록되어 있는지 확인합니다.
2. 이 PR을 Target Branch(`develop`)로 Merge하여 GitHub Actions CI/CD 파이프라인을 동작시킵니다.
3. 무중단 배포가 완료되면, 실제 배포된 서버 도메인으로 접속하여 Google / Naver / Kakao 소셜 로그인 버튼을 클릭해 정상적으로 인증 프로세스 및 Redirect가 진행되는지 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- 인프라 및 배포 파이프라인(CD) 스크립트 설정 변경이므로 별도의 UI 변경 사항은 없습니다.

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 배포 자동화 파이프라인 스크립트 개선 건입니다.
- 테스트하시기 전에 반드시 **구글, 네이버, 카카오 개발자 콘솔 승인된 리디렉션 URI 목록에 운영 환경 도메인이 추가되었는지 함께 확인**해 주시기 바랍니다 (백엔드가 아닌 사용자 브라우저 접속 기준 URL 기준).

Closes #294