### PR TITLE
[RSV] 예약 접근제어/시간제한/클릭선택 고도화

### DIFF
--- a/backend/src/main/java/com/coliving/global/error/ErrorCode.java
+++ b/backend/src/main/java/com/coliving/global/error/ErrorCode.java
@@ -28,7 +28,9 @@ public enum ErrorCode {
     SPACE_NOT_AVAILABLE(HttpStatus.CONFLICT, "해당 호실은 현재 계약/예약이 불가합니다"),
     APPLICATION_EXISTS(HttpStatus.CONFLICT, "이미 진행 중인 신청이 있습니다"),
     NO_ACTIVE_CONTRACT(HttpStatus.CONFLICT, "유효한 활성 계약이 없습니다"),
+    DAILY_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "일일 최대 예약 시간을 초과했습니다"),
     TIME_SLOT_CONFLICT(HttpStatus.CONFLICT, "해당 시간대는 이미 예약되었습니다"),
+    INVALID_SEQUENCE(HttpStatus.BAD_REQUEST, "시간 선택이 올바르지 않습니다"),
     INVALID_STATUS(HttpStatus.CONFLICT, "현재 상태에서 수행할 수 없는 작업입니다"),
 
     // ── 기기 제어 ──

--- a/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
+++ b/backend/src/main/java/com/coliving/reservation/adapter/out/jpa/ReservationJpaRepository.java
@@ -44,6 +44,10 @@ public interface ReservationJpaRepository extends JpaRepository<ReservationEntit
     /** 특정 사용자의 예약 목록 조회 (상태 필터링) */
     List<ReservationEntity> findByUser_UserIdAndStatusIn(Long userId, List<ReservationStatus> statuses);
 
+    /** 특정 사용자의 특정 날짜 예약 목록 조회 (상태 필터링) */
+    List<ReservationEntity> findByUser_UserIdAndReservationDateAndStatusIn(
+            Long userId, LocalDate reservationDate, List<ReservationStatus> statuses);
+
     /** 특정 사용자의 전체 예약 목록 조회 (최신순 정렬) */
     List<ReservationEntity> findByUser_UserIdOrderByReservationDateDescStartTimeDesc(Long userId);
 

--- a/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
+++ b/backend/src/main/java/com/coliving/reservation/application/service/ReservationCommandService.java
@@ -9,6 +9,7 @@ import com.coliving.reservation.adapter.out.jpa.ReservationEntity;
 import com.coliving.reservation.adapter.out.jpa.ReservationJpaRepository;
 import com.coliving.reservation.application.port.in.ReservationCommandUseCase;
 import com.coliving.reservation.exception.ReservationOverlapException;
+import com.coliving.reservation.model.ReservationStatus;
 import com.coliving.user.contract.adapter.out.jpa.ContractEntity;
 import com.coliving.user.contract.adapter.out.jpa.ContractJpaRepository;
 import com.coliving.user.contract.model.ContractStatus;
@@ -19,6 +20,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -39,6 +43,7 @@ import java.util.Objects;
 public class ReservationCommandService implements ReservationCommandUseCase {
 
     private static final long MAX_RESERVATION_MINUTES = 120;
+    private static final long SLOT_MINUTES = 30;
 
     private final ReservationJpaRepository reservationRepository;
     private final UserJpaRepository userRepository;
@@ -60,10 +65,8 @@ public class ReservationCommandService implements ReservationCommandUseCase {
     @Override
     @Transactional
     public Long reserveFacility(Long userId, ReservationCreateRequestDto request) {
-        // 1. 시간 범위 유효성 검사
-        if (!request.isValidTimeRange()) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "종료 시간은 시작 시간보다 이후여야 합니다.");
-        }
+        // 1. 시간 범위/연속성(30분 단위) 유효성 검사
+        validateSlotSequence(request);
 
         // 2. 요청 사용자 조회
         Objects.requireNonNull(userId, "userId는 null일 수 없습니다.");
@@ -79,19 +82,36 @@ public class ReservationCommandService implements ReservationCommandUseCase {
         ContractEntity activeContract = contractJpaRepository.findByUserIdAndStatus(userId, ContractStatus.ACTIVE)
                 .stream()
                 .findFirst()
-                .orElseThrow(() -> new BusinessException(ErrorCode.NO_ACTIVE_CONTRACT, "유효한 활성 계약이 없어 예약할 수 없습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN, "입주자만 공용시설을 예약할 수 있습니다."));
 
         if (activeContract.getEndDate() == null) {
-            throw new BusinessException(ErrorCode.NO_ACTIVE_CONTRACT, "유효한 활성 계약 종료일이 없어 예약할 수 없습니다.");
+            throw new BusinessException(ErrorCode.FORBIDDEN, "입주자만 공용시설을 예약할 수 있습니다.");
         }
 
         if (request.getReservationDate().isAfter(activeContract.getEndDate())) {
             throw new BusinessException(ErrorCode.VALIDATION_ERROR, "입주 기간 종료로 인해 예약이 불가능합니다");
         }
 
-        // 5. 최대 이용 시간(2시간) 검증
-        if (!request.isWithinMaxUsageMinutes(MAX_RESERVATION_MINUTES)) {
-            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "공용시설 예약은 최대 2시간까지만 가능합니다.");
+        // 5. 일일 최대 이용 시간(2시간) 검증 (프론트 UI 차단과 별개로 서버에서 재검증)
+        long requestedMinutes = ChronoUnit.MINUTES.between(request.getStartTime(), request.getEndTime());
+        if (requestedMinutes > MAX_RESERVATION_MINUTES) {
+            throw new BusinessException(ErrorCode.DAILY_LIMIT_EXCEEDED, "하루 최대 2시간까지만 예약할 수 있습니다.");
+        }
+
+        List<ReservationStatus> countableStatuses = List.of(
+                ReservationStatus.PENDING,
+                ReservationStatus.APPROVED,
+                ReservationStatus.COMPLETED
+        );
+
+        long alreadyReservedMinutes = reservationRepository
+                .findByUser_UserIdAndReservationDateAndStatusIn(userId, request.getReservationDate(), countableStatuses)
+                .stream()
+                .mapToLong(r -> ChronoUnit.MINUTES.between(r.getStartTime(), r.getEndTime()))
+                .sum();
+
+        if (alreadyReservedMinutes + requestedMinutes > MAX_RESERVATION_MINUTES) {
+            throw new BusinessException(ErrorCode.DAILY_LIMIT_EXCEEDED, "하루 최대 2시간까지만 예약할 수 있습니다.");
         }
 
         // 6. 동시성 체크: 해당 시간에 APPROVED 중복 예약 여부 확인
@@ -125,6 +145,33 @@ public class ReservationCommandService implements ReservationCommandUseCase {
                 savedReservation.getId(), savedReservation.getSpaceId(), savedReservation.getUserId());
 
         return savedReservation.getId();
+    }
+
+    private void validateSlotSequence(ReservationCreateRequestDto request) {
+        if (request.getStartTime() == null || request.getEndTime() == null) {
+            throw new BusinessException(ErrorCode.VALIDATION_ERROR, "시작/종료 시간은 필수입니다.");
+        }
+
+        LocalTime startTime = request.getStartTime();
+        LocalTime endTime = request.getEndTime();
+
+        if (!endTime.isAfter(startTime)) {
+            throw new BusinessException(ErrorCode.INVALID_SEQUENCE, "종료 시간은 시작 시간보다 이후여야 합니다.");
+        }
+
+        if (!isSlotAligned(startTime) || !isSlotAligned(endTime)) {
+            throw new BusinessException(ErrorCode.INVALID_SEQUENCE, "예약 시간은 30분 단위로 선택해야 합니다.");
+        }
+
+        long minutes = ChronoUnit.MINUTES.between(startTime, endTime);
+        if (minutes <= 0 || minutes % SLOT_MINUTES != 0) {
+            throw new BusinessException(ErrorCode.INVALID_SEQUENCE, "시간 선택이 올바르지 않습니다. 연속된 30분 단위로 선택해 주세요.");
+        }
+    }
+
+    private boolean isSlotAligned(LocalTime time) {
+        if (time.getSecond() != 0 || time.getNano() != 0) return false;
+        return time.getMinute() % SLOT_MINUTES == 0;
     }
 
     /**

--- a/frontend/src/app/(resident-app)/facilities/_components/ReservationAccessGateModal.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/ReservationAccessGateModal.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useRouter } from "next/navigation";
+
+type GateReason = "LOGIN_REQUIRED" | "RESIDENT_ONLY";
+
+interface ReservationAccessGateModalProps {
+  isOpen: boolean;
+  reason: GateReason;
+  onClose: () => void;
+}
+
+export function ReservationAccessGateModal({
+  isOpen,
+  reason,
+  onClose,
+}: ReservationAccessGateModalProps) {
+  const router = useRouter();
+
+  const content =
+    reason === "LOGIN_REQUIRED"
+      ? {
+          title: "로그인이 필요합니다",
+          message: "예약 기능은 로그인 후 이용할 수 있어요. 회원가입 후 바로 예약을 진행해보세요.",
+          primary: { label: "회원가입", href: "/register" },
+          secondary: { label: "로그인", href: "/login" },
+        }
+      : {
+          title: "입주자 전용 기능입니다",
+          message: "공용시설 예약은 입주자(RESIDENT)만 이용할 수 있어요. 방을 둘러보고 입주 신청을 진행해보세요.",
+          primary: { label: "방 알아보러 가기", href: "/rooms" },
+          secondary: { label: "입주 신청", href: "/contract-apply" },
+        };
+
+  const handleGo = (href: string) => {
+    onClose();
+    router.push(href);
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <div className="fixed inset-0 z-[140] flex items-center justify-center p-4 md:p-6">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="absolute inset-0 bg-primary/35 backdrop-blur-sm"
+            onClick={onClose}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, y: 18, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 18, scale: 0.97 }}
+            transition={{ type: "spring", damping: 24, stiffness: 280 }}
+            className="relative w-full max-w-md rounded-[2rem] border border-border bg-background p-6 shadow-2xl md:p-8"
+          >
+            <div className="space-y-3">
+              <p className="text-[10px] font-black uppercase tracking-[0.28em] text-muted-foreground">
+                Reservation Access
+              </p>
+              <h3 className="text-2xl font-black tracking-tight text-foreground">
+                {content.title}
+              </h3>
+              <p className="rounded-[1.5rem] border border-border bg-muted/15 px-5 py-4 text-sm font-medium leading-6 text-foreground/80">
+                {content.message}
+              </p>
+            </div>
+
+            <div className="mt-8 grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => handleGo(content.secondary.href)}
+                className="w-full rounded-xl border border-border bg-muted/10 px-5 py-3 text-sm font-black tracking-tight text-foreground transition hover:bg-muted/20"
+              >
+                {content.secondary.label}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleGo(content.primary.href)}
+                className="w-full rounded-xl bg-primary px-5 py-3 text-sm font-black tracking-tight text-primary-foreground transition hover:opacity-90"
+              >
+                {content.primary.label}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      ) : null}
+    </AnimatePresence>
+  );
+}
+

--- a/frontend/src/app/(resident-app)/facilities/_components/ReservationRequestModal.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/ReservationRequestModal.tsx
@@ -9,8 +9,6 @@ interface ReservationRequestModalProps {
   startLabel: string;
   endLabel: string;
   durationMinutes: number;
-  startIso: string;
-  endIso: string;
   onClose: () => void;
   onSubmit: (form: { purpose: string; notes: string }) => Promise<void> | void;
   isSubmitting?: boolean;
@@ -22,8 +20,6 @@ export function ReservationRequestModal({
   startLabel,
   endLabel,
   durationMinutes,
-  startIso,
-  endIso,
   onClose,
   onSubmit,
   isSubmitting = false,
@@ -90,10 +86,6 @@ export function ReservationRequestModal({
               <p className="mt-1 text-xs font-medium text-muted-foreground">
                 이용 시간 {durationMinutes}분
               </p>
-              <div className="mt-4 space-y-2 rounded-xl bg-background/80 p-3 text-xs font-medium text-muted-foreground">
-                <p>Start ISO: {startIso}</p>
-                <p>End ISO: {endIso}</p>
-              </div>
             </div>
 
             <div className="mt-6 space-y-4">

--- a/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
+++ b/frontend/src/app/(resident-app)/facilities/_components/WeeklyTimetable.tsx
@@ -10,8 +10,10 @@ import { ChevronLeft, ChevronRight, CalendarDays } from "lucide-react";
 import { fetchTimeSlots, createReservation } from "../_api";
 import type { Facility } from "../_types";
 import { ApiError } from "@/lib/api";
+import { useAuthStore } from "@/store/useAuthStore";
 import { ReservationRequestModal } from "./ReservationRequestModal";
 import { ReservationBlockedModal } from "./ReservationBlockedModal";
+import { ReservationAccessGateModal } from "./ReservationAccessGateModal";
 
 
 // ──────────────────────────────────────────
@@ -235,17 +237,20 @@ interface SlotCellProps {
   slotData?: SlotData;
   isSelected: boolean;
   isPast: boolean;
+  isBlocked?: boolean;
   onPointerDown: () => void;
   onPointerEnter: () => void;
 }
 
-function SlotCell({ slotData, isSelected, isPast, onPointerDown, onPointerEnter }: SlotCellProps) {
+function SlotCell({ slotData, isSelected, isPast, isBlocked = false, onPointerDown, onPointerEnter }: SlotCellProps) {
   const status = slotData?.status ?? "AVAILABLE";
 
   const baseClass = "h-8 w-full cursor-pointer rounded-lg border transition-all duration-150";
 
   const statusClass = isPast
     ? "border-transparent bg-muted/20 cursor-not-allowed opacity-40"
+    : isBlocked
+    ? "border-border/40 bg-muted/10 cursor-not-allowed opacity-60"
     : isSelected
     ? "border-primary bg-primary scale-[1.04] shadow-sm shadow-primary/30 cursor-pointer"
     : status === "MY_RESERVATION"
@@ -256,13 +261,14 @@ function SlotCell({ slotData, isSelected, isPast, onPointerDown, onPointerEnter 
 
   return (
     <motion.div
-      whileHover={!isPast && status === "AVAILABLE" ? { scale: 1.05 } : undefined}
-      whileTap={!isPast && status === "AVAILABLE" ? { scale: 0.95 } : undefined}
+      whileHover={!isPast && !isBlocked && status === "AVAILABLE" ? { scale: 1.05 } : undefined}
+      whileTap={!isPast && !isBlocked && status === "AVAILABLE" ? { scale: 0.95 } : undefined}
       className={`${baseClass} ${statusClass}`}
       onPointerDown={!isPast && status === "AVAILABLE" ? onPointerDown : undefined}
       onPointerEnter={!isPast ? onPointerEnter : undefined}
       title={
         isPast ? "지난 시간" :
+        isBlocked ? "로그인/입주자 권한 필요" :
         status === "MY_RESERVATION" ? "내 예약" :
         status === "OCCUPIED" ? "이미 예약된 시간" :
         isSelected ? "선택 취소" : "클릭하여 선택"
@@ -280,22 +286,6 @@ interface WeeklyTimetableProps {
   onReserved?: () => void;
 }
 
-function getUtcOffsetString(date: Date): string {
-  const offsetMinutes = -date.getTimezoneOffset();
-  const sign = offsetMinutes >= 0 ? "+" : "-";
-  const abs = Math.abs(offsetMinutes);
-  const hours = String(Math.floor(abs / 60)).padStart(2, "0");
-  const minutes = String(abs % 60).padStart(2, "0");
-  return `${sign}${hours}:${minutes}`;
-}
-
-function buildLocalIso(dateStr: string, timeStr: string): string {
-  const [year, month, day] = dateStr.split("-").map(Number);
-  const [hours, minutes, seconds = 0] = timeStr.split(":").map(Number);
-  const localDate = new Date(year, month - 1, day, hours, minutes, seconds, 0);
-  return `${dateStr}T${timeStr}${getUtcOffsetString(localDate)}`;
-}
-
 function getTimeValue(time: string): number {
   const [hours, minutes] = time.split(":").map(Number);
   return hours * 60 + minutes;
@@ -306,6 +296,7 @@ function isSelectableSlot(slotData?: SlotData, isPast?: boolean) {
 }
 
 export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) {
+  const { isLoggedIn, user, isLoading: authLoading } = useAuthStore();
   const [weekStart, setWeekStart] = useState<Date>(() => getWeekStart(new Date()));
   const [timetable, setTimetable] = useState<TimetableData>({});
   const [loading, setLoading] = useState(false);
@@ -318,11 +309,42 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
   const [feedback, setFeedback] = useState<{ type: "success" | "error"; msg: string } | null>(null);
   const [isReservationModalOpen, setIsReservationModalOpen] = useState(false);
   const [blockedReservationMessage, setBlockedReservationMessage] = useState<string | null>(null);
+  const [limitReservationMessage, setLimitReservationMessage] = useState<string | null>(null);
+  const [accessGate, setAccessGate] = useState<{ open: boolean; reason: "LOGIN_REQUIRED" | "RESIDENT_ONLY" }>({
+    open: false,
+    reason: "LOGIN_REQUIRED",
+  });
   const [dragState, setDragState] = useState<{ active: boolean; anchorDate: string | null; anchorTime: string | null }>({
     active: false,
     anchorDate: null,
     anchorTime: null,
   });
+
+  const canReserve = isLoggedIn && user?.role === "RESIDENT";
+
+  const openAccessGate = useCallback(() => {
+    if (authLoading) return;
+    setAccessGate({
+      open: true,
+      reason: isLoggedIn ? "RESIDENT_ONLY" : "LOGIN_REQUIRED",
+    });
+  }, [authLoading, isLoggedIn]);
+
+  const openLimitModal = useCallback((message: string) => {
+    setLimitReservationMessage((prev) => prev ?? message);
+  }, []);
+
+  const getMyReservedMinutesForDate = useCallback((date: string) => {
+    const day = timetable[date];
+    if (!day) return 0;
+    const reservedSlotCount = Object.values(day).filter((slot) => slot.status === "MY_RESERVATION").length;
+    return reservedSlotCount * SLOT_MINUTES;
+  }, [timetable]);
+
+  const getMaxSelectableSlotCountForDate = useCallback((date: string) => {
+    const remainingMinutes = MAX_RESERVATION_MINUTES - getMyReservedMinutesForDate(date);
+    return Math.max(0, Math.floor(remainingMinutes / SLOT_MINUTES));
+  }, [getMyReservedMinutesForDate]);
 
   // 이번 주 날짜 배열
   const weekDates = Array.from({ length: 7 }, (_, i) => {
@@ -336,6 +358,15 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
 
   // 타임슬롯 로드
   const loadSlots = useCallback(async () => {
+    if (!canReserve) {
+      // 비회원/비입주자: 타임테이블 API 자체가 차단되므로, UX 유도 모달로 안내
+      setLoading(false);
+      setError(null);
+      setTimetable({});
+      openAccessGate();
+      return;
+    }
+
     setLoading(true);
     setError(null);
     setSelectedSlots([]);
@@ -343,12 +374,21 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
       const res = await fetchTimeSlots(facility.spaceId, toDateStr(weekStart));
       setTimetable(parseSlots(res.data ?? {}));
     } catch (e) {
-      if (e instanceof ApiError) setError(e.message);
-      else setError("예약 현황을 불러올 수 없습니다.");
+      if (e instanceof ApiError) {
+        if (e.errorCode === "UNAUTHORIZED" || e.errorCode === "FORBIDDEN") {
+          setTimetable({});
+          setError(null);
+          openAccessGate();
+          return;
+        }
+        setError(e.message);
+      } else {
+        setError("예약 현황을 불러올 수 없습니다.");
+      }
     } finally {
       setLoading(false);
     }
-  }, [facility.spaceId, weekStart]);
+  }, [canReserve, facility.spaceId, openAccessGate, weekStart]);
 
   useEffect(() => {
     loadSlots();
@@ -374,6 +414,12 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
   const updateDraggedSelection = useCallback((date: string, targetTime: string) => {
     setDragState((currentDrag) => {
       if (!currentDrag.active || currentDrag.anchorDate !== date || !currentDrag.anchorTime) {
+        return currentDrag;
+      }
+
+      const maxSlotCountForDay = getMaxSelectableSlotCountForDate(date);
+      if (maxSlotCountForDay <= 0) {
+        openLimitModal("오늘은 이미 최대 2시간 예약했습니다.");
         return currentDrag;
       }
 
@@ -405,10 +451,11 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
       const targetIndex = TIME_SLOTS.indexOf(targetTime);
       const requestedSlotCount = Math.abs(targetIndex - anchorIndex) + 1;
 
-      if (requestedSlotCount > MAX_SLOT_COUNT) {
+      const effectiveMaxSlotCount = Math.min(MAX_SLOT_COUNT, maxSlotCountForDay);
+      if (requestedSlotCount > effectiveMaxSlotCount) {
         exceededMaxDuration = true;
         const limitedSelection: { date: string; time: string }[] = [];
-        for (let step = 0; step < MAX_SLOT_COUNT; step += 1) {
+        for (let step = 0; step < effectiveMaxSlotCount; step += 1) {
           const slotIndex = anchorIndex + step * direction;
           const time = TIME_SLOTS[slotIndex];
           if (!time) break;
@@ -432,23 +479,80 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
       }
 
       if (exceededMaxDuration) {
-        setFeedback({
-          type: "error",
-          msg: "최대 2시간까지만 선택할 수 있습니다.",
-        });
+        const remainingMinutes = MAX_RESERVATION_MINUTES - getMyReservedMinutesForDate(date);
+        openLimitModal(`오늘 남은 예약 가능 시간은 최대 ${remainingMinutes}분입니다.`);
       }
 
       return currentDrag;
     });
-  }, [nowTime, timetable, today]);
+  }, [getMaxSelectableSlotCountForDate, getMyReservedMinutesForDate, nowTime, openLimitModal, timetable, today]);
 
   const handleSelectionStart = (date: string, time: string, slotData?: SlotData, isPast?: boolean) => {
+    if (!canReserve) {
+      openAccessGate();
+      return;
+    }
+
     if (!isSelectableSlot(slotData, isPast)) {
       setFeedback({ type: "error", msg: "선택할 수 없는 슬롯입니다." });
       return;
     }
 
-    setSelectedSlots([{ date, time }]);
+    // 같은 슬롯 단독 클릭 → 토글(해제)
+    if (selectedSlots.length === 1 && selectedSlots[0]?.date === date && selectedSlots[0]?.time === time) {
+      setSelectedSlots([]);
+      setDragState({ active: false, anchorDate: null, anchorTime: null });
+      return;
+    }
+
+    const maxSlotCountForDay = getMaxSelectableSlotCountForDate(date);
+    if (maxSlotCountForDay <= 0) {
+      openLimitModal("오늘은 이미 최대 2시간 예약했습니다.");
+      return;
+    }
+
+    setSelectedSlots((current) => {
+      const sameDay = current.length > 0 && current[0]?.date === date;
+      const selectedTimes = sameDay ? current.map((s) => s.time) : [];
+      const alreadySelected = selectedTimes.includes(time);
+
+      // 날짜가 다르거나 비어있으면 새로 시작
+      if (!sameDay || current.length === 0) {
+        return [{ date, time }];
+      }
+
+      // 이미 선택된 슬롯 재클릭 → 해당 슬롯 기준으로 단일 선택으로 리셋
+      if (alreadySelected) {
+        return [{ date, time }];
+      }
+
+      // 연속성 검증: 시작/끝에만 30분 단위로 붙일 수 있음
+      const sorted = [...current].sort((a, b) => getTimeValue(a.time) - getTimeValue(b.time));
+      const startTime = sorted[0]!.time;
+      const endTime = sorted[sorted.length - 1]!.time;
+      const timeValue = getTimeValue(time);
+      const startValue = getTimeValue(startTime);
+      const endValue = getTimeValue(endTime);
+
+      const canPrepend = timeValue === startValue - SLOT_MINUTES;
+      const canAppend = timeValue === endValue + SLOT_MINUTES;
+
+      if (!canPrepend && !canAppend) {
+        setFeedback({ type: "error", msg: "여러 슬롯은 시간 순서대로 끊기지 않게(연속) 선택해야 합니다." });
+        return current;
+      }
+
+      if (current.length + 1 > Math.min(MAX_SLOT_COUNT, maxSlotCountForDay)) {
+        const remainingMinutes = MAX_RESERVATION_MINUTES - getMyReservedMinutesForDate(date);
+        openLimitModal(`오늘 남은 예약 가능 시간은 최대 ${remainingMinutes}분입니다.`);
+        return current;
+      }
+
+      const next = [...current, { date, time }];
+      return next.sort((a, b) => getTimeValue(a.time) - getTimeValue(b.time));
+    });
+
+    // pointerdown 기반 드래그(선택 확장) 지원
     setDragState({ active: true, anchorDate: date, anchorTime: time });
   };
 
@@ -471,13 +575,15 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
         date: selectedDate,
         startTime: `${selectedStart}:00`,
         endTime: `${selectedEnd}:00`,
-        startIso: buildLocalIso(selectedDate, `${selectedStart}:00`),
-        endIso: buildLocalIso(selectedDate, `${selectedEnd}:00`),
       }
     : null;
 
   const handleReserve = async (_form: { purpose: string; notes: string }) => {
     if (!reservationWindow) return;
+    if (!canReserve) {
+      openAccessGate();
+      return;
+    }
     setBooking(true);
     try {
       await createReservation({
@@ -493,12 +599,34 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
       onReserved?.();
     } catch (e) {
       if (e instanceof ApiError) {
+        if (e.errorCode === "UNAUTHORIZED") {
+          setIsReservationModalOpen(false);
+          setSelectedSlots([]);
+          openAccessGate();
+          return;
+        }
+        if (e.errorCode === "FORBIDDEN" || e.errorCode === "NO_ACTIVE_CONTRACT") {
+          setIsReservationModalOpen(false);
+          setSelectedSlots([]);
+          setAccessGate({ open: true, reason: "RESIDENT_ONLY" });
+          return;
+        }
+        if (e.errorCode === "DAILY_LIMIT_EXCEEDED") {
+          setIsReservationModalOpen(false);
+          setSelectedSlots([]);
+          openLimitModal(e.message);
+          return;
+        }
+        if (e.errorCode === "INVALID_SEQUENCE") {
+          setFeedback({ type: "error", msg: e.message });
+          return;
+        }
         if (e.message.includes("입주 기간 종료로 인해 예약이 불가능합니다")) {
           setIsReservationModalOpen(false);
           setBlockedReservationMessage("계약 종료 이후에는 공용시설 예약이 불가능합니다. 계약 기간을 확인해주세요.");
-        } else {
-          setFeedback({ type: "error", msg: e.message });
+          return;
         }
+        setFeedback({ type: "error", msg: e.message });
       } else {
         setFeedback({ type: "error", msg: "예약 신청에 실패했습니다." });
       }
@@ -641,8 +769,10 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
                 // 시간 레이블 셀
                 <div
                   key={`label-${time}`}
-                  className={`sticky left-0 flex items-center justify-end border-b border-border/40 bg-surface pr-2 ${
-                    isHourMark ? "text-[10px] font-semibold text-muted-foreground" : ""
+                  className={`sticky left-0 flex items-center justify-end bg-surface pr-2 ${
+                    isHourMark
+                      ? "border-b-2 border-border/70 text-[10px] font-semibold text-muted-foreground"
+                      : "border-b border-border/30"
                   }`}
                   style={{ minHeight: "2rem" }}
                 >
@@ -661,12 +791,15 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
                   return (
                     <div
                       key={`${dateStr}-${time}`}
-                      className="border-b border-l border-border/30 p-0.5"
+                      className={`border-l border-border/30 p-0.5 ${
+                        isHourMark ? "border-b-2 border-border/70" : "border-b border-border/30"
+                      }`}
                     >
                       <SlotCell
                         slotData={slotData}
                         isSelected={isSelected}
                         isPast={isPast}
+                        isBlocked={!canReserve}
                         onPointerDown={() => handleSelectionStart(dateStr, time, slotData, isPast)}
                         onPointerEnter={() => handleSelectionEnter(dateStr, time)}
                       />
@@ -700,7 +833,7 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
               </p>
               {reservationWindow ? (
                 <p className="text-[11px] font-medium text-muted-foreground/80">
-                  {reservationWindow.startIso} → {reservationWindow.endIso}
+                  {reservationWindow.startTime} → {reservationWindow.endTime}
                 </p>
               ) : null}
             </div>
@@ -742,8 +875,6 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
           startLabel={`${reservationWindow.date} ${selectedStart}`}
           endLabel={`${reservationWindow.date} ${selectedEnd}`}
           durationMinutes={selectedSlots.length * SLOT_MINUTES}
-          startIso={reservationWindow.startIso}
-          endIso={reservationWindow.endIso}
           onClose={() => setIsReservationModalOpen(false)}
           onSubmit={handleReserve}
           isSubmitting={booking}
@@ -754,6 +885,19 @@ export function WeeklyTimetable({ facility, onReserved }: WeeklyTimetableProps) 
         isOpen={blockedReservationMessage !== null}
         message={blockedReservationMessage ?? ""}
         onClose={() => setBlockedReservationMessage(null)}
+      />
+
+      <ReservationBlockedModal
+        isOpen={limitReservationMessage !== null}
+        title="예약 시간 제한"
+        message={limitReservationMessage ?? ""}
+        onClose={() => setLimitReservationMessage(null)}
+      />
+
+      <ReservationAccessGateModal
+        isOpen={accessGate.open}
+        reason={accessGate.reason}
+        onClose={() => setAccessGate((prev) => ({ ...prev, open: false }))}
       />
     </div>
   );


### PR DESCRIPTION
- 비로그인/비입주자 예약 차단 + 유도 모달(회원가입/로그인, 방 알아보러 가기/입주 신청)
- start_iso/end_iso 관련 프론트 표시/로직 제거
- 단독 클릭으로 슬롯 선택(토글/확장) + 연속성 검증
- 1인 1일 최대 2시간 제한(프론트 UI + 백엔드 검증)
- 에러코드 분리: DAILY_LIMIT_EXCEEDED, INVALID_SEQUENCE, TIME_SLOT_CONFLICT(기존)

테스트:
- 비로그인/비입주자: facilities에서 타임테이블 접근 시 모달 유도
- 클릭/드래그로 2시간 초과 시 제한 모달 노출
- 비연속 선택/중복예약/일일합산 초과 케이스 처리 확인