### PR TITLE
[SPC/fix] 사용자용 평면도 공용 시설 라벨 오류 수정

### DIFF
--- a/frontend/src/app/(public)/floor/_components/SpaceBlock.tsx
+++ b/frontend/src/app/(public)/floor/_components/SpaceBlock.tsx
@@ -61,7 +61,7 @@ export function SpaceBlock({ block, cellSize }: SpaceBlockProps) {
               color: 'var(--background)',
             }}
           >
-            {statusInfo.label}
+            {block.type === 'COMMON' ? '공용' : statusInfo.label}
           </span>
         </div>
 


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자 배치 관리 페이지와 달리 사용자 층별 평면도(`/floor`)에서 공용 시설 블록이 "공용"이 아닌 "공실"로 표시되는 문제가 있었습니다.
- 일반 사용자가 어플리케이션을 이용 시 공용 시설의 상태 정보를 오인하는 것을 방지하고, 명확하고 올바른 라벨("공용")을 표시하기 위해 수정했습니다.

## 🔑 주요 변경 사항 (What)
- [frontend/src/app/(public)/floor/_components/SpaceBlock.tsx](cci:7://file:///c:/team1_cokkiri/frontend/src/app/%28public%29/floor/_components/SpaceBlock.tsx:0:0-0:0) 컴포넌트의 라벨 렌더링 로직 수정
- 시설 블록의 타입이 공용(`block.type === 'COMMON'`)일 경우 `statusInfo.label` 대신 `'공용'`이라는 텍스트를 출력하도록 삼항 연산자 분기 조건 추가 (관리자 측 에디터와 동일한 로직 적용)

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #305

## 💻 테스트 방법 (How to Test)
1. 로컬 환경에서 `docker compose up` 또는 프론트엔드 서버를 실행(`npm run dev`)합니다.
2. 웹 브라우저에서 `/floor` (층별 안내/퍼블릭 도면 뷰어) 페이지로 접속합니다.
3. 공용 공간(예: 1F 메인 로비 회의실 또는 B1 헬스장 등)이 포함된 층 탭을 클릭하여 확인합니다.
4. 공용 공간 블록의 좌측 상단 상태 라벨이 "공실"이 아닌 **"공용"**이라는 텍스트로 정상 출력되는지 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
> _(이 부분에 깃허브 업로드 기능으로 수정 전/수정 후 캡처 화면을 드래그해서 넣어주세요)_

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 관리자용 평면도 에디터 컴포넌트에 적용되었던 패치를 누락된 사용자 뷰어([SpaceBlock](cci:1://file:///c:/team1_cokkiri/frontend/src/app/%28public%29/floor/_components/SpaceBlock.tsx:13:0-88:1)) 쪽에도 동일하게 적용한 간단한 핫픽스 수정 사항입니다.

Closes #305