### PR TITLE
[CS/fix] 공지사항 등록 및 수정 권한 안내 수정 (Bug Fix)

### DIFF
--- a/frontend/src/app/(common)/community/[postId]/edit/_components/EditPostForm.tsx
+++ b/frontend/src/app/(common)/community/[postId]/edit/_components/EditPostForm.tsx
@@ -9,6 +9,7 @@ import { POST_CATEGORIES, type PostAttachment } from "../../../_types/community"
 import { cn } from "@/lib/utils";
 import { messageFromBffResponse } from "@/lib/bff-error-message";
 import { LoginRequiredModal } from "@/components/shared/LoginRequiredModal";
+import { AccessDeniedModal } from "@/components/shared/AccessDeniedModal";
 import { LOGIN_REQUIRED_MESSAGE } from "@/lib/auth-messages";
 import { CancelModal } from "@/components/shared/CancelModal";
 import {
@@ -79,6 +80,7 @@ export function EditPostForm({
   const [newFiles, setNewFiles] = useState<File[]>([]);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [showLoginModal, setShowLoginModal] = useState(false);
+  const [showAccessDenied, setShowAccessDenied] = useState(false);
   const [showCancelModal, setShowCancelModal] = useState(false);
 
   function removeAttachment(index: number) {
@@ -139,6 +141,10 @@ export function EditPostForm({
           setShowLoginModal(true);
           return;
         }
+        if (res.status === 403) {
+          setShowAccessDenied(true);
+          return;
+        }
         let json: ApiResponse<unknown>;
         try {
           json = await res.json();
@@ -163,6 +169,16 @@ export function EditPostForm({
   return (
     <form onSubmit={submit} className="mx-auto max-w-5xl space-y-6">
       <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
+      <AccessDeniedModal
+        isOpen={showAccessDenied}
+        onClose={() => setShowAccessDenied(false)}
+        title={category === "NOTICE" ? "관리자 전용 기능입니다" : "입주자 전용 기능입니다"}
+        description={
+          category === "NOTICE"
+            ? "공지사항 등록 및 수정은 관리자 권한을 가진 계정으로만 가능합니다."
+            : "게시글·댓글·민원 등록은 입주 계약을 완료한 입주자만 이용할 수 있습니다.\n입주 신청 후 계약이 체결되면 자동으로 권한이 부여됩니다."
+        }
+      />
 
       {submitError ? (
         <p

--- a/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
+++ b/frontend/src/app/(common)/community/new/_components/NewPostForm.tsx
@@ -135,7 +135,16 @@ export function NewPostForm() {
   return (
     <form onSubmit={submit} className="mx-auto max-w-5xl space-y-6">
       <LoginRequiredModal isOpen={showLoginModal} onClose={() => setShowLoginModal(false)} />
-      <AccessDeniedModal isOpen={showAccessDenied} onClose={() => setShowAccessDenied(false)} />
+      <AccessDeniedModal
+        isOpen={showAccessDenied}
+        onClose={() => setShowAccessDenied(false)}
+        title={category === "NOTICE" ? "관리자 전용 기능입니다" : "입주자 전용 기능입니다"}
+        description={
+          category === "NOTICE"
+            ? "공지사항 등록 및 수정은 관리자 권한을 가진 계정으로만 가능합니다."
+            : "게시글·댓글·민원 등록은 입주 계약을 완료한 입주자만 이용할 수 있습니다.\n입주 신청 후 계약이 체결되면 자동으로 권한이 부여됩니다."
+        }
+      />
 
       {submitError ? (
         <p


### PR DESCRIPTION
### 🚀 Pull Request: 관리자 대시보드 지표 연동 및 입주자 서비스 UI/UX 표준화 최적화
### 📝 개요
본 PR은 관리자 대시보드의 실시간 운영 지표 도입과 입주자용 마이페이지 전체의 디자인 시스템(Moss & Aloe Editorial) 통합을 목적으로 합니다. 또한, 공지사항 등록 시 발생하던 안내 문구 오류를 수정하고 반응형 환경에서의 사용성을 대폭 개선했습니다.

### 🔑 주요 변경 사항
### 1. 공지사항 등록 및 수정 권한 안내 수정 (Bug Fix) 🐛
권한별 맞춤형 피드백: 입주민이 공지(NOTICE) 카테고리를 선택하고 등록을 시도할 때, 기존의 모순된 멘트("입주민만 이용 가능합니다") 대신 **"관리자 전용 기능입니다"**라는 정확한 안내가 출력되도록 수정했습니다.
컴포넌트 적용: NewPostForm 뿐만 아니라 EditPostForm에도 동일한 권한 체크 및 AccessDeniedModal 로직을 적용하여 예외 상황에 대한 사용자 경험을 통일했습니다.

### 2. 관리자 대시보드 (Admin Dashboard) 📊
운영 현황 지표 통합: 실시간 계약(활성/만료), 금일 예약 현황, 입주자 및 방문자 수 등 핵심 데이터를 집계하는 API(AdminDashboardSummaryController)를 구현하고 UI에 실시간 연동했습니다.
레이아웃 우선순위 조정: 운영 지표 카드를 최상단으로 배치하여 즉각적인 현황 파악이 가능하도록 개편했습니다.

### 3. 입주자 서비스 UI 표준화 (Moss & Aloe Editorial) ✨
에디토리얼 헤더 시스템 통합: 나의 민원, 계약 내역, 결제 내역, 알림 센터 등 모든 마이페이지의 헤더를 동일한 룩앤필로 개편했습니다.
가변형 타이틀 (Fluid Typography): clamp()를 적용하여 해상도에 따라 타이틀 크기가 유동적으로 변하며, 어떤 기기에서도 한 줄로 유지되도록(whitespace-nowrap) 처리했습니다.
컨테이너 규격화: 모든 하위 페이지의 너비를 max-w-5xl로 통일하고 상단 여백을 줄여 시각적 피로도를 낮췄습니다.

### 4. 반응형 UI 개선 및 버그 수정 📱
지능형 버튼 줄바꿈 (Conditional Wrapping): 헤더의 액션 버튼들이 평소에는 타이틀과 나란히 배치되다가, 공간이 부족한 모바일 환경에서만 자연스럽게 하단으로 이동하도록 레이아웃을 개선했습니다.
모바일 메뉴 간섭 수정: 모바일 GNB에서 'MY' 하위 메뉴 클릭 시 전체 메뉴가 닫히던 문제를 해결하여 탐색 편의성을 높였습니다.

### 🧪 테스트 결과
 입주민 계정으로 공지 등록 시 "관리자 전용" 안내 팝업 노출 확인
 관리자 대시보드 지표 실시간 로딩 검증
 모든 마이페이지 디자인 일관성(Width, Padding) 확인
 프론트엔드 빌드(npm run build) 성공

### 📸 관련 화면
Bug Fix: 공지 선택 시 나타나는 "관리자 전용 기능입니다" 안내 창
Standardization: 알림 페이지와 동일한 선상에 위치하는 마이페이지 헤더들