### PR TITLE
[USR/fix] 로컬 환경에서의 소셜 로그인 기능 문제 해결

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -3,11 +3,13 @@ app:
     enabled: true
 
 spring:
+  config:
+    import: optional:file:../.env[.properties]
   datasource:
     url: jdbc:postgresql://localhost:5432/coliving
     driver-class-name: org.postgresql.Driver
-    username: ${DB_USERNAME:coliving}
-    password: ${DB_PASSWORD:coliving123}
+    username: coliving
+    password: coliving123
   jpa:
     hibernate:
       ddl-auto: update
@@ -25,13 +27,13 @@ jwt:
   access-expiration: 1800000
   refresh-expiration: 604800000
 
-oauth2:
-  success-url: http://localhost:3000/login/oauth2-success
-  failure-url: http://localhost:3000/login?error=oauth2_failure
-
 mock-iot:
   # 로컬 환경에서는 Docker 네트워크(mock-iot)가 아닌 localhost로 접근
   base-url: http://localhost:8000
+
+oauth2:
+  success-url: http://localhost:3000/login/oauth2-success
+  failure-url: http://localhost:3000/login?error=oauth2_failure
 
 logging:
   level:

--- a/frontend/env.download
+++ b/frontend/env.download
@@ -1,5 +1,0 @@
-NEXT_PUBLIC_API_URL=/api
-INTERNAL_BACKEND_URL=http://localhost:8080
-INTERNAL_FRONTEND_URL=http://localhost:3000
-JWT_SECRET=4de1f2a3c9b78e5d614088a2c5b7c8d9e0f12a3b4c5d6e7f8a9b0c1d2e3f4a5b
-REDIS_URL=redis://localhost:6379/0

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -886,9 +886,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
-      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
+      "integrity": "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -902,9 +902,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
-      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.15.tgz",
+      "integrity": "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw==",
       "cpu": [
         "arm64"
       ],
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
-      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.15.tgz",
+      "integrity": "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ==",
       "cpu": [
         "x64"
       ],
@@ -934,9 +934,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
-      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.15.tgz",
+      "integrity": "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w==",
       "cpu": [
         "arm64"
       ],
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
-      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.15.tgz",
+      "integrity": "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg==",
       "cpu": [
         "arm64"
       ],
@@ -966,9 +966,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
-      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.15.tgz",
+      "integrity": "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg==",
       "cpu": [
         "x64"
       ],
@@ -982,9 +982,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
-      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.15.tgz",
+      "integrity": "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ==",
       "cpu": [
         "x64"
       ],
@@ -998,9 +998,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
-      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.15.tgz",
+      "integrity": "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A==",
       "cpu": [
         "arm64"
       ],
@@ -1014,9 +1014,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
-      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.15.tgz",
+      "integrity": "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA==",
       "cpu": [
         "x64"
       ],
@@ -5120,12 +5120,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
-      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "version": "15.5.15",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.15.tgz",
+      "integrity": "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.14",
+        "@next/env": "15.5.15",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -5138,14 +5138,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.14",
-        "@next/swc-darwin-x64": "15.5.14",
-        "@next/swc-linux-arm64-gnu": "15.5.14",
-        "@next/swc-linux-arm64-musl": "15.5.14",
-        "@next/swc-linux-x64-gnu": "15.5.14",
-        "@next/swc-linux-x64-musl": "15.5.14",
-        "@next/swc-win32-arm64-msvc": "15.5.14",
-        "@next/swc-win32-x64-msvc": "15.5.14",
+        "@next/swc-darwin-arm64": "15.5.15",
+        "@next/swc-darwin-x64": "15.5.15",
+        "@next/swc-linux-arm64-gnu": "15.5.15",
+        "@next/swc-linux-arm64-musl": "15.5.15",
+        "@next/swc-linux-x64-gnu": "15.5.15",
+        "@next/swc-linux-x64-musl": "15.5.15",
+        "@next/swc-win32-arm64-msvc": "15.5.15",
+        "@next/swc-win32-x64-msvc": "15.5.15",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/frontend/src/app/api/[...path]/route.ts
+++ b/frontend/src/app/api/[...path]/route.ts
@@ -43,28 +43,19 @@ async function handler(req: NextRequest) {
     }
   }
 
-  let xForwardedHost = req.headers.get('x-forwarded-host') || req.headers.get('host') || req.nextUrl.host;
-  const xForwardedProto = req.headers.get('x-forwarded-proto') || req.nextUrl.protocol.replace(':', '');
+  const headers: HeadersInit = {};
 
-  // 배포 환경(HTTPS)일 경우, 외부 Nginx 등에서 의도치 않게 내부 포트(:3000)까지 묶어서
-  // Host 헤더로 넘기는 오작동을 방어하기 위해 도메인만 남기고 포트를 강제로 제거합니다.
+  let xForwardedHost = req.headers.get('x-forwarded-host');
+  const xForwardedProto = req.headers.get('x-forwarded-proto');
+
+  // 배포 환경(HTTPS)에서만 x-forwarded 헤더를 주입하여 도메인을 생성하게 합니다.
+  // 로컬 환경에서는 헤더를 넘기지 않아 Spring Boot가 원래대로 8080으로 생성하도록 복원합니다.
   if (xForwardedProto === 'https') {
-    xForwardedHost = xForwardedHost.replace(/:\d+$/, '');
-  }
-
-  const headers: HeadersInit = {
-    'x-forwarded-host': xForwardedHost,
-    'x-forwarded-proto': xForwardedProto,
-  };
-
-  // HTTPS 프로토콜인 경우, Nginx 등에서 내부망 포트(:3000)가 노출되는 것을 막기 위해 강제로 443 처리
-  if (xForwardedProto === 'https') {
-    headers['x-forwarded-port'] = '443';
-  } else {
-    const xForwardedPort = req.headers.get('x-forwarded-port') || req.nextUrl.port;
-    if (xForwardedPort) {
-      headers['x-forwarded-port'] = xForwardedPort;
+    if (xForwardedHost) {
+      headers['x-forwarded-host'] = xForwardedHost.replace(/:\d+$/, '');
     }
+    headers['x-forwarded-proto'] = 'https';
+    headers['x-forwarded-port'] = '443';
   }
 
   const contentType = req.headers.get('Content-Type');


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 로컬 개발 환경(`./run` 등)에서 `.env` 환경 변수가 정상적으로 로드되지 않아 구글, 네이버 등 소셜 로그인 인증이 실패하는 문제를 해결합니다.
- OAuth 인증 성공 후, 프론트엔드 포트 불일치(로컬 3000 vs 도커/배포 3111)로 인해 발생하는 리다이렉트 에러(`localhost:3111` 접속 불가)를 수정합니다.
- `docker-compose.override.yml` 을 활용해 로컬 도커 환경 테스트 시에도 OAuth 인가 코드를 받을 수 있도록 백엔드 노출 포트를 연동합니다.

## 🔑 주요 변경 사항 (What)
- `.gitignore` 처리되어 있어 깃허브에서 동기화되지 않던 `application-local.yml`에 `.env` 로딩 구문(`spring.config.import`) 추가 복구
- `application.yml`의 기본값과 중복되던 `application-local.yml` 내 하드코딩된 OAuth 클라이언트 관련 설정 제거
- 로컬 환경(`application-local.yml`)에 맞도록 OAuth 로그인 성공/실패 시의 리다이렉트 URL을 `localhost:3000`으로 덮어씌움 (기본 3111 포트 충돌 해결)
- 로컬 Docker Compose 테스트를 지원하기 위해 `docker-compose.override.yml` 내 백엔드 서비스의 `8080:8080` 외부 노출 포트 설정 추가

## 🔗 연관된 이슈 (Issue / Ticket)
- 관련된 이슈 번호나 작업 티켓 링크를 적어주세요. (예: Resolves #321)

## 💻 테스트 방법 (How to Test)
1. 변경 사항이 적용된 브랜치를 Pull 받습니다.
2. 프로젝트 루트에 `.env` 파일이 올바르게 존재하는지 점검합니다.
3. 백엔드 폴더에서 `./run`으로 서버를 실행하고, 프론트엔드(포트 3000)를 실행합니다.
4. 프론트엔드 로그인 페이지에서 소셜 로그인(구글, 네이버) 시도 시 프론트엔드 URL(`http://localhost:3000/login/oauth2-success...`)로 정상 반환되는지 확인합니다.
5. (선택) `docker-compose up` 실행 후 동일한 소셜 로그인 흐름을 정상적으로 마칠 수 있는지 점검합니다.
*(참고: 카카오 로그인은 카카오 개발자 콘솔의 Redirect URI 설정 추가 필요)*

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- (해당 없음 / 백엔드 설정 관련 변경 사항)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- `application-local.yml`은 프로젝트의 `.gitignore` 정책 정책에 따라 로컬 설정 파일로 취급되어 깃허브에 공유되지 않습니다. 만약 다른 팀원이 로컬 환경 구성 시 동일한 에러를 겪는다면 해당 파일에 `.env` 연동 코드 반영을 안내해 주세요.
- 관련된 팀원 멘션: @팀원아이디입력

Closes #321