### PR TITLE
[SPC/fix] 시드 데이터 최적화 및 에러 해결

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/DataInitializer.java
@@ -465,7 +465,6 @@ public class DataInitializer implements ApplicationRunner {
     private void seedSpacesFromDevDataset() {
         RoomTypeEntity singleType = getOrCreateRoomType("SINGLE", "싱글룸");
         RoomTypeEntity doubleType = getOrCreateRoomType("DOUBLE", "더블룸");
-        RoomTypeEntity studioType = getOrCreateRoomType("STUDIO", "스튜디오");
         RoomTypeEntity suiteType = getOrCreateRoomType("SUITE", "스위트");
 
         // ═══════════ 1층 (101~103호) ═══════════
@@ -477,10 +476,7 @@ public class DataInitializer implements ApplicationRunner {
                 "102호", 1, new BigDecimal("26.00"), "[\"에어컨\",\"냉장고\",\"세탁기\"]", "1층 넓은 더블룸",
                 doubleType, 2, 1, "남향",
                 new BigDecimal("6000000"), new BigDecimal("580000"), new BigDecimal("50000"), true);
-        getOrCreatePrivateSpace(
-                "103호", 1, new BigDecimal("20.00"), "[\"에어컨\"]", "1층 스튜디오 (관리동 인접)",
-                studioType, 1, 1, "서향",
-                new BigDecimal("3500000"), new BigDecimal("380000"), new BigDecimal("38000"), false);
+
 
         // ═══════════ 2층 (201~203호) ═══════════
         getOrCreatePrivateSpace(
@@ -505,15 +501,12 @@ public class DataInitializer implements ApplicationRunner {
                 "302호", 3, new BigDecimal("30.00"), "[\"에어컨\",\"세탁기\",\"냉장고\"]", "복층 구조 더블룸",
                 doubleType, 2, 1, "동향",
                 new BigDecimal("8000000"), new BigDecimal("700000"), new BigDecimal("60000"), true);
-        getOrCreatePrivateSpace(
-                "303호", 3, new BigDecimal("22.00"), "[\"에어컨\",\"냉장고\"]", "3층 중앙 스튜디오",
-                studioType, 1, 1, "서향",
-                new BigDecimal("4200000"), new BigDecimal("430000"), new BigDecimal("42000"), false);
+
 
         // ═══════════ 4층 (401~403호) ═══════════
         getOrCreatePrivateSpace(
-                "401호", 4, new BigDecimal("20.00"), "[\"에어컨\"]", "깔끔한 스튜디오",
-                studioType, 1, 1, "서향",
+                "401호", 4, new BigDecimal("20.00"), "[\"에어컨\"]", "깔끔한 싱글룸",
+                singleType, 1, 1, "서향",
                 new BigDecimal("3000000"), new BigDecimal("400000"), new BigDecimal("40000"), false);
         getOrCreatePrivateSpace(
                 "402호", 4, new BigDecimal("28.00"), "[\"에어컨\",\"냉장고\",\"Wi-Fi\"]", "현재 입주 중인 방",

--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -64,8 +64,7 @@ public class SecurityConfig {
                                                 // --- 공개: 공간·룸 조회 ---
                                                 .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/api/room-types").permitAll() // 방 유형
-                                                .requestMatchers(HttpMethod.GET, "/api/admin/spaces/*/images/serve/**")
-                                                .permitAll() // 관리자가 업로드한 이미지 조회 (비회원 허용)
+                                                .requestMatchers(HttpMethod.GET, "/api/admin/spaces/*/images/serve/**").permitAll() // 관리자가 업로드한 이미지 조회 (비회원 허용)
                                                 .requestMatchers(HttpMethod.GET, "/api/experience/**").permitAll() // EXPERIENCE 공용시설 소개 🔓 Public
                                                 .requestMatchers(HttpMethod.GET, "/api/floors").permitAll() // FLOOR 층별 평면도 🔓 Public
 


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자 및 사용자 공간 기능 연동 시 발생하던 다수의 에러(예측 불가 데이터 결함 및 페이징 이슈)를 해결하여 도메인의 안정성을 확보하기 위해 작성되었습니다.
- 단일 진실 공급원(Single Source of Truth)을 구축하기 위해 레거시 시드 데이터를 제거/정리하고 통합 테스트에 적합한 환경으로 최적화합니다.

## 🔑 주요 변경 사항 (What)
- **에러 핸들링 및 누락 버그 해결**
  - `GlobalExceptionHandler` 내 `DataIntegrityViolationException` 필터링 및 에러 메시지 개선
  - 관리자 배치 에디터 렌더링 시 페이징 처리 누락 해결 (`fetchSpaces`에 `size=500` 적용)
  - 빈 층이 퍼블릭 도면 뷰어에 나타나던 버그 수정 (공간 존재 층만 표시)
  - 방 유형 정렬 설정이 프론트에 즉각 반영되도록 `GET /api/room-types` 퍼블릭 API 신설 및 필터 칩 이슈 해결
- **시드 데이터 최적화 ([DataInitializer](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/DataInitializer.java:76:0-799:1))**
  - 모든 `isSystemDefault` 보호 로직 기능 제거 (관리자 전체 제어권 부여)
  - 레거시 `data-dev.sql` 완전 삭제 및 [DataInitializer.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/DataInitializer.java:0:0-0:0) 단일 관리 지점화
  - 공용 공간 6곳 전용 시드 이미지 추가 (`backend/src/main/resources/static/api/seed/` 정적 서빙)
  - 개인 공간 축소(25개 → 13개) 및 사용되지 않던 `STUDIO` 관련 방과 유형 코드 최종 정리

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305