### PR TITLE
[SPC/fix] 관리자 도면에서 공용시설 라벨 에러 표시 수정

### DIFF
--- a/frontend/src/app/admin/spaces/_components/floor-plan/SpaceBlock.tsx
+++ b/frontend/src/app/admin/spaces/_components/floor-plan/SpaceBlock.tsx
@@ -134,7 +134,7 @@ export function SpaceBlock({ block, cellSize, onResizeEnd }: SpaceBlockProps) {
                   color: 'var(--background)',
                 }}
               >
-                {statusInfo.label}
+                {block.type === 'COMMON' ? '공용' : statusInfo.label}
               </span>
             </div>
           </div>


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 기존 도면 컴포넌트([SpaceBlock.tsx](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/SpaceBlock.tsx:0:0-0:0))에서는 블록의 상태(`AVAILABLE`) 값에만 의존하여 라벨을 렌더링하고 있었습니다.
- 이로 인해 항상 `AVAILABLE` 상태를 유지하는 다수의 '공용시설(COMMON)' 블록들이 원래 의미와 맞지 않는 '공실'로 잘못 표시되는 사용자 경험의 혼선이 발생하여 이를 시급히 수정하고자 합니다.

## 🔑 주요 변경 사항 (What)
- **공용시설 전용 라벨 분기 적용**
  - 프론트엔드 렌더링 로직([SpaceBlock.tsx](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_components/floor-plan/SpaceBlock.tsx:0:0-0:0)) 내에서 공간 유형(`block.type`)을 체크하여, 해당 블록이 `COMMON`(공용시설)일 경우 상태와 무관하게 **'공용'** 이라는 라벨을 출력하도록 삼항 연산자 렌더링 조건을 추가했습니다.
  - 해당 타입이 `PRIVATE`(개인 공간)일 경우에는 기존처럼 '공실', '사용중', '점검중' 등 본래의 상태가 표시됩니다.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305

## 💻 테스트 방법 (How to Test)
1. 프론트엔드 구동 후 **관리자 페이지의 배치/도면 에디터(`/admin/spaces`)**에 진입합니다.
2. 도면 위에 배치된 공용시설 블록(예: 1층 메인 로비 회의실, 1층 세탁실 등)의 상단 상태 뱃지를 확인합니다.
3. 뱃지의 글씨가 기존의 '공실'이 아닌, 정상적으로 **'공용'** 으로 표시되는지 확인합니다.
4. 개인 사용자용 방(예: 101호)의 뱃지는 기존처럼 '공실' 이나 '사용중'으로 정상 표기되고 있는지 병행 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- N/A (간단한 텍스트 렌더링 분기 추가)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 단순히 텍스트만 '공용'으로 출력하도록 변경한 것이므로, 기존에 설계된 색상 프리셋(`STATUS_COLORS`)이나 백엔드 DB의 실제 상태값 변화 등에는 어떠한 부작용(Side-effect)도 일으키지 않습니다! 안심하고 머지하셔도 좋습니다.

Closes #305 