### PR TITLE
[CMN/style] 관리자 헤더 UI 표준화

### DIFF
--- a/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
+++ b/frontend/src/app/(common)/notifications/_components/NotificationListItem.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Trash2 } from "lucide-react";
 import { invalidateNotificationsUnreadCount } from "@/lib/notifications-events";
+import { useAuthStore } from "@/store/useAuthStore";
 
 type NotificationItem = {
   notificationId: number;
@@ -30,6 +31,7 @@ function senderLabel(referenceType: string | null): string {
 
 export function NotificationListItem({ item }: { item: NotificationItem }) {
   const router = useRouter();
+  const { user } = useAuthStore();
   const [readLocally, setReadLocally] = useState(false);
   const [deleted, setDeleted] = useState(false);
 
@@ -39,6 +41,7 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
   }, [item.notificationId]);
 
   const isRead = readLocally || item.isRead;
+  const isAdmin = user?.role === "ADMIN";
 
   const handleClick = async () => {
     if (!isRead) {
@@ -60,20 +63,15 @@ export function NotificationListItem({ item }: { item: NotificationItem }) {
 
     let targetPath = "/notifications";
     const refType = item.referenceType?.toUpperCase();
-    const type = item.type?.toUpperCase();
     const refId = item.referenceId;
 
     if (refId) {
       if (refType === "COMMUNITY") {
         targetPath = `/community/${refId}`;
       } else if (refType === "VOC") {
-        if (type === "VOC_CREATED") {
-          targetPath = `/admin/vocs/${refId}`;
-        } else {
-          targetPath = `/vocs/${refId}`;
-        }
+        targetPath = isAdmin ? `/admin/vocs/${refId}` : `/vocs/${refId}`;
       } else if (refType === "CONTRACT") {
-        targetPath = `/my-contracts`;
+        targetPath = isAdmin ? `/admin/contracts` : `/my-contracts`;
       } else if (refType === "RESERVATION") {
         targetPath = `/my-history/reservation`;
       } else if (refType === "PAYMENT") {

--- a/frontend/src/app/admin/billing/page.tsx
+++ b/frontend/src/app/admin/billing/page.tsx
@@ -26,27 +26,33 @@ export default function BillingPage() {
   ];
 
   return (
-    <div className="flex flex-col gap-8 p-6 md:p-12 bg-background min-h-screen text-primary">
+    <div className="max-w-[1400px] mx-auto">
       {/* ── Header ── */}
-      <section className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-8 border-b-2 border-primary">
-        <div className="flex flex-col gap-2">
-          <p className="text-[10px] font-black tracking-[0.3em] uppercase text-accent">
-            Admin / Billing Management
-          </p>
-          <h1 className="text-[10vw] md:text-[6vw] font-black tracking-tighter leading-[0.85] uppercase">
-            Billing
-          </h1>
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Billing Management</p>
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+              <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                ADMIN <span className="underline underline-offset-4 decoration-accent">BILLING.</span>
+                <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">결제 관리</span>
+              </h1>
+              <motion.button
+                whileHover={{ scale: 1.05 }}
+                whileTap={{ scale: 0.95 }}
+                onClick={() => setShowCreateModal(true)}
+                className="px-6 py-3 bg-primary text-white rounded-full font-black tracking-tight text-xs flex items-center gap-2 transition-all shadow-lg w-fit h-12"
+              >
+                <Plus className="w-4 h-4" />
+                결제 등록
+              </motion.button>
+            </div>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              입주민의 월세, 보증금 및 기타 서비스 이용에 대한 결제 내역을 조회하고 수동 결제를 등록하거나 승인합니다.
+            </p>
+          </div>
         </div>
-        <motion.button
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          onClick={() => setShowCreateModal(true)}
-          className="px-8 py-5 bg-primary text-background rounded-full font-black tracking-widest uppercase text-[10px] flex items-center gap-3 transition-all hover:bg-accent shadow-lg"
-        >
-          <Plus className="w-4 h-4" />
-          결제 등록
-        </motion.button>
-      </section>
+      </header>
 
       {/* ── Tab Navigation ── */}
       <div className="flex items-center gap-1 p-1.5 bg-primary/5 rounded-full w-fit">

--- a/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
+++ b/frontend/src/app/admin/community/_components/CommunityModerationPanel.tsx
@@ -293,7 +293,7 @@ export function CommunityModerationPanel() {
   const toDate = parseDateInput(createdTo);
   const calendarCells = buildCalendarCells(viewMonth);
 
-  const tabBase = "shrink-0 text-[15px] font-bold uppercase tracking-wider transition-all whitespace-nowrap pb-1.5 border-b-2 border-transparent cursor-pointer";
+  const tabBase = "shrink-0 text-sm md:text-base font-bold uppercase tracking-wider transition-all whitespace-nowrap pb-1.5 border-b-2 border-transparent cursor-pointer";
 
   function openPicker(target: "from" | "to") {
     const current = target === "from" ? fromDate : toDate;
@@ -325,20 +325,20 @@ export function CommunityModerationPanel() {
       <div className="flex flex-col gap-4 border-b border-primary/10 pb-4">
         <div className="flex items-center gap-6">
           <div className="flex items-center gap-3 shrink-0">
-            <span className="text-[13px] font-bold uppercase tracking-widest text-primary">글 종류</span>
+            <span className="text-sm md:text-base font-bold uppercase tracking-widest text-primary">글 종류</span>
             <span className="text-primary/10 select-none">|</span>
           </div>
           <button
             type="button"
             onClick={() => setTab("posts")}
-            className={cn(tabBase, tab === "posts" ? "text-accent border-accent" : "text-primary/40 hover:text-primary")}
+            className={cn(tabBase, tab === "posts" ? "text-accent border-accent" : "text-primary/60 hover:text-primary")}
           >
             게시글
           </button>
           <button
             type="button"
             onClick={() => setTab("comments")}
-            className={cn(tabBase, tab === "comments" ? "text-accent border-accent" : "text-primary/40 hover:text-primary")}
+            className={cn(tabBase, tab === "comments" ? "text-accent border-accent" : "text-primary/60 hover:text-primary")}
           >
             댓글
           </button>
@@ -347,7 +347,7 @@ export function CommunityModerationPanel() {
         {tab === "posts" && (
           <div className="flex items-center gap-6 overflow-x-auto no-scrollbar">
             <div className="flex items-center gap-3 shrink-0">
-              <span className="text-[13px] font-bold uppercase tracking-widest text-primary">유형별</span>
+              <span className="text-sm md:text-base font-bold uppercase tracking-widest text-primary">유형별</span>
               <span className="text-primary/10 select-none">|</span>
             </div>
             {POST_CATEGORIES.map((c) => (
@@ -355,7 +355,7 @@ export function CommunityModerationPanel() {
                 key={c.value}
                 type="button"
                 onClick={() => setCategory(c.value)}
-                className={cn(tabBase, category === c.value ? "text-accent border-accent" : "text-primary/40 hover:text-primary")}
+                className={cn(tabBase, category === c.value ? "text-accent border-accent" : "text-primary/60 hover:text-primary")}
               >
                 {c.label}
               </button>
@@ -366,23 +366,23 @@ export function CommunityModerationPanel() {
         <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
           <div className="flex flex-wrap items-center gap-4">
             <div className="flex items-center gap-3 shrink-0">
-              <span className="text-[13px] font-bold uppercase tracking-widest text-primary">날짜별</span>
+              <span className="text-sm md:text-base font-bold uppercase tracking-widest text-primary">날짜별</span>
               <span className="text-primary/10 select-none">|</span>
             </div>
             <div className="relative flex items-center gap-2">
               <button
                 type="button"
                 onClick={() => openPicker("from")}
-                className="inline-flex h-9 items-center gap-2 rounded-full border border-stone-200 bg-white px-4 text-xs font-semibold text-foreground/80 shadow-sm transition-colors hover:border-primary/40"
+                className="inline-flex h-9 items-center gap-2 rounded-full border border-stone-200 bg-white px-4 text-sm font-semibold text-foreground/80 shadow-sm transition-colors hover:border-primary/40"
               >
                 <CalendarDays className="h-4 w-4 text-stone-400" />
                 {createdFrom || "시작일"}
               </button>
-              <span className="text-foreground/30 text-xs text-center">~</span>
+              <span className="text-foreground/30 text-sm text-center">~</span>
               <button
                 type="button"
                 onClick={() => openPicker("to")}
-                className="inline-flex h-9 items-center gap-2 rounded-full border border-stone-200 bg-white px-4 text-xs font-semibold text-foreground/80 shadow-sm transition-colors hover:border-primary/40"
+                className="inline-flex h-9 items-center gap-2 rounded-full border border-stone-200 bg-white px-4 text-sm font-semibold text-foreground/80 shadow-sm transition-colors hover:border-primary/40"
               >
                 <CalendarDays className="h-4 w-4 text-stone-400" />
                 {createdTo || "종료일"}
@@ -461,14 +461,14 @@ export function CommunityModerationPanel() {
                   <button onClick={handleClearSearch}><X className="h-3.5 w-3.5" /></button>
                 </motion.div>
               ) : (
-                <button onClick={() => setIsSearchOpen(true)} className="flex items-center gap-1.5 text-[13px] font-black tracking-widest hover:opacity-60 transition-opacity">
+                <button onClick={() => setIsSearchOpen(true)} className="flex items-center gap-1.5 text-xs md:text-sm font-black tracking-widest hover:opacity-60 transition-opacity">
                   <Search className="h-4 w-4" /> SEARCH
                 </button>
               )}
             </AnimatePresence>
 
             <div className="relative">
-              <button onClick={() => setIsSortOpen(!isSortOpen)} className="flex items-center gap-1.5 text-[13px] font-black tracking-widest hover:opacity-60 transition-opacity">
+              <button onClick={() => setIsSortOpen(!isSortOpen)} className="flex items-center gap-1.5 text-xs md:text-sm font-black tracking-widest hover:opacity-60 transition-opacity">
                 <Filter className="h-4 w-4" /> SORT
               </button>
               <AnimatePresence>
@@ -525,25 +525,25 @@ export function CommunityModerationPanel() {
                 ) : (
                   posts.map((item, idx) => (
                     <tr key={item.postId} className="border-b border-primary/5 hover:bg-primary/[0.02] transition-colors group">
-                      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/40">{page * pageSize + idx + 1}</td>
+                      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/70">{page * pageSize + idx + 1}</td>
                       <td className="px-5 py-4 text-center">
-                        <span className="text-[15px] font-medium text-primary/70">{categoryLabel(item.category)}</span>
+                        <span className="text-[15px] font-medium text-primary/95">{categoryLabel(item.category)}</span>
                       </td>
                       <td className="px-5 py-4">
-                        <Link href={`/admin/community/posts/${item.postId}`} className="text-lg font-normal text-primary hover:text-accent transition-colors line-clamp-1">
+                        <Link href={`/admin/community/posts/${item.postId}`} className="text-[17px] font-medium text-primary hover:text-accent transition-colors line-clamp-1">
                           {item.title}
                         </Link>
-                        <div className="flex items-center gap-3 mt-1 text-[11px] font-bold text-primary/30">
+                        <div className="flex items-center gap-3 mt-1 text-[11px] font-bold text-primary/60">
                           <span>조회 {item.viewCount}</span> · <span>좋아요 {item.likeCount}</span> · <span>댓글 {item.commentCount}</span>
                         </div>
                       </td>
-                      <td className="px-5 py-4 text-center text-[15px] font-medium text-primary/70">회원 #{item.authorUserId}</td>
-                      <td className="px-5 py-4 text-center text-sm font-normal text-primary/40">{item.createdAt.split("T")[0]}</td>
+                      <td className="px-5 py-4 text-center text-[15px] font-medium text-primary/95">회원 #{item.authorUserId}</td>
+                      <td className="px-5 py-4 text-center text-sm font-normal text-primary/70">{item.createdAt.split("T")[0]}</td>
                       <td className="px-5 py-4 text-center">
                         <button
                           disabled={isPending}
                           onClick={() => confirm("삭제하시겠습니까?") && handleDeletePost(item.postId)}
-                          className="p-2 text-primary/20 hover:text-destructive transition-colors"
+                          className="p-2 text-primary/50 hover:text-destructive transition-colors"
                           title="삭제"
                         >
                           <Trash2 className="size-4" />
@@ -558,22 +558,22 @@ export function CommunityModerationPanel() {
                 ) : (
                   comments.map((item, idx) => (
                     <tr key={item.commentId} className="border-b border-primary/5 hover:bg-primary/[0.02] transition-colors group">
-                      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/40">{page * pageSize + idx + 1}</td>
+                      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/70">{page * pageSize + idx + 1}</td>
                       <td className="px-5 py-4 max-w-[200px]">
-                        <p className="text-sm font-medium text-primary/40 truncate">{item.postTitle}</p>
+                        <p className="text-sm font-medium text-primary/70 truncate">{item.postTitle}</p>
                       </td>
                       <td className="px-5 py-4">
-                        <Link href={`/admin/community/comments/${item.commentId}`} className="text-lg font-normal text-primary hover:text-accent transition-colors line-clamp-1">
+                        <Link href={`/admin/community/comments/${item.commentId}`} className="text-[17px] font-medium text-primary hover:text-accent transition-colors line-clamp-1">
                           {item.content}
                         </Link>
-                        <p className="text-[11px] font-bold text-primary/30 mt-1">{item.createdAt.split("T")[0]}</p>
+                        <p className="text-[11px] font-bold text-primary/60 mt-1">{item.createdAt.split("T")[0]}</p>
                       </td>
-                      <td className="px-5 py-4 text-center text-[15px] font-medium text-primary/70">회원 #{item.authorUserId}</td>
+                      <td className="px-5 py-4 text-center text-[15px] font-medium text-primary/95">회원 #{item.authorUserId}</td>
                       <td className="px-5 py-4 text-center">
                         <button
                           disabled={isPending}
                           onClick={() => confirm("댓글을 삭제하시겠습니까?") && handleDeleteComment(item.commentId)}
-                          className="p-2 text-primary/20 hover:text-destructive transition-colors"
+                          className="p-2 text-primary/50 hover:text-destructive transition-colors"
                           title="삭제"
                         >
                           <Trash2 className="size-4" />

--- a/frontend/src/app/admin/community/page.tsx
+++ b/frontend/src/app/admin/community/page.tsx
@@ -11,9 +11,9 @@ export const metadata = {
 export default function AdminCommunityPage() {
   return (
     <MotionEnter>
-      <div className="max-w-5xl">
-        <header className="mb-6">
-          <div className="flex flex-col gap-3">
+      <div className="max-w-[1400px] mx-auto">
+        <header className="mb-12">
+          <div className="flex flex-col gap-6">
             <div className="border-b border-primary/10 pb-8 space-y-4">
               <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Community</p>
               <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">

--- a/frontend/src/app/admin/community/posts/[postId]/_components/AdminCommunityPostActions.tsx
+++ b/frontend/src/app/admin/community/posts/[postId]/_components/AdminCommunityPostActions.tsx
@@ -34,7 +34,7 @@ export function AdminCommunityPostActions({ postId }: Props) {
     setSuccess(null);
     startTransition(async () => {
       try {
-        const res = await fetch(`/api/community/posts/${postId}/comments`, {
+        const res = await fetch(`/api/posts/${postId}/comments`, {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },

--- a/frontend/src/app/admin/community/posts/[postId]/page.tsx
+++ b/frontend/src/app/admin/community/posts/[postId]/page.tsx
@@ -45,6 +45,17 @@ export default async function AdminCommunityPostDetailPage({ params }: { params:
   if (!body.success || !body.data) notFound();
   const detail = body.data;
 
+  const commentsRes = await adminCommunityBffGet(`admin/comments?post_id=${id}&s=100`);
+  let comments: any[] = [];
+  if (commentsRes.ok) {
+    try {
+      const cBody = await commentsRes.json();
+      comments = cBody.data?.content ?? [];
+    } catch {
+      // Ignore
+    }
+  }
+
   return (
     <div className="pt-4 pb-32">
       <MotionEnter>
@@ -108,7 +119,7 @@ export default async function AdminCommunityPostDetailPage({ params }: { params:
                   {detail.links.map((link, idx) => (
                     <li key={`${link.url}-${idx}`}>
                       <a
-                        href={link.url ?? "#"}
+                         href={link.url ?? "#"}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="group inline-flex items-center gap-2 text-base font-medium text-stone-800 hover:text-accent transition-colors"
@@ -136,6 +147,26 @@ export default async function AdminCommunityPostDetailPage({ params }: { params:
                 <span className="text-[10px] font-black uppercase tracking-widest text-primary/30">Comments</span>
                 <span className="text-xl font-bold text-primary/80">{detail.commentCount}</span>
               </div>
+            </section>
+
+            {/* Comments List */}
+            <section className="space-y-6 pt-6 border-t border-primary/10">
+              <h3 className="text-sm md:text-base font-black uppercase tracking-[0.2em] text-stone-900">댓글 목록</h3>
+              {comments.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-10 text-center">등록된 댓글이 없습니다.</p>
+              ) : (
+                <ul className="space-y-4">
+                  {comments.map((comment: any) => (
+                    <li key={comment.commentId} className="bg-white border border-primary/5 p-6 rounded-3xl shadow-sm">
+                      <div className="flex items-center justify-between mb-3">
+                        <span className="text-xs font-bold text-primary/60">회원 #{comment.authorUserId}</span>
+                        <time className="text-xs text-primary/30">{formatDateTimeKo(comment.createdAt)}</time>
+                      </div>
+                      <p className="text-base text-stone-900 whitespace-pre-wrap">{comment.content}</p>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </section>
 
             <AdminCommunityPostActions postId={detail.postId} />

--- a/frontend/src/app/admin/contracts/page.tsx
+++ b/frontend/src/app/admin/contracts/page.tsx
@@ -29,27 +29,33 @@ export default function AdminContractsPage() {
   ];
 
   return (
-    <div className="flex flex-col gap-8 p-6 md:p-12 bg-background min-h-screen text-primary">
+    <div className="max-w-[1400px] mx-auto">
       {/* ── Header ── */}
-      <section className="flex flex-col md:flex-row md:items-end justify-between gap-6 pb-8 border-b-2 border-primary">
-        <div className="flex flex-col gap-2">
-          <p className="text-[10px] font-black tracking-[0.3em] uppercase text-accent">
-            Admin / Contract Management
-          </p>
-          <h1 className="text-[10vw] md:text-[6vw] font-black tracking-tighter leading-[0.85] uppercase">
-            Contracts
-          </h1>
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Contracts</p>
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+              <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                ADMIN <span className="underline underline-offset-4 decoration-accent">CONTRACTS.</span>
+                <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">계약 관리</span>
+              </h1>
+              <motion.button
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+                onClick={() => setShowCreateModal(true)}
+                className="px-6 py-3 bg-primary text-background rounded-full font-black tracking-widest uppercase text-[10px] flex items-center gap-2 transition-all hover:bg-accent shadow-lg w-fit"
+              >
+                <Plus className="w-4 h-4" />
+                직접 등록
+              </motion.button>
+            </div>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              입주자 계약 체결 현황을 조회하고, 현장 방문 등을 통한 수기 계약을 직접 등록할 수 있습니다.
+            </p>
+          </div>
         </div>
-        <motion.button
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          onClick={() => setShowCreateModal(true)}
-          className="px-8 py-5 bg-primary text-background rounded-full font-black tracking-widest uppercase text-[10px] flex items-center gap-3 transition-all hover:bg-accent shadow-lg"
-        >
-          <Plus className="w-4 h-4" />
-          직접 등록
-        </motion.button>
-      </section>
+      </header>
 
       {/* ── Tab Navigation ── */}
       <div className="flex items-center gap-1 p-1.5 bg-primary/5 rounded-full w-fit">

--- a/frontend/src/app/admin/dashboard/page.tsx
+++ b/frontend/src/app/admin/dashboard/page.tsx
@@ -61,17 +61,20 @@ export default function DashboardPage() {
       className="max-w-[1400px] mx-auto"
     >
       {/* 페이지 헤더 */}
-      <div className="mb-12">
-        <p className="text-muted-foreground text-[10px] font-black tracking-[0.35em] uppercase">
-          Admin · Dashboard
-        </p>
-        <h1 className="text-[12vw] leading-[0.85] font-black tracking-tighter text-[#2C3424] uppercase md:text-[6vw] mt-4">
-          Dash<span className="text-[#768064]">board</span>
-        </h1>
-        <p className="max-w-2xl text-base font-medium tracking-tight text-balance text-[#4C583E] md:text-lg mt-5">
-          코리빙 시설 운영 현황을 한눈에 확인합니다
-        </p>
-      </div>
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Dashboard</p>
+            <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+              ADMIN <span className="underline underline-offset-4 decoration-accent">DASHBOARD.</span>
+              <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">대시보드</span>
+            </h1>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              코리빙 시설의 전반적인 운영 지표와 실시간 현황을 한눈에 파악할 수 있는 요약 보드입니다.
+            </p>
+          </div>
+        </div>
+      </header>
 
       {/* ══════════════════════════════════════════════
           실시간 기기 현황 섹션

--- a/frontend/src/app/admin/devices/page.tsx
+++ b/frontend/src/app/admin/devices/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Plus } from "lucide-react";
 import { DeviceListTable } from "./_components/DeviceListTable";
 
 export const metadata = {
@@ -8,44 +9,50 @@ export const metadata = {
 
 export default function DevicesPage() {
   return (
-    <div className="space-y-8">
-      <header>
-        <div className="mb-10">
-          <p className="text-muted-foreground text-[10px] font-black tracking-[0.35em] uppercase">
-            Admin · IoT Devices
-          </p>
-          <h1 className="text-[12vw] leading-[0.85] font-black tracking-tighter text-[#2C3424] uppercase md:text-[6vw] mt-4">
-            Device <span className="text-[#768064]">Control</span>
-          </h1>
-          <p className="max-w-2xl text-base font-medium tracking-tight text-balance text-[#4C583E] md:text-lg mt-5">
-            등록된 기기의 활성화/비활성화, 제어, 수정, 삭제를 관리합니다.
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <Link
-            href="/admin/monitoring"
-            className="inline-flex items-center gap-2 whitespace-nowrap rounded-xl border border-border px-4 py-2.5 md:px-5 md:py-3
-              text-xs font-bold uppercase tracking-[0.2em] text-primary
-              transition-colors duration-200 hover:bg-muted"
-          >
-            📊 기기 모니터링
-          </Link>
-          <Link
-            href="/admin/devices/types"
-            className="inline-flex items-center gap-2 whitespace-nowrap rounded-xl border border-border px-4 py-2.5 md:px-5 md:py-3
-              text-xs font-bold uppercase tracking-[0.2em] text-primary
-              transition-colors duration-200 hover:bg-muted"
-          >
-            종류 관리
-          </Link>
-          <Link
-            href="/admin/devices/register"
-            className="inline-flex items-center gap-2 whitespace-nowrap rounded-xl bg-primary px-4 py-2.5 md:px-5 md:py-3
-              text-xs font-bold uppercase tracking-[0.2em] text-primary-foreground
-              transition-colors duration-200 hover:bg-secondary"
-          >
-            + 기기 등록
-          </Link>
+    <div className="max-w-[1400px] mx-auto space-y-8">
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · IoT Devices</p>
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+              <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                DEVICE <span className="underline underline-offset-4 decoration-accent">CONTROL.</span>
+                <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">기기 관리</span>
+              </h1>
+              <div className="flex flex-wrap items-center gap-3">
+                <Link
+                  href="/admin/devices/register"
+                  className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-primary px-6 py-3
+                    text-xs font-bold uppercase tracking-tight text-white
+                    transition-all duration-200 hover:scale-105 shadow-lg"
+                >
+                  <Plus className="size-4" />
+                  기기 등록
+                </Link>
+              </div>
+            </div>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              시설 내 설치된 모든 IoT 기기(도어락, 조명, 에어컨 등)를 조회하고 원격 제어 및 상태를 모니터링합니다.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/admin/monitoring"
+              className="inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary/10 bg-primary/5 px-4 py-2
+                text-xs font-bold uppercase tracking-tight text-primary/70
+                transition-colors duration-200 hover:bg-primary/10"
+            >
+              📊 기기 모니터링
+            </Link>
+            <Link
+              href="/admin/devices/types"
+              className="inline-flex items-center gap-2 whitespace-nowrap rounded-full border border-primary/10 bg-primary/5 px-4 py-2
+                text-xs font-bold uppercase tracking-tight text-primary/70
+                transition-colors duration-200 hover:bg-primary/10"
+            >
+              종류 관리
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/frontend/src/app/admin/monitoring/page.tsx
+++ b/frontend/src/app/admin/monitoring/page.tsx
@@ -70,39 +70,42 @@ export default function MonitoringPage() {
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.4 }}
-      className="max-w-[1200px] mx-auto px-6 md:px-12 py-8"
+      className="max-w-[1400px] mx-auto"
     >
       {/* 헤더 */}
-      <div className="mb-10">
-        <p className="text-muted-foreground text-[10px] font-black tracking-[0.35em] uppercase">
-          Admin · Monitoring
-        </p>
-        <h1 className="text-[12vw] leading-[0.85] font-black tracking-tighter text-[#2C3424] uppercase md:text-[6vw] mt-4">
-          Device <span className="text-[#768064]">Monitor</span>
-        </h1>
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between mt-5">
-          <p className="max-w-2xl text-base font-medium tracking-tight text-balance text-muted md:text-lg">
-            기기 상태, 제어 빈도, 에러 이력을 한눈에 확인합니다
-          </p>
-          <div className="flex items-center gap-3 shrink-0">
-            {lastUpdated && (
-              <span className="text-[10px] text-muted-foreground">
-                {lastUpdated.toLocaleTimeString("ko-KR")} 갱신
-              </span>
-            )}
-            <button
-              onClick={() => setAutoRefresh(!autoRefresh)}
-              className={`text-xs px-3 py-1.5 rounded-full border transition-colors ${
-                autoRefresh
-                  ? "bg-accent text-white border-accent"
-                  : "bg-transparent text-muted-foreground border-border"
-              }`}
-            >
-              {autoRefresh ? "● 실시간" : "○ 수동"}
-            </button>
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Monitoring</p>
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+              <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                DEVICE <span className="underline underline-offset-4 decoration-accent">MONITOR.</span>
+                <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">기기 모니터링</span>
+              </h1>
+              <div className="flex items-center gap-3 shrink-0">
+                {lastUpdated && (
+                  <span className="text-[10px] text-muted-foreground font-medium uppercase tracking-wider">
+                    {lastUpdated.toLocaleTimeString("ko-KR")} 갱신
+                  </span>
+                )}
+                <button
+                  onClick={() => setAutoRefresh(!autoRefresh)}
+                  className={`text-[10px] font-black uppercase tracking-widest px-4 py-2 rounded-full border transition-all ${
+                    autoRefresh
+                      ? "bg-accent text-white border-accent shadow-md"
+                      : "bg-primary/5 text-primary/40 border-primary/10 hover:bg-primary/10"
+                  }`}
+                >
+                  {autoRefresh ? "● LIVE" : "○ MANUAL"}
+                </button>
+              </div>
+            </div>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              전체 기기의 실시간 작동 상태, 제어 성공률 및 에러 로그를 분석하여 시스템의 안정성을 모니터링합니다.
+            </p>
           </div>
         </div>
-      </div>
+      </header>
 
       {/* 에러 표시 */}
       {error && (

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -36,16 +36,20 @@ const shortcuts: { href: string; label: string; description: string; icon: typeo
 
 export default function AdminHomePage() {
   return (
-    <div className="space-y-12">
-      <header className="space-y-4">
-        <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">CoKkiri Admin</p>
-        <h1 className="text-balance text-4xl font-black uppercase tracking-tighter text-foreground md:text-5xl">
-          관리자{" "}
-          <span className="underline decoration-secondary decoration-2 underline-offset-[0.15em]">홈</span>
-        </h1>
-        <p className="max-w-2xl text-lg font-medium tracking-tight text-foreground/80">
-          왼쪽 메뉴 또는 아래 바로가기에서 업무 영역으로 이동하세요.
-        </p>
+    <div className="max-w-[1400px] mx-auto space-y-12">
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">CoKkiri · Admin</p>
+            <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+              ADMIN <span className="underline underline-offset-4 decoration-accent">HOME.</span>
+              <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">관리자 홈</span>
+            </h1>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              왼쪽 메뉴 또는 아래 바로가기에서 업무 영역을 선택하여 관리 작업을 시작하세요.
+            </p>
+          </div>
+        </div>
       </header>
 
       <section>

--- a/frontend/src/app/admin/reservations/_components/AdminReservationManager.tsx
+++ b/frontend/src/app/admin/reservations/_components/AdminReservationManager.tsx
@@ -212,35 +212,34 @@ export function AdminReservationManager() {
 
   return (
     <>
-      <div className="p-6 md:p-12 lg:px-24">
-        <header className="mb-12 flex flex-col gap-8 lg:flex-row lg:items-end lg:justify-between">
-          <div className="space-y-5">
-            <p className="text-muted-foreground text-[10px] font-black tracking-[0.35em] uppercase">
-              Admin · Reservation
-            </p>
-            <h1 className="text-[12vw] leading-[0.85] font-black tracking-tighter text-[#2C3424] uppercase md:text-[6vw]">
-              Reservation <span className="text-[#768064]">Control</span>
-            </h1>
-            <p className="max-w-2xl text-base font-medium tracking-tight text-balance text-[#4C583E] md:text-lg">
-              현재 페이지 데이터 안에서 빠르게 검색하고, 승인 대기 예약을 검토하거나 예약을 즉시
-              취소할 수 있는 관리자용 운영 보드입니다.
-            </p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-3">
-            <Button
-              variant="outline"
-              className="rounded-full px-5"
-              onClick={() => void handleRefresh()}
-              disabled={isReloading}
-            >
-              {isReloading ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : (
-                <RefreshCw className="size-4" />
-              )}
-              새로고침
-            </Button>
+      <div className="max-w-[1400px] mx-auto">
+        <header className="mb-12">
+          <div className="flex flex-col gap-6">
+            <div className="border-b border-primary/10 pb-8 space-y-4">
+              <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Reservation</p>
+              <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+                <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                  RESERVATION <span className="underline underline-offset-4 decoration-accent">CONTROL.</span>
+                  <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">예약 관리</span>
+                </h1>
+                <Button
+                  variant="outline"
+                  className="rounded-full px-5 border-primary/20 hover:bg-primary/5 h-11"
+                  onClick={() => void handleRefresh()}
+                  disabled={isReloading}
+                >
+                  {isReloading ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="size-4" />
+                  )}
+                  새로고침
+                </Button>
+              </div>
+              <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base max-w-3xl">
+                현재 페이지 데이터 안에서 빠르게 검색하고, 승인 대기 예약을 검토하거나 예약을 즉시 취소할 수 있는 관리자용 운영 보드입니다.
+              </p>
+            </div>
           </div>
         </header>
 

--- a/frontend/src/app/admin/spaces/page.tsx
+++ b/frontend/src/app/admin/spaces/page.tsx
@@ -71,28 +71,33 @@ export default function SpacesPage() {
   ];
 
   return (
-    <div className="relative min-h-screen bg-[var(--background)] text-[var(--foreground)] p-12 lg:p-24">
+    <div className="max-w-[1400px] mx-auto">
       {/* 헤더 + 탭 */}
-      <div className="flex items-end justify-between mb-8">
-        <div>
-          <motion.h1 
-            initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} 
-            className="text-[12vw] md:text-[8vw] lg:text-[5vw] font-black tracking-tighter leading-[0.85] uppercase"
-          >
-            SPACES
-          </motion.h1>
+      <header className="mb-12">
+        <div className="flex flex-col gap-6">
+          <div className="border-b border-primary/10 pb-8 space-y-4">
+            <p className="font-black text-[10px] uppercase tracking-[0.35em] text-muted-foreground">Admin · Spaces</p>
+            <div className="flex flex-col md:flex-row md:items-end justify-between gap-6">
+              <h1 className="text-5xl md:text-7xl font-black leading-tight tracking-tight uppercase whitespace-nowrap">
+                ADMIN <span className="underline underline-offset-4 decoration-accent">SPACES.</span>
+                <span className="text-2xl md:text-4xl font-bold tracking-normal ml-2 align-bottom opacity-80">공간 관리</span>
+              </h1>
+              {activeTab === 'spaces' && (
+                <button 
+                  onClick={() => setIsCreateModalOpen(true)}
+                  className="flex items-center gap-2 bg-primary text-white px-6 py-3 rounded-full font-black tracking-tight hover:scale-105 transition shadow-lg w-fit h-12"
+                >
+                  <Plus size={18} />
+                  <span>새 공간 생성</span>
+                </button>
+              )}
+            </div>
+            <p className="font-medium tracking-tight text-foreground/70 text-sm md:text-base">
+              시설 내 모든 공간(개인/공용)의 정보를 등록하고 관리하며, 도면 배치 및 유형 설정을 수행합니다.
+            </p>
+          </div>
         </div>
-        
-        {activeTab === 'spaces' && (
-          <button 
-            onClick={() => setIsCreateModalOpen(true)}
-            className="flex items-center gap-2 bg-[var(--foreground)] text-[var(--background)] px-6 py-4 rounded-full font-black tracking-tighter hover:scale-105 transition shadow-xl"
-          >
-            <Plus />
-            <span className="hidden sm:inline">새 공간 생성</span>
-          </button>
-        )}
-      </div>
+      </header>
 
       {/* 탭 전환 */}
       <div className="flex gap-2 mb-10">

--- a/frontend/src/app/admin/vocs/_components/AdminVocListCard.tsx
+++ b/frontend/src/app/admin/vocs/_components/AdminVocListCard.tsx
@@ -26,24 +26,24 @@ interface AdminVocListRowProps {
 export function AdminVocListRow({ item, rowNumber }: AdminVocListRowProps) {
   return (
     <tr className="border-b border-primary/5 hover:bg-primary/[0.03] transition-colors group">
-      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/50">
+      <td className="px-5 py-4 text-center font-mono text-[15px] font-medium text-primary/70">
         {rowNumber}
       </td>
       <td className="px-5 py-4 text-center">
-        <span className="text-[15px] font-medium text-primary/70">
+        <span className="text-[15px] font-medium text-primary/90">
           {adminVocCategoryLabel(item.category)}
         </span>
       </td>
       <td className="px-5 py-4">
         <Link
           href={`/admin/vocs/${item.vocId}`}
-          className="text-lg font-normal text-primary hover:text-accent transition-colors line-clamp-1"
+          className="text-[17px] font-medium text-primary hover:text-accent transition-colors line-clamp-1"
         >
           {item.title}
         </Link>
       </td>
       <td className="px-5 py-4 text-center">
-        <span className="text-[15px] font-medium text-primary/70">
+        <span className="text-[15px] font-medium text-primary/90">
           {item.userName || `회원 #${item.userId}`}
         </span>
       </td>
@@ -58,7 +58,7 @@ export function AdminVocListRow({ item, rowNumber }: AdminVocListRowProps) {
           {adminVocStatusLabel(item.status)}
         </span>
       </td>
-      <td className="px-5 py-4 text-center text-sm font-normal text-primary/50 tabular-nums" suppressHydrationWarning>
+      <td className="px-5 py-4 text-center text-sm font-normal text-primary/70 tabular-nums" suppressHydrationWarning>
         <time dateTime={item.createdAt}>
           {formatDateTimeKo(item.createdAt)}
         </time>

--- a/frontend/src/app/admin/vocs/page.tsx
+++ b/frontend/src/app/admin/vocs/page.tsx
@@ -49,7 +49,7 @@ export default async function AdminVocListPage({ searchParams }: { searchParams:
 
   return (
     <MotionEnter>
-      <div className="max-w-5xl">
+      <div className="max-w-[1400px] mx-auto">
         <header className="mb-12">
           <div className="flex flex-col gap-6">
             <div className="border-b border-primary/10 pb-8 space-y-4">


### PR DESCRIPTION
### 🚀 개요
관리자 대시보드 전반의 UI 표준화 작업을 통해 일관된 관리 업무 환경을 구축하고, 발견된 버그를 수정했습니다.

### 🛠 주요 변경 사항
### 1. 관리자 UI 표준화 (Moss & Aloe 디자인 시스템 적용)
헤더 레이아웃 통일: 모든 관리 모듈(대시보드, 공간, 계약, 예약, 기기, 모니터링, 결제, 민원, 커뮤니티 등)의 헤더 위치와 스타일을 대시보드 기준으로 정렬했습니다.
루트 컨테이너를 max-w-[1400px] mx-auto로 단일화하여 정렬 불일치 해결.
불필요한 중첩 패딩(p-6, p-12 등)을 제거하여 헤더 위치 고정.
고밀도 타이포그래피 적용: 모든 페이지 제목에 5xl/7xl 크기, font-black 두께, 그리고 underline decoration-accent 가 적용된 표준 시스템을 이식했습니다.
가독성 및 대비 개선: 민원(VOC) 및 커뮤니티 관리 목록의 텍스트 투명도를 조정하여 더 진하고 선명하게 보이도록 수정하였습니다. (폰트 크기 17px, 두께 font-medium으로 최적화)

### 2. 기능 수정 및 시스템 개선
기기 관리(Devices): 기기 등록 버튼의 아이콘(Plus) 참조 오류를 해결하여 페이지 렌더링 중단을 방지했습니다.
커뮤니티 관리:
글 관리 필터의 글씨 크기와 스타일을 민원 관리(VOC) 필터와 동일하게 규격화했습니다.
삭제 아이콘 및 텍스트 대비를 상향하여 관리 편의성을 높였습니다.
관리자 댓글 작성 후 목록에 즉시 반영되지 않던 문제를 서버 데이터 재검증(router.refresh)을 통해 해결했습니다.
알림 이동 로직: 관리자가 알림을 클릭할 경우 '나의 정보' 페이지가 아닌 관련 '관리 페이지'(계약관리, 민원관리 등)로 이동하도록 라우팅 로직을 최적화했습니다.

### 📸 스크린샷 (Optional)
(표준화된 대시보드 헤더 및 정렬된 목록 화면 확인 가능)

### ✅ 테스트 체크리스트
 모든 관리 페이지 헤더 위치가 대시보드와 동일하게 정렬되는가?
 기기 관리 페이지가 ReferenceError 없이 정상 노출되는가?
 커뮤니티 관리에서 댓글 등록 시 즉시 목록에서 확인 가능한가?
 모바일 및 테블릿 뷰에서 헤더가 레이아웃을 벗어나지 않는가?