### PR TITLE
[SPC/feat] 관리자 공간 관리 페이지 개인 공간 상태(공실/입주 중) 필터 추가

### DIFF
--- a/frontend/src/app/admin/spaces/page.tsx
+++ b/frontend/src/app/admin/spaces/page.tsx
@@ -20,6 +20,7 @@ export default function SpacesPage() {
 
   // 필터 상태
   const [filterType, setFilterType] = useState<'ALL' | 'PRIVATE' | 'COMMON'>('ALL');
+  const [filterStatus, setFilterStatus] = useState<'ALL' | 'AVAILABLE' | 'OCCUPIED'>('ALL');
   const [sortOption, setSortOption] = useState('name,asc');
   const [isSortOpen, setIsSortOpen] = useState(false);
   const sortRef = React.useRef<HTMLDivElement>(null);
@@ -37,7 +38,7 @@ export default function SpacesPage() {
 
   const loadSpaces = async () => {
     try {
-      const res = await fetchSpaces({ type: filterType, sort: sortOption });
+      const res = await fetchSpaces({ type: filterType, status: filterStatus, sort: sortOption });
       setSpaces(res.data?.content || []);
     } catch (e) {
       console.error(e);
@@ -46,7 +47,7 @@ export default function SpacesPage() {
 
   useEffect(() => {
     loadSpaces();
-  }, [filterType, sortOption]);
+  }, [filterType, filterStatus, sortOption]);
 
   const getStatusDisplay = (space: SpaceDTO) => {
     if (space.type === 'PRIVATE') {
@@ -125,7 +126,7 @@ export default function SpacesPage() {
             {['ALL', 'PRIVATE', 'COMMON'].map((type) => (
               <button
                 key={type}
-                onClick={() => setFilterType(type as any)}
+                onClick={() => { setFilterType(type as any); if (type !== 'PRIVATE') setFilterStatus('ALL'); }}
                 className={`px-4 py-2 rounded-full text-xs font-bold tracking-widest uppercase transition-all
                   ${filterType === type 
                     ? 'bg-[var(--color-accent)] text-white shadow-md' 
@@ -136,6 +137,26 @@ export default function SpacesPage() {
               </button>
             ))}
           </div>
+
+          {/* 상태 필터 칩 (PRIVATE 선택 시에만 노출) */}
+          {filterType === 'PRIVATE' && (
+          <div className="flex gap-2 mb-6">
+            {(['ALL', 'AVAILABLE', 'OCCUPIED'] as const).map((st) => (
+              <button
+                key={st}
+                onClick={() => setFilterStatus(st)}
+                className={`px-4 py-2 rounded-full text-xs font-bold tracking-tight transition-all
+                  ${filterStatus === st
+                    ? 'bg-[var(--foreground)] text-[var(--background)] shadow-md'
+                    : 'bg-black/5 text-foreground hover:bg-black/10'
+                  }`}
+              >
+                {st === 'ALL' ? '전체' : st === 'AVAILABLE' ? '입주 가능' : '입주 중'}
+              </button>
+            ))}
+          </div>
+          )}
+
 
           {/* 정렬 드롭다운 */}
           <div ref={sortRef} className="relative inline-block mb-6">


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 관리자 공간 목록 페이지(`/admin/spaces`)에서 기존에는 공간(PRIVATE)의 공실 혹은 입주 상태를 직관적으로 파악하기 어려웠습니다.
- 이에 따라 관리자가 '입주 가능(AVAILABLE)' 상태의 빈 방인지, '입주 중(OCCUPIED)' 상태인지 분류해서 쉽게 모아볼 수 있는 필터 기능을 추가 도입하여 관리 업무의 효율을 높이고자 합니다.

## 🔑 주요 변경 사항 (What)
- **상태 필터 칩(UI) 추가**
  - 기존 '타입 필터(전체보기/PRIVATE/COMMON)' 하단에 '상태 필터(전체/입주 가능/입주 중)' 칩 목록을 추가했습니다.
  - 해당 상태 필터는 개인 호실의 공실 관리가 목적이므로, 타입이 `PRIVATE`으로 선택되었을 때만 노출되도록 렌더링 분기를 적용했습니다.
- **백엔드 상태 쿼리 파라미터 연동**
  - 프론트엔드의 [page.tsx](cci:7://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/page.tsx:0:0-0:0) 내에서 필터 상태 값(`filterStatus`)을 관리하도록 `useState`를 추가했습니다.
  - 백엔드의 `/api/admin/spaces` API에는 이미 `status`를 받을 수 있는 로직이 존재하므로, [fetchSpaces](cci:1://file:///c:/team1_cokkiri/frontend/src/app/admin/spaces/_api/spaceAdminApi.ts:65:0-82:2) 호출 시점에 상태 변수를 전달하여 즉각적으로 재조회가 이루어지게 처리했습니다.

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #353

## 💻 테스트 방법 (How to Test)
1. 프론트엔드 환경 실행 후 **관리자 페이지의 공간 관리(`/admin/spaces`)**에 진입합니다.
2. 공간 목록 상단의 '타입 필터' 중 **PRIVATE**을 클릭합니다.
3. 그 아래에 새롭게 나타나는 **[전체], [입주 가능], [입주 중]** 필터 칩을 클릭해 봅니다.
4. '입주 가능' 클릭 시 공실인 호실들만, '입주 중' 클릭 시 사용 중인 호실들만 정상적으로 필터링 되어 리스트업 되는지 확인합니다.

## 📸 화면 스크린샷 또는 영상 (UI 변경 시)
- N/A

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?
- [x] 불필요한 콘솔 로그나 디버깅 코드를 제거했습니까?
- [x] 변경된 로직에 맞춰 관련된 문서를 업데이트했습니까?

## 💬 리뷰어에게 전달할 내용 (Review Notes)
- 백엔드의 [AdminSpaceController](cci:2://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/admin/space/adapter/in/web/AdminSpaceController.java:29:0-191:1)에는 이미 `@RequestParam SpaceStatus status`가 구현되어 있어서 프론트엔드쪽 UI 추가와 쿼리 파라미터 연동 처리만으로 이번 작업을 깔끔하게 해결했습니다! 🚀