### PR TITLE
[IOT]기기 등록 UI 개선 및 Mock IoT 시드 데이터 확장

### DIFF
--- a/backend/src/main/java/com/coliving/admin/device/adapter/out/jpa/DeviceTypeEntity.java
+++ b/backend/src/main/java/com/coliving/admin/device/adapter/out/jpa/DeviceTypeEntity.java
@@ -12,10 +12,7 @@ import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.type.SqlTypes;
 
 @Entity
-@Table(
-        name = "device_types",
-        uniqueConstraints = {@UniqueConstraint(columnNames = "code")}
-)
+@Table(name = "device_types")
 @SQLDelete(sql = "UPDATE device_types SET deleted_at = CURRENT_TIMESTAMP WHERE device_type_id = ?")
 @SQLRestriction("deleted_at IS NULL")
 @Getter

--- a/backend/src/main/java/com/coliving/global/config/SchemaInitializer.java
+++ b/backend/src/main/java/com/coliving/global/config/SchemaInitializer.java
@@ -1,0 +1,70 @@
+package com.coliving.global.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Hibernate ddl-auto=update가 처리하지 못하는 스키마 마이그레이션을 담당합니다.
+ *
+ * <p>DataInitializer(@Order(100))보다 먼저 실행되며,
+ * Profile 조건 없이 항상 실행됩니다.</p>
+ *
+ * <p>모든 SQL은 IF EXISTS / IF NOT EXISTS로 idempotent하게 작성합니다.</p>
+ */
+@Slf4j
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class SchemaInitializer implements ApplicationRunner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        migrateDeviceTypesCodeConstraint();
+    }
+
+    /**
+     * device_types.code 컬럼의 전체 Unique 제약을 Partial Unique Index로 교체.
+     *
+     * <p>Soft Delete 후 동일 code로 재등록할 수 있도록,
+     * 활성 레코드(deleted_at IS NULL)에서만 중복을 방지합니다.</p>
+     */
+    private void migrateDeviceTypesCodeConstraint() {
+        try {
+            // 기존 code 컬럼의 모든 Unique 제약을 동적으로 찾아 삭제
+            var constraints = jdbcTemplate.queryForList(
+                    "SELECT tc.constraint_name " +
+                    "FROM information_schema.table_constraints tc " +
+                    "JOIN information_schema.constraint_column_usage ccu " +
+                    "  ON tc.constraint_name = ccu.constraint_name " +
+                    "WHERE tc.table_name = 'device_types' " +
+                    "  AND tc.constraint_type = 'UNIQUE' " +
+                    "  AND ccu.column_name = 'code'",
+                    String.class
+            );
+
+            for (String constraintName : constraints) {
+                jdbcTemplate.execute(
+                        "ALTER TABLE device_types DROP CONSTRAINT IF EXISTS " + constraintName
+                );
+                log.info("[스키마 마이그레이션] device_types Unique 제약 삭제: {}", constraintName);
+            }
+
+            // Partial Unique Index 생성 (활성 레코드만)
+            jdbcTemplate.execute(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uk_device_types_code_active " +
+                    "ON device_types (code) WHERE deleted_at IS NULL"
+            );
+
+            log.info("[스키마 마이그레이션] device_types.code Partial Unique Index 적용 완료");
+        } catch (Exception e) {
+            log.warn("[스키마 마이그레이션] device_types.code 제약 교체 실패 — {}", e.getMessage());
+        }
+    }
+}

--- a/frontend/src/app/admin/devices/_components/DeviceRegisterForm.tsx
+++ b/frontend/src/app/admin/devices/_components/DeviceRegisterForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { createDevice, discoverIotDevices, fetchDeviceTypes, fetchGateways, fetchSpaces, updateDeviceType } from "../_api";
+import { createDevice, discoverIotDevices, fetchDeviceTypes, fetchDevices, fetchGateways, fetchSpaces, updateDeviceType } from "../_api";
 import type { CreateDeviceRequest, DeviceType, Space, IotDeviceInfo, DeviceCapability, GatewayInfo } from "../_types";
 import { ApiError } from "@/lib/api";
 import { parseCommands, type DeviceCommand } from "@/components/ui/DeviceControlPanel";
@@ -26,6 +26,9 @@ export function DeviceRegisterForm() {
   const [iotLoading, setIotLoading] = useState(false);
   const [iotError, setIotError] = useState<string | null>(null);
   const [selectedDevice, setSelectedDevice] = useState<IotDeviceInfo | null>(null);
+
+  // ── 이미 등록된 MAC 주소 목록 ──
+  const [registeredMacs, setRegisteredMacs] = useState<Set<string>>(new Set());
 
   // ── 등록 폼 ──
   const [form, setForm] = useState<CreateDeviceRequest>({
@@ -94,11 +97,23 @@ export function DeviceRegisterForm() {
     }
   }, []);
 
+  // ── 등록된 기기 MAC 조회 ──
+  const loadRegisteredMacs = useCallback(async () => {
+    try {
+      const res = await fetchDevices({ s: 9999 });
+      const content = res.data?.content ?? [];
+      setRegisteredMacs(new Set(content.map((d) => d.macAddress)));
+    } catch {
+      // 실패해도 등록 자체에는 영향 없음
+    }
+  }, []);
+
   useEffect(() => {
     loadDeviceTypes();
     loadSpaces();
     loadGateways();
-  }, [loadDeviceTypes, loadSpaces, loadGateways]);
+    loadRegisteredMacs();
+  }, [loadDeviceTypes, loadSpaces, loadGateways, loadRegisteredMacs]);
 
   // ── 게이트웨이 선택 → 로컬 네트워크 스캔 ──
   const handleSelectGateway = async (gw: GatewayInfo) => {
@@ -121,8 +136,9 @@ export function DeviceRegisterForm() {
     }
   };
 
-  // ── 기기 선택 ──
+  // ── 기기 선택 (이미 등록된 기기는 선택 불가) ──
   const handleSelectDevice = (device: IotDeviceInfo) => {
+    if (registeredMacs.has(device.macAddress)) return;
     setSelectedDevice(device);
     setForm((prev) => ({
       ...prev,
@@ -240,7 +256,8 @@ export function DeviceRegisterForm() {
       const submittedMac = form.macAddress;
       setForm({ macAddress: "", name: "", spaceId: 0, deviceTypeId: 0 });
       setSelectedDevice(null);
-      setIotDevices((prev) => prev.filter((d) => d.macAddress !== submittedMac));
+      // 등록 완료된 기기를 registeredMacs에 추가하여 즉시 "등록됨" 표시
+      setRegisteredMacs((prev) => new Set([...prev, submittedMac]));
     } catch (err) {
       if (err instanceof ApiError) {
         if (err.errorCode === "DUPLICATE_MAC_ADDRESS") {
@@ -444,39 +461,51 @@ export function DeviceRegisterForm() {
                 <p className="text-xs text-muted-foreground pl-1">
                   {iotDevices.length}개 기기 발견 — 등록할 기기를 선택하세요
                 </p>
-                {iotDevices.map((device) => (
-                  <motion.div
-                    key={device.macAddress}
-                    whileHover={{ y: -2 }}
-                    onClick={() => handleSelectDevice(device)}
-                    className={`cursor-pointer rounded-xl border px-4 py-3 transition-all duration-200
-                      ${selectedDevice?.macAddress === device.macAddress
-                        ? "border-accent bg-accent/10 ring-2 ring-accent/30"
-                        : "border-border bg-surface hover:border-secondary"
-                      }`}
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <p className="text-sm font-semibold text-primary font-mono">{device.modelName}</p>
-                        <p className="text-xs text-muted-foreground font-mono">
-                          MAC: {device.macAddress} · Local: {device.localIp}
-                        </p>
-                        {device.capabilities?.length > 0 && (
-                          <p className="text-xs text-muted-foreground mt-1">
-                            지원: {device.capabilities.map(c => c.command).join(", ")}
+                {iotDevices.map((device) => {
+                  const isRegistered = registeredMacs.has(device.macAddress);
+                  return (
+                    <motion.div
+                      key={device.macAddress}
+                      whileHover={isRegistered ? {} : { y: -2 }}
+                      onClick={() => handleSelectDevice(device)}
+                      className={`rounded-xl border px-4 py-3 transition-all duration-200
+                        ${isRegistered
+                          ? "border-border/50 bg-muted/10 opacity-60 cursor-not-allowed"
+                          : selectedDevice?.macAddress === device.macAddress
+                            ? "border-accent bg-accent/10 ring-2 ring-accent/30 cursor-pointer"
+                            : "border-border bg-surface hover:border-secondary cursor-pointer"
+                        }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <p className="text-sm font-semibold text-primary font-mono">{device.modelName}</p>
+                            {isRegistered && (
+                              <span className="inline-flex items-center rounded-md bg-secondary/30 border border-secondary/50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+                                등록됨
+                              </span>
+                            )}
+                          </div>
+                          <p className="text-xs text-muted-foreground font-mono">
+                            MAC: {device.macAddress} · Local: {device.localIp}
                           </p>
-                        )}
+                          {device.capabilities?.length > 0 && (
+                            <p className="text-xs text-muted-foreground mt-1">
+                              지원: {device.capabilities.map(c => c.command).join(", ")}
+                            </p>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className={`inline-block w-2 h-2 rounded-full ${
+                            device.status === "ONLINE" ? "bg-green-500" :
+                            device.status === "ERROR" ? "bg-red-500" : "bg-gray-400"
+                          }`} />
+                          <span className="text-xs text-muted-foreground">{device.status}</span>
+                        </div>
                       </div>
-                      <div className="flex items-center gap-2">
-                        <span className={`inline-block w-2 h-2 rounded-full ${
-                          device.status === "ONLINE" ? "bg-green-500" :
-                          device.status === "ERROR" ? "bg-red-500" : "bg-gray-400"
-                        }`} />
-                        <span className="text-xs text-muted-foreground">{device.status}</span>
-                      </div>
-                    </div>
-                  </motion.div>
-                ))}
+                    </motion.div>
+                  );
+                })}
               </div>
             )}
 

--- a/mock-iot/seed/default-devices.json
+++ b/mock-iot/seed/default-devices.json
@@ -1,5 +1,185 @@
 [
   {
+    "mac_address": "AA:BB:CC:DD:07:01",
+    "model_name": "SmartLight-200W",
+    "host": "192.168.1.1",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:02",
+    "model_name": "CoolMax-500",
+    "host": "192.168.1.1",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:03",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.1.1",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:04",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.1.1",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:05",
+    "model_name": "SmartLight-200W",
+    "host": "192.168.1.2",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:06",
+    "model_name": "CoolMax-500",
+    "host": "192.168.1.2",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:07",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.1.2",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:07:08",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.1.2",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:01",
+    "model_name": "SmartLight-200W",
+    "host": "192.168.2.1",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:02",
+    "model_name": "CoolMax-500",
+    "host": "192.168.2.1",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:03",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.2.1",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:04",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.2.1",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:05",
+    "model_name": "SmartLight-200W",
+    "host": "192.168.2.2",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:06",
+    "model_name": "CoolMax-500",
+    "host": "192.168.2.2",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:07",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.2.2",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:08:08",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.2.2",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:01",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.2.3",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:02",
+    "model_name": "CoolMax-1000",
+    "host": "192.168.2.3",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:03",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.2.3",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:04",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.2.3",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
     "mac_address": "AA:BB:CC:DD:01:01",
     "model_name": "SmartLight-200W",
     "host": "192.168.3.1",
@@ -35,7 +215,6 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
   {
     "mac_address": "AA:BB:CC:DD:01:05",
     "model_name": "SmartLight-200W",
@@ -72,7 +251,6 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
   {
     "mac_address": "AA:BB:CC:DD:01:09",
     "model_name": "SmartLight-200W",
@@ -109,7 +287,6 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
   {
     "mac_address": "AA:BB:CC:DD:02:01",
     "model_name": "SmartLight-200W",
@@ -146,7 +323,42 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
+  {
+    "mac_address": "AA:BB:CC:DD:09:05",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.4.3",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:06",
+    "model_name": "CoolMax-1000",
+    "host": "192.168.4.3",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:07",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.4.3",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:09:08",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.4.3",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
   {
     "mac_address": "AA:BB:CC:DD:02:05",
     "model_name": "SmartLight-300W",
@@ -183,7 +395,78 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
+  {
+    "mac_address": "AA:BB:CC:DD:0A:01",
+    "model_name": "SmartLight-200W",
+    "host": "192.168.5.2",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:02",
+    "model_name": "CoolMax-500",
+    "host": "192.168.5.2",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:03",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.5.2",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:04",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.5.2",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:05",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.5.3",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:06",
+    "model_name": "CoolMax-1000",
+    "host": "192.168.5.3",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:07",
+    "model_name": "SecureLock-Pro",
+    "host": "192.168.5.3",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0A:08",
+    "model_name": "HeatFlow-300",
+    "host": "192.168.5.3",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
   {
     "mac_address": "AA:BB:CC:DD:03:01",
     "model_name": "SmartLight-300W",
@@ -211,7 +494,6 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
   {
     "mac_address": "AA:BB:CC:DD:04:01",
     "model_name": "SmartLight-300W",
@@ -239,7 +521,6 @@
     "status": "ONLINE",
     "error_mode": "normal"
   },
-
   {
     "mac_address": "AA:BB:CC:DD:05:01",
     "model_name": "SmartLight-300W",
@@ -263,6 +544,96 @@
     "model_name": "SecureCam-HD",
     "host": "192.168.0.10",
     "local_ip": "10.0.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0B:01",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.12.1",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0B:02",
+    "model_name": "WashMaster-700",
+    "host": "192.168.12.1",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0B:03",
+    "model_name": "DryMax-400",
+    "host": "192.168.12.1",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0B:04",
+    "model_name": "SecureCam-HD",
+    "host": "192.168.12.1",
+    "local_ip": "10.1.0.4",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0C:01",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.13.1",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0C:02",
+    "model_name": "CoolMax-1000",
+    "host": "192.168.13.1",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0C:03",
+    "model_name": "SecureCam-HD",
+    "host": "192.168.13.1",
+    "local_ip": "10.1.0.3",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0D:01",
+    "model_name": "SmartLight-300W",
+    "host": "192.168.14.1",
+    "local_ip": "10.1.0.1",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0D:02",
+    "model_name": "CoolMax-1000",
+    "host": "192.168.14.1",
+    "local_ip": "10.1.0.2",
+    "state": {},
+    "status": "ONLINE",
+    "error_mode": "normal"
+  },
+  {
+    "mac_address": "AA:BB:CC:DD:0D:03",
+    "model_name": "SecureCam-HD",
+    "host": "192.168.14.1",
+    "local_ip": "10.1.0.3",
     "state": {},
     "status": "ONLINE",
     "error_mode": "normal"


### PR DESCRIPTION
## 기기 등록 UI 개선 및 Mock IoT 시드 데이터 확장

### 💡 배경 및 목적 (Why)

기기 등록 페이지에서 이미 DB에 등록된 기기도 발견 목록에 동일하게 표시되어
관리자가 중복 등록을 시도하는 혼란이 발생했습니다.
또한 101호~503호, 세탁실, 도서관, 화상회의실 공간에 대한 Mock IoT 시드 기기 데이터가 없어
기기 등록 데모가 불가능한 상태였습니다.

### 🔑 주요 변경 사항 (What)

#### 1. 기기 등록 UI — 이미 등록된 기기 시각적 표시

| 변경 파일 | 내용 |
|-----------|------|
| `frontend/src/app/admin/devices/_components/DeviceRegisterForm.tsx` | 페이지 진입 시 `fetchDevices`로 등록된 전체 기기 MAC 주소 Set을 로드하여, 발견된 기기와 비교 |

**상세 변경:**
- `registeredMacs` 상태(`Set<string>`) 추가 — 페이지 마운트 시 `/api/admin/devices` 조회로 초기화
- 이미 등록된 기기: **"등록됨" 뱃지** 표시 + `opacity-60` + `cursor-not-allowed` (선택 불가)
- 등록 대기 기기: 기존과 동일하게 선택·하이라이트 가능
- 등록 완료 즉시 해당 MAC을 `registeredMacs`에 추가 → 목록 재조회 없이 즉시 "등록됨" 전환

#### 2. Mock IoT 시드 데이터 확장

| 변경 파일 | 내용 |
|-----------|------|
| `mock-iot/seed/default-devices.json` | 11개 공간 × 3~4개 기기 = **44개 기기 추가** (기존 항목 수정 없음) |

**추가된 공간 및 기기 구성:**

| 공간 | 게이트웨이(host) | 기기 구성 |
|------|----------------|----------|
| **101호** | `192.168.1.1` | 조명(SmartLight-200W) · 에어컨(CoolMax-500) · 도어락(SecureLock-Pro) · 난방(HeatFlow-300) |
| **102호** | `192.168.1.2` | 동일 4종 |
| **201호** | `192.168.2.1` | 동일 4종 |
| **202호** | `192.168.2.2` | 동일 4종 |
| **203호** | `192.168.2.3` | 조명(SmartLight-300W) · 에어컨(CoolMax-1000) · 도어락 · 난방 |
| **403호** | `192.168.4.3` | 조명(SmartLight-300W) · 에어컨(CoolMax-1000) · 도어락 · 난방 |
| **502호** | `192.168.5.2` | 조명(SmartLight-200W) · 에어컨(CoolMax-500) · 도어락 · 난방 |
| **503호** | `192.168.5.3` | 조명(SmartLight-300W) · 에어컨(CoolMax-1000) · 도어락 · 난방 |
| **세탁실** | `192.168.12.1` | 조명(SmartLight-300W) · 세탁기(WashMaster-700) · 건조기(DryMax-400) · CCTV(SecureCam-HD) |
| **도서관** | `192.168.13.1` | 조명(SmartLight-300W) · 에어컨(CoolMax-1000) · CCTV(SecureCam-HD) |
| **화상회의실** | `192.168.14.1` | 조명(SmartLight-300W) · 에어컨(CoolMax-1000) · CCTV(SecureCam-HD) |

> 모든 모델명은 기존 `capabilities.json`에 정의된 모델만 사용 (`WashMaster-700`, `DryMax-400` 등) — `capabilities.json` 수정 없음

### 🔗 연관된 이슈 (Issue / Ticket)

Closes #339

### 💻 테스트 방법 (How to Test)

**이미 등록된 기기 표시 확인 (`/admin/devices`)**
1. 관리자 로그인 후 「기기 등록」 진입
2. 게이트웨이 선택 → 기기 발견 목록 확인
3. 이미 DB에 등록된 기기는 **"등록됨" 뱃지** + 흐릿하게 표시되고 클릭 불가한지 확인
4. 등록되지 않은 기기는 정상 선택 가능한지 확인
5. 기기 등록 완료 후 해당 기기가 즉시 "등록됨"으로 전환되는지 확인

**Mock IoT 시드 기기 발견 확인**
1. Docker Compose 재기동 (볼륨 삭제 또는 시드 해시 변경으로 자동 재초기화)
2. 「기기 등록」 → 각 게이트웨이(`192.168.1.1` ~ `192.168.14.1`) 선택
3. 해당 공간의 기기 목록이 정상 표시되는지 확인
4. 기기 등록 후 `/admin/devices` 목록에서 해당 공간에 연결되는지 확인

### ✅ 체크리스트 (Self-Review)

- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

### 💬 리뷰어에게 전달할 내용 (Review Notes)

- **`capabilities.json` 수정 없음**: 새로 추가된 기기는 모두 기존 `capabilities.json`에 등록된 모델명만 사용하므로 Mock IoT 서버의 다른 파일은 변경이 없습니다.
- **시드 자동 재초기화**: `device-store.js`의 MD5 해시 비교 로직에 의해, `default-devices.json` 변경 시 컨테이너 재시작만으로 새 기기가 자동 반영됩니다.
- **기존 기기 데이터 유지**: 기존 29개 항목은 그대로 두고 끝에 추가만 했습니다.
- **변경 파일 2개**: `DeviceRegisterForm.tsx` (프론트엔드), `default-devices.json` (Mock IoT 시드)

