### PR TITLE
[SPC/fix] 사용자 방 검색 페이지 가격대 프리셋 미노출 에러(401) 수정

### DIFF
--- a/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/coliving/global/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                                                 // --- 공개: 공간·룸 조회 ---
                                                 .requestMatchers(HttpMethod.GET, "/api/rooms/**").permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/api/room-types").permitAll() // 방 유형
+                                                .requestMatchers(HttpMethod.GET, "/api/price-ranges").permitAll() // 가격대 프리셋 🔓 Public
                                                 .requestMatchers(HttpMethod.GET, "/api/admin/spaces/*/images/serve/**").permitAll() // 관리자가 업로드한 이미지 조회 (비회원 허용)
                                                 .requestMatchers(HttpMethod.GET, "/api/experience/**").permitAll() // EXPERIENCE 공용시설 소개 🔓 Public
                                                 .requestMatchers(HttpMethod.GET, "/api/floors").permitAll() // FLOOR 층별 평면도 🔓 Public


### PR DESCRIPTION
## 💡 배경 및 목적 (Why)
- 일반 유저(비로그인 상태)가 방 목록 페이지(`/rooms`)에 접속했을 때 가격대 필터 칩(Chip)이 렌더링되지 않는 오류가 발생했습니다.
- 원인은 사용자용 가격대 노출 API(`/api/price-ranges`)가 Spring Security의 익명 접근 허용(`permitAll`) 목록에서 누락되어 `401 Unauthorized` 예외가 발생했기 때문입니다. 이를 해결하고자 합니다.

## 🔑 주요 변경 사항 (What)
- **백엔드:** [SecurityConfig.java](cci:7://file:///c:/team1_cokkiri/backend/src/main/java/com/coliving/global/config/SecurityConfig.java:0:0-0:0) 파일의 통합 권한 설정 내에서 `/api/price-ranges` GET 요청을 `permitAll` 정책으로 추가 지정

## 🔗 연관된 이슈 (Issue / Ticket)
- Resolves #353 (또는 해당하는 이슈 번호로 수정해 주세요)

## 💻 테스트 방법 (How to Test)
1. 백엔드 및 프론트엔드 서버를 켭니다.
2. **비로그인 상태**(토큰 없음)로 브라우저 시크릿 창을 열어 `localhost:3000/rooms`에 접속합니다.
3. 방 목록 화면 상단 필터 영역에 설정해둔 가격대 프리셋 칩들이 정상적으로 노출되는지 확인합니다.

## 📸 화면 스크린샷 
- (여기에 비로그인 상태에서 칩이 잘 보이는 화면 캡처 영상 또는 이미지를 첨부해주세요)

## ✅ 체크리스트 (Self-Review)
- [x] 프로젝트의 코딩 컨벤션과 아키텍처 규칙을 준수했습니까?
- [x] 로컬 환경에서 빌드 및 테스트를 성공적으로 완료했습니까?

## 💬 리뷰어에게 전달할 내용 
- 과거 `room-types` API의 `permitAll` 누락 때와 완벽히 동일한 패턴의 버그였습니다.
- 1줄짜리 간단한 SecurityConfig 수정입니다!