### PR TITLE
fix(RSV): 예약 이동 방식 수정 및 관리자 예약 관리 데이터 처리 수정

### DIFF
--- a/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
+++ b/frontend/src/app/(public)/experience/_components/FacilityCard.tsx
@@ -10,14 +10,8 @@ export function FacilityCard({ space, index }: { space: CommonSpaceDto; index: n
 
   return (
     <Link
-      href={`/facilities?spaceId=${space.spaceId}`}
+      href={`/experience/${space.spaceId}`}
       className="block"
-      onClick={(e) => {
-        if (!space.isReservable) {
-          e.preventDefault();
-          window.alert("예약이 필요 없는 공용 시설입니다.");
-        }
-      }}
     >
       <motion.article
         initial={{ opacity: 0, y: 40 }}


### PR DESCRIPTION
### 수정 사항

- 이동 경로 변경: Experience 페이지의 시설 카드 클릭 시, 공용 시설 예약 페이지(/facilities)로 바로 이동하던 것을 시설 상세 정보 페이지(/experience/[id])로 이동하도록 수정했습니다.
- 클릭 제한 해제: 기존에 isReservable이 false인 시설에 대해 클릭을 막고 알럿을 띄우던 로직을 제거하여, 모든 시설의 상세 정보를 확인할 수 있도록 개선했습니다.
- 관리자 예약 조회에서 삭제된 사용자/시설 연관이 끊겨도 목록이 깨지지 않도록 fallback 처리
- 예약이 존재하는 시설은 관리자에서 삭제할 수 없도록 방어 로직 추가
- 프론트 공용시설 카드 클릭 시 예약 페이지가 아닌 상세(/experience/{spaceId})로 이동하도록 링크 수정
