### PR TITLE
Fix: 관리자 배치 에디터와 사용자 층별 안내의 층 표시 기준 불일치 해결

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/DataInitializer.java
@@ -641,10 +641,18 @@ public class DataInitializer implements ApplicationRunner {
 
     private void saveSpaceImageIfNotExists(
             SpaceEntity space, String imageUrl, ImageType imageType, int sortOrder, boolean thumbnail) {
-        boolean exists = spaceImageJpaRepository.findAll().stream()
-                .anyMatch(img -> img.getSpace().getSpaceId().equals(space.getSpaceId())
-                        && imageUrl.equals(img.getImageUrl()));
+        
+        java.util.List<com.coliving.admin.space.adapter.out.jpa.SpaceImageEntity> existingImages = spaceImageJpaRepository.findBySpace_SpaceId(space.getSpaceId());
+        
+        // 이전 테스트에서 남겨진 잘못된 로컬 더미 이미지 일괄 삭제
+        existingImages.stream()
+                .filter(img -> img.getImageUrl().startsWith("/api/uploads/") && img.getImageUrl().endsWith(".png"))
+                .forEach(spaceImageJpaRepository::delete);
+
+        boolean exists = existingImages.stream()
+                .anyMatch(img -> imageUrl.equals(img.getImageUrl()));
         if (exists) return;
+        
         spaceImageJpaRepository.save(SpaceImageEntity.builder()
                 .space(space)
                 .imageUrl(imageUrl)

--- a/backend/src/main/java/com/coliving/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/DataInitializer.java
@@ -641,18 +641,10 @@ public class DataInitializer implements ApplicationRunner {
 
     private void saveSpaceImageIfNotExists(
             SpaceEntity space, String imageUrl, ImageType imageType, int sortOrder, boolean thumbnail) {
-        
-        java.util.List<com.coliving.admin.space.adapter.out.jpa.SpaceImageEntity> existingImages = spaceImageJpaRepository.findBySpace_SpaceId(space.getSpaceId());
-        
-        // 이전 테스트에서 남겨진 잘못된 로컬 더미 이미지 일괄 삭제
-        existingImages.stream()
-                .filter(img -> img.getImageUrl().startsWith("/api/uploads/") && img.getImageUrl().endsWith(".png"))
-                .forEach(spaceImageJpaRepository::delete);
-
-        boolean exists = existingImages.stream()
-                .anyMatch(img -> imageUrl.equals(img.getImageUrl()));
+        boolean exists = spaceImageJpaRepository.findAll().stream()
+                .anyMatch(img -> img.getSpace().getSpaceId().equals(space.getSpaceId())
+                        && imageUrl.equals(img.getImageUrl()));
         if (exists) return;
-        
         spaceImageJpaRepository.save(SpaceImageEntity.builder()
                 .space(space)
                 .imageUrl(imageUrl)

--- a/backend/src/main/java/com/coliving/user/floor/adapter/out/persistence/FloorViewPersistenceAdapter.java
+++ b/backend/src/main/java/com/coliving/user/floor/adapter/out/persistence/FloorViewPersistenceAdapter.java
@@ -45,16 +45,12 @@ public class FloorViewPersistenceAdapter implements FloorViewRepositoryPort {
         Map<Integer, FloorPlanEntity> plansByFloor = floorPlanJpaRepository.findAll().stream()
                 .collect(Collectors.toMap(FloorPlanEntity::getFloor, fp -> fp, (a, b) -> a));
 
-        // 3. 공간 또는 floor_plan이 존재하는 모든 층 번호 수집
-        TreeMap<Integer, Object> allFloors = new TreeMap<>();
-        spacesByFloor.keySet().forEach(f -> allFloors.put(f, null));
-        plansByFloor.keySet().forEach(f -> allFloors.put(f, null));
-
+        // 3. 공간이 존재하는 층만 표시 (관리자 에디터와 동일한 기준)
         // 4. 층별로 FloorView 생성
         List<FloorView> result = new ArrayList<>();
-        for (Integer floor : allFloors.keySet()) {
+        for (Integer floor : spacesByFloor.keySet()) {
             FloorPlanEntity plan = plansByFloor.get(floor);
-            List<SpaceEntity> spaces = spacesByFloor.getOrDefault(floor, Collections.emptyList());
+            List<SpaceEntity> spaces = spacesByFloor.get(floor);
 
             result.add(FloorView.builder()
                     .floor(floor)

--- a/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
+++ b/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts
@@ -63,11 +63,12 @@ export function extractRoomTypeName(space: SpaceDTO): string | undefined {
   return space.roomTypeName || nested?.roomTypeName;
 }
 
-export const fetchSpaces = async (params?: { type?: string; status?: string; sort?: string }) => {
+export const fetchSpaces = async (params?: { type?: string; status?: string; sort?: string; size?: number }) => {
   const query = new URLSearchParams();
   if (params?.type && params.type !== 'ALL') query.append('type', params.type);
   if (params?.status && params.status !== 'ALL') query.append('status', params.status);
   if (params?.sort) query.append('sort', params.sort);
+  if (params?.size) query.append('size', String(params.size));
   
   const queryString = query.toString() ? `?${query.toString()}` : '';
   const res = await apiFetch<any>(`/admin/spaces${queryString}`);

--- a/frontend/src/app/admin/spaces/_hooks/useFloorPlan.ts
+++ b/frontend/src/app/admin/spaces/_hooks/useFloorPlan.ts
@@ -56,7 +56,7 @@ export function useFloorPlan() {
   const loadSpaces = useCallback(async () => {
     try {
       setLoading(true);
-      const res = await fetchSpaces();
+      const res = await fetchSpaces({ size: 500 });
       const spaces: SpaceDTO[] = res.data?.content || res.data || [];
       setAllSpaces(spaces);
 


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자의 [도면 배치 에디터]와 사용자의 [층별 안내] 뷰어에서 층(Floor)을 감지하고 표시하는 기준이 서로 달라, 공간 삭제 후에도 유저 페이지에서 빈 도면이 계속 보여지는 오류가 있었습니다.
- 또한 관리자 페이지에 20개가 넘는 데이터가 존재할 경우, 일부 데이터가 페이징에 의해 잘려나가 도면 층 목록(예: 10층) 자체가 누락되는 백오피스 버그를 해결하기 위함입니다.

## 🔑 주요 변경 사항 (What)
- **배치 에디터 페이징 데이터 누락 픽스 ([spaceAdminApi.ts](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts:0:0-0:0), [useFloorPlan.ts](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_hooks/useFloorPlan.ts:0:0-0:0))**
  - 관리자 도면 배치 화면에서 전체 공간을 한 번에 가져올 수 있도록 [fetchSpaces](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts:65:0-82:2) 호출 API에 `size=500` 파라미터를 추가 전송하여, 전체 공간과 층 목록이 정상적으로 다 로드되도록 조치했습니다.
- **사용자 층별 뷰어 표시 기준 동기화 ([FloorViewPersistenceAdapter.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/user/floor/adapter/out/persistence/FloorViewPersistenceAdapter.java:0:0-0:0))**
  - 사용자(Public)가 보는 층별 뷰어의 응답 로직을 수정했습니다. 배경 도면(FloorPlan) 데이터만 잔존하더라도 무조건 띄우던 기존 방식에서 벗어나, **물리적인 "공간(Space)"이 1개 이상 존재하는 층만 렌더링**하도록 관리자 에디터의 조건과 완벽하게 일치시켰습니다.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305 (해당할 경우 번호 기입)

## 💻 테스트 방법 (How to Test)
1. 로컬 환경에서 도커 또는 애플리케이션을 기동합니디.
2. 관리자 페이지 > [공간 관리]에서 특정 층의 방(예: 10층 파티룸)을 완전히 삭제해 봅니다.
3. 관리자 [공간 배치] 에디터 화면과 비로그인 접속자의 [층별 안내] 화면 모두에서 10층 탭이 깔끔하게 동시에 사라지는지 확인합니다.
4. 관리자 [공간 관리]에서 다시 10층 호실을 추가하면 양쪽 화면에 한 번에 다시 나타나는지 동기화 여부를 검증합니다.

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?